### PR TITLE
Standardize Development Environment and CI Quality Gates

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,6 +33,16 @@ jobs:
     - name: Install nightly toolchain
       uses: dtolnay/rust-toolchain@nightly
 
+    # --- QUALITY CHECKS ---
+    - name: Check Formatting
+      working-directory: blocklace
+      run: cargo fmt --all --check
+
+    - name: Lint with Clippy
+      working-directory: blocklace
+      run: cargo clippy --all-targets --all-features -- -D warnings
+
+    # --- BUILD & TEST ---
     - name: Build
       working-directory: blocklace
       run: cargo build --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,11 +36,15 @@ jobs:
     # --- QUALITY CHECKS ---
     - name: Check Formatting
       working-directory: blocklace
-      run: cargo fmt --package blocklace --check
+      run: |
+        cargo fmt -p cordial-miners-core --check
+        cargo fmt -p cordial-f1r3node-adapter --check
+        cargo fmt -p cordial-f1r3space-adapter --check
 
     - name: Lint with Clippy
       working-directory: blocklace
-      run: cargo clippy --package blocklace --all-features -- -D warnings
+      run: |
+        cargo clippy -p cordial-miners-core -p cordial-f1r3node-adapter -p cordial-f1r3space-adapter --all-targets --all-features --no-deps -- -D warnings
 
     # --- BUILD & TEST ---
     - name: Build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,11 +36,11 @@ jobs:
     # --- QUALITY CHECKS ---
     - name: Check Formatting
       working-directory: blocklace
-      run: cargo fmt --all --check
+      run: cargo fmt --package blocklace --check
 
     - name: Lint with Clippy
       working-directory: blocklace
-      run: cargo clippy --all-targets --all-features -- -D warnings
+      run: cargo clippy --package blocklace --all-features -- -D warnings
 
     # --- BUILD & TEST ---
     - name: Build

--- a/Justfile
+++ b/Justfile
@@ -6,10 +6,10 @@ default:
     just --list
 
 fmt:
-    cargo +{{toolchain}} fmt -p cordial-miners-core -p cordial-f1r3node-adapter -p cordial-f1r3space-adapter
+    cargo +{{toolchain}} fmt -p cordial-miners-core -p cordial-miners-core -p cordial-f1r3node-adapter -p cordial-f1r3space-adapter --check
 
 clippy:
-    cargo +{{toolchain}} clippy --workspace --all-targets -- -D warnings
+    cargo +{{toolchain}} cordial-miners-core -p cordial-f1r3node-adapter -p cordial-f1r3space-adapter --all-targets --all-features --no-deps -- -D warnings
 
 build:
     cargo +{{toolchain}} build --workspace

--- a/crates/cordial-f1r3node-adapter/src/runtime_bridge.rs
+++ b/crates/cordial-f1r3node-adapter/src/runtime_bridge.rs
@@ -6,7 +6,6 @@ use cordial_miners_core::cordiality::ConsensusEngine;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
 #[value(rename_all = "kebab-case")]
-
 #[derive(Default)]
 pub enum ConsensusKind {
     #[default]

--- a/crates/cordial-f1r3node-adapter/src/runtime_bridge.rs
+++ b/crates/cordial-f1r3node-adapter/src/runtime_bridge.rs
@@ -6,15 +6,12 @@ use cordial_miners_core::cordiality::ConsensusEngine;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
 #[value(rename_all = "kebab-case")]
+
+#[derive(Default)]
 pub enum ConsensusKind {
+    #[default]
     Legacy,
     CordialMiners,
-}
-
-impl Default for ConsensusKind {
-    fn default() -> Self {
-        Self::Legacy
-    }
 }
 
 impl FromStr for ConsensusKind {

--- a/crates/cordial-miners-core/src/blocklace.rs
+++ b/crates/cordial-miners-core/src/blocklace.rs
@@ -1,6 +1,6 @@
-use std::collections::{HashMap, BTreeSet, VecDeque, HashSet};
 use crate::block::Block;
 use crate::types::{BlockContent, BlockIdentity, NodeId};
+use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 
 // The blocklace B - a set of blocks satisfying the closure and axioms
 // From definition 2.3, A blocklace B is a set of blocks subject to some invariants.
@@ -111,25 +111,25 @@ impl Blocklace {
     }
 
     pub fn observe(&self, from: &BlockIdentity) -> BTreeSet<BlockIdentity> {
-            let mut visited = BTreeSet::new();
-            let mut queue = VecDeque::new();
+        let mut visited = BTreeSet::new();
+        let mut queue = VecDeque::new();
 
-            // Start from the block itself (inclusive closure)
-            queue.push_back(from.clone());
-            visited.insert(from.clone());
+        // Start from the block itself (inclusive closure)
+        queue.push_back(from.clone());
+        visited.insert(from.clone());
 
-            while let Some(current_id) = queue.pop_front() {
-                if let Some(content) = self.content(&current_id) {
-                    for pred_id in &content.predecessors {
-                        // BTreeSet.insert returns false if the item was already present
-                        if visited.insert(pred_id.clone()) {
-                            queue.push_back(pred_id.clone());
-                        }
+        while let Some(current_id) = queue.pop_front() {
+            if let Some(content) = self.content(&current_id) {
+                for pred_id in &content.predecessors {
+                    // BTreeSet.insert returns false if the item was already present
+                    if visited.insert(pred_id.clone()) {
+                        queue.push_back(pred_id.clone());
                     }
                 }
             }
-            visited
         }
+        visited
+    }
 
     /// ⪯b — ancestors of b including b itself
     /// This is downward closure used heavly throughout the paper, so we provide a direct method for it.

--- a/crates/cordial-miners-core/src/consensus/validation.rs
+++ b/crates/cordial-miners-core/src/consensus/validation.rs
@@ -135,26 +135,24 @@ pub fn validate_block(
         // - DO NOT assume 64-byte signature (Ed25519 assumption)
         // - Secp256k1 signatures are DER encoded (variable length ~70–72 bytes)
         // - Public key may be 33 or 65 bytes
-        if !block.identity.signature.is_empty() {
-            if !crypto::verify(
+        if !block.identity.signature.is_empty()
+            && !crypto::verify(
                 &block.identity.content_hash,
                 public_key,
                 &block.identity.signature,
             ) {
                 errors.push(InvalidBlock::InvalidSignature);
             }
-        }
         // Empty signature is allowed for unsigned blocks (e.g., in tests)
     }
 
     // 3. Sender is bonded
-    if config.check_sender {
-        if !bonds.contains_key(&block.identity.creator) {
+    if config.check_sender
+        && !bonds.contains_key(&block.identity.creator) {
             errors.push(InvalidBlock::UnknownSender {
                 creator: block.identity.creator.clone(),
             });
         }
-    }
 
     // 4. Closure axiom — all predecessors must exist
     if config.check_closure {
@@ -186,14 +184,13 @@ pub fn validate_block(
             let existing_has_new_in_ancestry =
                 blocklace.precedes(&block.identity, &existing.identity);
 
-            if !new_has_existing_in_ancestry && !existing_has_new_in_ancestry {
-                if block.identity != existing.identity {
+            if !new_has_existing_in_ancestry && !existing_has_new_in_ancestry
+                && block.identity != existing.identity {
                     errors.push(InvalidBlock::Equivocation {
                         conflicting: existing.identity.clone(),
                     });
                     break; // one conflict is enough
                 }
-            }
         }
     }
 

--- a/crates/cordial-miners-core/src/consensus/validation.rs
+++ b/crates/cordial-miners-core/src/consensus/validation.rs
@@ -140,19 +140,19 @@ pub fn validate_block(
                 &block.identity.content_hash,
                 public_key,
                 &block.identity.signature,
-            ) {
-                errors.push(InvalidBlock::InvalidSignature);
-            }
+            )
+        {
+            errors.push(InvalidBlock::InvalidSignature);
+        }
         // Empty signature is allowed for unsigned blocks (e.g., in tests)
     }
 
     // 3. Sender is bonded
-    if config.check_sender
-        && !bonds.contains_key(&block.identity.creator) {
-            errors.push(InvalidBlock::UnknownSender {
-                creator: block.identity.creator.clone(),
-            });
-        }
+    if config.check_sender && !bonds.contains_key(&block.identity.creator) {
+        errors.push(InvalidBlock::UnknownSender {
+            creator: block.identity.creator.clone(),
+        });
+    }
 
     // 4. Closure axiom — all predecessors must exist
     if config.check_closure {
@@ -184,13 +184,15 @@ pub fn validate_block(
             let existing_has_new_in_ancestry =
                 blocklace.precedes(&block.identity, &existing.identity);
 
-            if !new_has_existing_in_ancestry && !existing_has_new_in_ancestry
-                && block.identity != existing.identity {
-                    errors.push(InvalidBlock::Equivocation {
-                        conflicting: existing.identity.clone(),
-                    });
-                    break; // one conflict is enough
-                }
+            if !new_has_existing_in_ancestry
+                && !existing_has_new_in_ancestry
+                && block.identity != existing.identity
+            {
+                errors.push(InvalidBlock::Equivocation {
+                    conflicting: existing.identity.clone(),
+                });
+                break; // one conflict is enough
+            }
         }
     }
 

--- a/crates/cordial-miners-core/src/consensus/validation.rs
+++ b/crates/cordial-miners-core/src/consensus/validation.rs
@@ -181,9 +181,7 @@ pub fn validate_block(
                 .content
                 .predecessors
                 .iter()
-                .any(|pred_id| {
-                    blocklace.preceedes_or_equals(&existing.identity, pred_id)
-                });
+                .any(|pred_id| blocklace.preceedes_or_equals(&existing.identity, pred_id));
 
             let existing_has_new_in_ancestry =
                 blocklace.precedes(&block.identity, &existing.identity);

--- a/crates/cordial-miners-core/src/crypto.rs
+++ b/crates/cordial-miners-core/src/crypto.rs
@@ -7,7 +7,7 @@ use k256::ecdsa::{
     Signature as SecpSignature, SigningKey as SecpSigningKey, VerifyingKey as SecpVerifyingKey,
     signature::hazmat::{PrehashSigner, PrehashVerifier},
 };
-use sha2::{Digest as Sha2Digest, Sha256};
+use sha2::{Sha256};
 
 use crate::types::BlockContent;
 

--- a/crates/cordial-miners-core/src/crypto.rs
+++ b/crates/cordial-miners-core/src/crypto.rs
@@ -7,7 +7,7 @@ use k256::ecdsa::{
     Signature as SecpSignature, SigningKey as SecpSigningKey, VerifyingKey as SecpVerifyingKey,
     signature::hazmat::{PrehashSigner, PrehashVerifier},
 };
-use sha2::{Sha256};
+use sha2::Sha256;
 
 use crate::types::BlockContent;
 

--- a/crates/cordial-miners-core/src/crypto.rs
+++ b/crates/cordial-miners-core/src/crypto.rs
@@ -1,23 +1,17 @@
-use sha2::{Sha256, Digest as Sha2Digest};
 use blake2::{Blake2b, Digest as Blake2Digest, digest::consts::U32};
 use ed25519_dalek::{
-    SigningKey as EdSigningKey, 
-    VerifyingKey as EdVerifyingKey, 
-    Signature as EdSignature, 
-    Signer as _, Verifier as _
+    Signature as EdSignature, Signer as _, SigningKey as EdSigningKey, Verifier as _,
+    VerifyingKey as EdVerifyingKey,
 };
 use k256::ecdsa::{
-    SigningKey as SecpSigningKey, 
-    VerifyingKey as SecpVerifyingKey, 
-    Signature as SecpSignature, 
-    signature::hazmat::{PrehashSigner, PrehashVerifier}
+    Signature as SecpSignature, SigningKey as SecpSigningKey, VerifyingKey as SecpVerifyingKey,
+    signature::hazmat::{PrehashSigner, PrehashVerifier},
 };
+use sha2::{Digest as Sha2Digest, Sha256};
 
 use crate::types::BlockContent;
 
-
 // 1. Traits and Enums (Algorithm Abstractions)
-
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HashAlgorithm {
@@ -42,14 +36,14 @@ pub trait SignatureScheme {
     fn verify(&self, hash: &[u8; 32], public_key: &[u8], signature: &[u8]) -> bool;
 }
 
-
 // 2. Hasher Implementations
-
 
 /// Blake2b-256: default for f1r3node alignment.
 pub struct Blake2b256Hasher;
 impl Hasher for Blake2b256Hasher {
-    fn name(&self) -> String { "blake2b256".to_string() }
+    fn name(&self) -> String {
+        "blake2b256".to_string()
+    }
     fn hash(&self, data: &[u8]) -> [u8; 32] {
         let mut hasher = Blake2b::<U32>::new();
         hasher.update(data);
@@ -59,7 +53,9 @@ impl Hasher for Blake2b256Hasher {
 
 pub struct Sha256Hasher;
 impl Hasher for Sha256Hasher {
-    fn name(&self) -> String { "sha256".to_string() }
+    fn name(&self) -> String {
+        "sha256".to_string()
+    }
     fn hash(&self, data: &[u8]) -> [u8; 32] {
         let mut hasher = Sha256::new();
         hasher.update(data);
@@ -67,49 +63,64 @@ impl Hasher for Sha256Hasher {
     }
 }
 
-
 // 3. Signature Scheme Implementations
-
 
 /// Secp256k1: default for f1r3node validator alignment.
 pub struct Secp256k1Scheme;
 impl SignatureScheme for Secp256k1Scheme {
-    fn name(&self) -> String { "secp256k1".to_string() }
+    fn name(&self) -> String {
+        "secp256k1".to_string()
+    }
     fn sign(&self, hash: &[u8; 32], private_key: &[u8]) -> Result<Vec<u8>, String> {
-        let signing_key = SecpSigningKey::from_slice(private_key).map_err(|_| "Invalid Secp256k1 privkey")?;
+        let signing_key =
+            SecpSigningKey::from_slice(private_key).map_err(|_| "Invalid Secp256k1 privkey")?;
         // Prehash signing: signs the 32-byte hash directly.
-        let signature: SecpSignature = signing_key.sign_prehash(hash).map_err(|_| "Signing failed")?;
+        let signature: SecpSignature = signing_key
+            .sign_prehash(hash)
+            .map_err(|_| "Signing failed")?;
         // Returns DER encoding to match f1r3node wire format.
         Ok(signature.to_der().as_bytes().to_vec())
     }
     fn verify(&self, hash: &[u8; 32], public_key: &[u8], signature: &[u8]) -> bool {
-        let Ok(vk) = SecpVerifyingKey::from_sec1_bytes(public_key) else { return false };
-        let Ok(sig) = SecpSignature::from_der(signature) else { return false };
+        let Ok(vk) = SecpVerifyingKey::from_sec1_bytes(public_key) else {
+            return false;
+        };
+        let Ok(sig) = SecpSignature::from_der(signature) else {
+            return false;
+        };
         vk.verify_prehash(hash, &sig).is_ok()
     }
 }
 
 pub struct Ed25519Scheme;
 impl SignatureScheme for Ed25519Scheme {
-    fn name(&self) -> String { "ed25519".to_string() }
+    fn name(&self) -> String {
+        "ed25519".to_string()
+    }
     fn sign(&self, hash: &[u8; 32], private_key: &[u8]) -> Result<Vec<u8>, String> {
-        let key_bytes: [u8; 32] = private_key.try_into().map_err(|_| "ED25519 privkey != 32 bytes")?;
+        let key_bytes: [u8; 32] = private_key
+            .try_into()
+            .map_err(|_| "ED25519 privkey != 32 bytes")?;
         let signing_key = EdSigningKey::from_bytes(&key_bytes);
         Ok(signing_key.sign(hash).to_bytes().to_vec())
     }
     fn verify(&self, hash: &[u8; 32], public_key: &[u8], signature: &[u8]) -> bool {
-        let Ok(pk_bytes) = public_key.try_into() else { return false };
-        let Ok(vk) = EdVerifyingKey::from_bytes(pk_bytes) else { return false };
-        let Ok(sig) = EdSignature::from_slice(signature) else { return false };
+        let Ok(pk_bytes) = public_key.try_into() else {
+            return false;
+        };
+        let Ok(vk) = EdVerifyingKey::from_bytes(pk_bytes) else {
+            return false;
+        };
+        let Ok(sig) = EdSignature::from_slice(signature) else {
+            return false;
+        };
         vk.verify(hash, &sig).is_ok()
     }
 }
 
-
 // 4. Content Hashing Logic (Logical Parity)
 
-
-/// Generic content hashing. 
+/// Generic content hashing.
 /// In f1r3node, the creator is usually part of the block message structure
 /// that gets hashed. We ensure the logical sequence is preserved.
 pub fn hash_content_ext(content: &BlockContent, hasher: &dyn Hasher) -> [u8; 32] {
@@ -135,9 +146,7 @@ pub fn hash_content_ext(content: &BlockContent, hasher: &dyn Hasher) -> [u8; 32]
     hasher.hash(&buf)
 }
 
-
 // 5. Default Implementations (ALIGNED WITH FIRE NODE)
-
 
 /// Default hash uses Blake2b-256 for f1r3node alignment.
 pub fn hash_content(content: &BlockContent) -> [u8; 32] {
@@ -146,7 +155,9 @@ pub fn hash_content(content: &BlockContent) -> [u8; 32] {
 
 /// Default sign uses Secp256k1 for f1r3node alignment.
 pub fn sign(hash: &[u8; 32], private_key: &[u8]) -> Vec<u8> {
-    Secp256k1Scheme.sign(hash, private_key).expect("Default Secp256k1 sign failed")
+    Secp256k1Scheme
+        .sign(hash, private_key)
+        .expect("Default Secp256k1 sign failed")
 }
 
 /// Default verify uses Secp256k1 for f1r3node alignment.

--- a/crates/cordial-miners-core/tests/test_blocklace.rs
+++ b/crates/cordial-miners-core/tests/test_blocklace.rs
@@ -1,6 +1,6 @@
 use cordial_miners_core::blocklace::Blocklace;
 use cordial_miners_core::{Block, BlockContent, BlockIdentity, NodeId};
-use std::collections::{BTreeSet, HashSet};
+use std::collections::{HashSet};
 // Helpers test
 
 /// Helper to create a block without the boilerplate

--- a/crates/cordial-miners-core/tests/test_blocklace.rs
+++ b/crates/cordial-miners-core/tests/test_blocklace.rs
@@ -1,6 +1,6 @@
 use cordial_miners_core::blocklace::Blocklace;
 use cordial_miners_core::{Block, BlockContent, BlockIdentity, NodeId};
-use std::collections::{HashSet};
+use std::collections::HashSet;
 // Helpers test
 
 /// Helper to create a block without the boilerplate

--- a/crates/cordial-miners-core/tests/test_blocklace.rs
+++ b/crates/cordial-miners-core/tests/test_blocklace.rs
@@ -1,6 +1,6 @@
-use cordial_miners_core::{Block, BlockContent, BlockIdentity, NodeId};
 use cordial_miners_core::blocklace::Blocklace;
-use std::collections::{HashSet, BTreeSet};
+use cordial_miners_core::{Block, BlockContent, BlockIdentity, NodeId};
+use std::collections::{BTreeSet, HashSet};
 // Helpers test
 
 /// Helper to create a block without the boilerplate
@@ -261,7 +261,6 @@ fn dom_contains_all_inserted_identities() {
     assert!(dom.contains(&b2.identity));
 }
 
-
 /// Logic tests in Observe and Closure Closure
 #[test]
 fn test_closure_axiom_enforcement() {
@@ -276,17 +275,20 @@ fn test_closure_axiom_enforcement() {
     insert(&mut bl, b1);
 
     // Invalid insertion
-    let unknown_id  = create_mock_block(9, 0xFF, HashSet::new()).identity;
+    let unknown_id = create_mock_block(9, 0xFF, HashSet::new()).identity;
     let mut bad_preds = HashSet::new();
     bad_preds.insert(unknown_id);
     let rouge_block = create_mock_block(3, 0xCC, bad_preds);
 
-    assert!(bl.insert(rouge_block).is_err(), "Should fail due to missing predecessor");
+    assert!(
+        bl.insert(rouge_block).is_err(),
+        "Should fail due to missing predecessor"
+    );
 }
 
 /// New observe and Determinism Tests
 #[test]
-fn test_observe_includes_self_and_ancestors () {
+fn test_observe_includes_self_and_ancestors() {
     let mut bl = Blocklace::new();
 
     let g = create_mock_block(1, 0x01, HashSet::new());
@@ -306,8 +308,14 @@ fn test_observe_includes_self_and_ancestors () {
     let observation = bl.observe(&b.identity);
 
     assert_eq!(observation.len(), 3);
-    assert!(observation.contains(&b.identity), "observation must be inclusive");
-    assert!(observation.contains(&g.identity), "observation must find transitive ancestor");
+    assert!(
+        observation.contains(&b.identity),
+        "observation must be inclusive"
+    );
+    assert!(
+        observation.contains(&g.identity),
+        "observation must find transitive ancestor"
+    );
 }
 
 #[test]
@@ -333,11 +341,14 @@ fn test_observe_isolates_parallet_forks() {
 
     assert!(obs_a.contains(&a1.identity)); // INCLUSIVE: MEANING CONTAINS ITSELF TOO!
     assert!(obs_a.contains(&g.identity));
-    assert!(!obs_a.contains(&b1.identity), "Should not see blocks on parallel paths")
+    assert!(
+        !obs_a.contains(&b1.identity),
+        "Should not see blocks on parallel paths"
+    )
 }
 
 #[test]
-fn test_observe_determinism_across_reconstruction () {
+fn test_observe_determinism_across_reconstruction() {
     let mut bl1 = Blocklace::new();
     let mut bl2 = Blocklace::new();
 
@@ -362,8 +373,8 @@ fn test_observe_determinism_across_reconstruction () {
     let list1: Vec<_> = bl1.observe(&c.identity).into_iter().collect();
     let list2: Vec<_> = bl2.observe(&c.identity).into_iter().collect();
 
-    assert_eq!(list1, list2, "BTreeSet iteration must be identical regardless of insertion order")
-
-
-
+    assert_eq!(
+        list1, list2,
+        "BTreeSet iteration must be identical regardless of insertion order"
+    )
 }

--- a/crates/cordial-miners-core/tests/test_hash.rs
+++ b/crates/cordial-miners-core/tests/test_hash.rs
@@ -1,10 +1,13 @@
-use cordial_miners_core::crypto::{hash_content_ext, Sha256Hasher};
+use cordial_miners_core::crypto::{Sha256Hasher, hash_content_ext};
 use cordial_miners_core::{BlockContent, BlockIdentity, NodeId};
 use std::collections::HashSet;
 
 #[test]
 fn sha256_hash_of_empty_genesis_is_deterministic() {
-    let content = BlockContent { payload: vec![], predecessors: HashSet::new() };
+    let content = BlockContent {
+        payload: vec![],
+        predecessors: HashSet::new(),
+    };
     let h1 = hash_content_ext(&content, &Sha256Hasher);
     let h2 = hash_content_ext(&content, &Sha256Hasher);
     assert_eq!(h1, h2);
@@ -12,33 +15,83 @@ fn sha256_hash_of_empty_genesis_is_deterministic() {
 
 #[test]
 fn sha256_different_payloads_produce_different_hashes() {
-    let c1 = BlockContent { payload: vec![1, 2, 3], predecessors: HashSet::new() };
-    let c2 = BlockContent { payload: vec![4, 5, 6], predecessors: HashSet::new() };
-    assert_ne!(hash_content_ext(&c1, &Sha256Hasher), hash_content_ext(&c2, &Sha256Hasher));
+    let c1 = BlockContent {
+        payload: vec![1, 2, 3],
+        predecessors: HashSet::new(),
+    };
+    let c2 = BlockContent {
+        payload: vec![4, 5, 6],
+        predecessors: HashSet::new(),
+    };
+    assert_ne!(
+        hash_content_ext(&c1, &Sha256Hasher),
+        hash_content_ext(&c2, &Sha256Hasher)
+    );
 }
 
 #[test]
 fn sha256_different_predecessors_produce_different_hashes() {
-    let pred_a = BlockIdentity { content_hash: [0x01; 32], creator: NodeId(vec![1]), signature: vec![] };
-    let pred_b = BlockIdentity { content_hash: [0x02; 32], creator: NodeId(vec![2]), signature: vec![] };
-    let c1 = BlockContent { payload: vec![], predecessors: HashSet::from([pred_a]) };
-    let c2 = BlockContent { payload: vec![], predecessors: HashSet::from([pred_b]) };
-    assert_ne!(hash_content_ext(&c1, &Sha256Hasher), hash_content_ext(&c2, &Sha256Hasher));
+    let pred_a = BlockIdentity {
+        content_hash: [0x01; 32],
+        creator: NodeId(vec![1]),
+        signature: vec![],
+    };
+    let pred_b = BlockIdentity {
+        content_hash: [0x02; 32],
+        creator: NodeId(vec![2]),
+        signature: vec![],
+    };
+    let c1 = BlockContent {
+        payload: vec![],
+        predecessors: HashSet::from([pred_a]),
+    };
+    let c2 = BlockContent {
+        payload: vec![],
+        predecessors: HashSet::from([pred_b]),
+    };
+    assert_ne!(
+        hash_content_ext(&c1, &Sha256Hasher),
+        hash_content_ext(&c2, &Sha256Hasher)
+    );
 }
 
 #[test]
 fn sha256_hash_is_independent_of_predecessor_insertion_order() {
-    let pred_a = BlockIdentity { content_hash: [0x01; 32], creator: NodeId(vec![1]), signature: vec![] };
-    let pred_b = BlockIdentity { content_hash: [0x02; 32], creator: NodeId(vec![2]), signature: vec![] };
-    let mut set1 = HashSet::new(); set1.insert(pred_a.clone()); set1.insert(pred_b.clone());
-    let mut set2 = HashSet::new(); set2.insert(pred_b); set2.insert(pred_a);
-    let c1 = BlockContent { payload: vec![10], predecessors: set1 };
-    let c2 = BlockContent { payload: vec![10], predecessors: set2 };
-    assert_eq!(hash_content_ext(&c1, &Sha256Hasher), hash_content_ext(&c2, &Sha256Hasher));
+    let pred_a = BlockIdentity {
+        content_hash: [0x01; 32],
+        creator: NodeId(vec![1]),
+        signature: vec![],
+    };
+    let pred_b = BlockIdentity {
+        content_hash: [0x02; 32],
+        creator: NodeId(vec![2]),
+        signature: vec![],
+    };
+    let mut set1 = HashSet::new();
+    set1.insert(pred_a.clone());
+    set1.insert(pred_b.clone());
+    let mut set2 = HashSet::new();
+    set2.insert(pred_b);
+    set2.insert(pred_a);
+    let c1 = BlockContent {
+        payload: vec![10],
+        predecessors: set1,
+    };
+    let c2 = BlockContent {
+        payload: vec![10],
+        predecessors: set2,
+    };
+    assert_eq!(
+        hash_content_ext(&c1, &Sha256Hasher),
+        hash_content_ext(&c2, &Sha256Hasher)
+    );
 }
 
 #[test]
 fn sha256_hash_output_is_32_bytes() {
-    let content = BlockContent { payload: vec![0xff; 100], predecessors: HashSet::new() };
+    let content = BlockContent {
+        payload: vec![0xff; 100],
+        predecessors: HashSet::new(),
+    };
     assert_eq!(hash_content_ext(&content, &Sha256Hasher).len(), 32);
 }

--- a/crates/cordial-miners-core/tests/test_hash_with_blake.rs
+++ b/crates/cordial-miners-core/tests/test_hash_with_blake.rs
@@ -1,4 +1,4 @@
-use cordial_miners_core::crypto::{hash_content, hash_content_ext, Sha256Hasher};
+use cordial_miners_core::crypto::{Sha256Hasher, hash_content, hash_content_ext};
 use cordial_miners_core::{BlockContent, BlockIdentity, NodeId};
 use std::collections::HashSet;
 
@@ -6,7 +6,10 @@ use std::collections::HashSet;
 
 #[test]
 fn blake_hash_of_empty_genesis_is_deterministic() {
-    let content = BlockContent { payload: vec![], predecessors: HashSet::new() };
+    let content = BlockContent {
+        payload: vec![],
+        predecessors: HashSet::new(),
+    };
     let h1 = hash_content(&content);
     let h2 = hash_content(&content);
     assert_eq!(h1, h2);
@@ -14,34 +17,75 @@ fn blake_hash_of_empty_genesis_is_deterministic() {
 
 #[test]
 fn blake_different_payloads_produce_different_hashes() {
-    let c1 = BlockContent { payload: vec![1, 2, 3], predecessors: HashSet::new() };
-    let c2 = BlockContent { payload: vec![4, 5, 6], predecessors: HashSet::new() };
+    let c1 = BlockContent {
+        payload: vec![1, 2, 3],
+        predecessors: HashSet::new(),
+    };
+    let c2 = BlockContent {
+        payload: vec![4, 5, 6],
+        predecessors: HashSet::new(),
+    };
     assert_ne!(hash_content(&c1), hash_content(&c2));
 }
 
 #[test]
 fn blake_different_predecessors_produce_different_hashes() {
-    let pred_a = BlockIdentity { content_hash: [0x01; 32], creator: NodeId(vec![1]), signature: vec![] };
-    let pred_b = BlockIdentity { content_hash: [0x02; 32], creator: NodeId(vec![2]), signature: vec![] };
-    let c1 = BlockContent { payload: vec![], predecessors: HashSet::from([pred_a]) };
-    let c2 = BlockContent { payload: vec![], predecessors: HashSet::from([pred_b]) };
+    let pred_a = BlockIdentity {
+        content_hash: [0x01; 32],
+        creator: NodeId(vec![1]),
+        signature: vec![],
+    };
+    let pred_b = BlockIdentity {
+        content_hash: [0x02; 32],
+        creator: NodeId(vec![2]),
+        signature: vec![],
+    };
+    let c1 = BlockContent {
+        payload: vec![],
+        predecessors: HashSet::from([pred_a]),
+    };
+    let c2 = BlockContent {
+        payload: vec![],
+        predecessors: HashSet::from([pred_b]),
+    };
     assert_ne!(hash_content(&c1), hash_content(&c2));
 }
 
 #[test]
 fn blake_hash_is_independent_of_predecessor_insertion_order() {
-    let pred_a = BlockIdentity { content_hash: [0x01; 32], creator: NodeId(vec![1]), signature: vec![] };
-    let pred_b = BlockIdentity { content_hash: [0x02; 32], creator: NodeId(vec![2]), signature: vec![] };
-    let mut set1 = HashSet::new(); set1.insert(pred_a.clone()); set1.insert(pred_b.clone());
-    let mut set2 = HashSet::new(); set2.insert(pred_b); set2.insert(pred_a);
-    let c1 = BlockContent { payload: vec![10], predecessors: set1 };
-    let c2 = BlockContent { payload: vec![10], predecessors: set2 };
+    let pred_a = BlockIdentity {
+        content_hash: [0x01; 32],
+        creator: NodeId(vec![1]),
+        signature: vec![],
+    };
+    let pred_b = BlockIdentity {
+        content_hash: [0x02; 32],
+        creator: NodeId(vec![2]),
+        signature: vec![],
+    };
+    let mut set1 = HashSet::new();
+    set1.insert(pred_a.clone());
+    set1.insert(pred_b.clone());
+    let mut set2 = HashSet::new();
+    set2.insert(pred_b);
+    set2.insert(pred_a);
+    let c1 = BlockContent {
+        payload: vec![10],
+        predecessors: set1,
+    };
+    let c2 = BlockContent {
+        payload: vec![10],
+        predecessors: set2,
+    };
     assert_eq!(hash_content(&c1), hash_content(&c2));
 }
 
 #[test]
 fn blake_hash_output_is_32_bytes() {
-    let content = BlockContent { payload: vec![0xff; 100], predecessors: HashSet::new() };
+    let content = BlockContent {
+        payload: vec![0xff; 100],
+        predecessors: HashSet::new(),
+    };
     assert_eq!(hash_content(&content).len(), 32);
 }
 
@@ -49,7 +93,10 @@ fn blake_hash_output_is_32_bytes() {
 
 #[test]
 fn sha256_hash_of_empty_genesis_is_deterministic() {
-    let content = BlockContent { payload: vec![], predecessors: HashSet::new() };
+    let content = BlockContent {
+        payload: vec![],
+        predecessors: HashSet::new(),
+    };
     let h1 = hash_content_ext(&content, &Sha256Hasher);
     let h2 = hash_content_ext(&content, &Sha256Hasher);
     assert_eq!(h1, h2);
@@ -57,33 +104,83 @@ fn sha256_hash_of_empty_genesis_is_deterministic() {
 
 #[test]
 fn sha256_different_payloads_produce_different_hashes() {
-    let c1 = BlockContent { payload: vec![1, 2, 3], predecessors: HashSet::new() };
-    let c2 = BlockContent { payload: vec![4, 5, 6], predecessors: HashSet::new() };
-    assert_ne!(hash_content_ext(&c1, &Sha256Hasher), hash_content_ext(&c2, &Sha256Hasher));
+    let c1 = BlockContent {
+        payload: vec![1, 2, 3],
+        predecessors: HashSet::new(),
+    };
+    let c2 = BlockContent {
+        payload: vec![4, 5, 6],
+        predecessors: HashSet::new(),
+    };
+    assert_ne!(
+        hash_content_ext(&c1, &Sha256Hasher),
+        hash_content_ext(&c2, &Sha256Hasher)
+    );
 }
 
 #[test]
 fn sha256_different_predecessors_produce_different_hashes() {
-    let pred_a = BlockIdentity { content_hash: [0x01; 32], creator: NodeId(vec![1]), signature: vec![] };
-    let pred_b = BlockIdentity { content_hash: [0x02; 32], creator: NodeId(vec![2]), signature: vec![] };
-    let c1 = BlockContent { payload: vec![], predecessors: HashSet::from([pred_a]) };
-    let c2 = BlockContent { payload: vec![], predecessors: HashSet::from([pred_b]) };
-    assert_ne!(hash_content_ext(&c1, &Sha256Hasher), hash_content_ext(&c2, &Sha256Hasher));
+    let pred_a = BlockIdentity {
+        content_hash: [0x01; 32],
+        creator: NodeId(vec![1]),
+        signature: vec![],
+    };
+    let pred_b = BlockIdentity {
+        content_hash: [0x02; 32],
+        creator: NodeId(vec![2]),
+        signature: vec![],
+    };
+    let c1 = BlockContent {
+        payload: vec![],
+        predecessors: HashSet::from([pred_a]),
+    };
+    let c2 = BlockContent {
+        payload: vec![],
+        predecessors: HashSet::from([pred_b]),
+    };
+    assert_ne!(
+        hash_content_ext(&c1, &Sha256Hasher),
+        hash_content_ext(&c2, &Sha256Hasher)
+    );
 }
 
 #[test]
 fn sha256_hash_is_independent_of_predecessor_insertion_order() {
-    let pred_a = BlockIdentity { content_hash: [0x01; 32], creator: NodeId(vec![1]), signature: vec![] };
-    let pred_b = BlockIdentity { content_hash: [0x02; 32], creator: NodeId(vec![2]), signature: vec![] };
-    let mut set1 = HashSet::new(); set1.insert(pred_a.clone()); set1.insert(pred_b.clone());
-    let mut set2 = HashSet::new(); set2.insert(pred_b); set2.insert(pred_a);
-    let c1 = BlockContent { payload: vec![10], predecessors: set1 };
-    let c2 = BlockContent { payload: vec![10], predecessors: set2 };
-    assert_eq!(hash_content_ext(&c1, &Sha256Hasher), hash_content_ext(&c2, &Sha256Hasher));
+    let pred_a = BlockIdentity {
+        content_hash: [0x01; 32],
+        creator: NodeId(vec![1]),
+        signature: vec![],
+    };
+    let pred_b = BlockIdentity {
+        content_hash: [0x02; 32],
+        creator: NodeId(vec![2]),
+        signature: vec![],
+    };
+    let mut set1 = HashSet::new();
+    set1.insert(pred_a.clone());
+    set1.insert(pred_b.clone());
+    let mut set2 = HashSet::new();
+    set2.insert(pred_b);
+    set2.insert(pred_a);
+    let c1 = BlockContent {
+        payload: vec![10],
+        predecessors: set1,
+    };
+    let c2 = BlockContent {
+        payload: vec![10],
+        predecessors: set2,
+    };
+    assert_eq!(
+        hash_content_ext(&c1, &Sha256Hasher),
+        hash_content_ext(&c2, &Sha256Hasher)
+    );
 }
 
 #[test]
 fn sha256_hash_output_is_32_bytes() {
-    let content = BlockContent { payload: vec![0xff; 100], predecessors: HashSet::new() };
+    let content = BlockContent {
+        payload: vec![0xff; 100],
+        predecessors: HashSet::new(),
+    };
     assert_eq!(hash_content_ext(&content, &Sha256Hasher).len(), 32);
 }

--- a/crates/cordial-miners-core/tests/test_sign.rs
+++ b/crates/cordial-miners-core/tests/test_sign.rs
@@ -15,7 +15,7 @@ fn ed25519_sign_and_verify_roundtrip() {
     let (private_key, public_key) = generate_ed_keypair();
     let scheme = Ed25519Scheme;
     let hash = [0x13; 32];
-    
+
     let signature = scheme.sign(&hash, &private_key).expect("Ed sign failed");
     assert!(scheme.verify(&hash, &public_key, &signature));
 }
@@ -25,7 +25,7 @@ fn ed25519_signature_is_exactly_64_bytes() {
     let (private_key, _) = generate_ed_keypair();
     let scheme = Ed25519Scheme;
     let hash = [0xab; 32];
-    
+
     let signature = scheme.sign(&hash, &private_key).unwrap();
     assert_eq!(signature.len(), 64);
 }
@@ -36,7 +36,7 @@ fn ed25519_verify_fails_with_wrong_public_key() {
     let (_, wrong_public_key) = generate_ed_keypair();
     let scheme = Ed25519Scheme;
     let hash = [0x01; 32];
-    
+
     let signature = scheme.sign(&hash, &private_key).unwrap();
     assert!(!scheme.verify(&hash, &wrong_public_key, &signature));
 }
@@ -46,10 +46,10 @@ fn ed25519_verify_fails_with_tampered_signature() {
     let (private_key, public_key) = generate_ed_keypair();
     let scheme = Ed25519Scheme;
     let hash = [0x01; 32];
-    
+
     let mut signature = scheme.sign(&hash, &private_key).unwrap();
     signature[0] ^= 0xff;
-    
+
     assert!(!scheme.verify(&hash, &public_key, &signature));
 }
 
@@ -59,7 +59,7 @@ fn ed25519_different_hashes_produce_different_signatures() {
     let scheme = Ed25519Scheme;
     let h1 = [0x01; 32];
     let h2 = [0x02; 32];
-    
+
     let sig1 = scheme.sign(&h1, &private_key).unwrap();
     let sig2 = scheme.sign(&h2, &private_key).unwrap();
     assert_ne!(sig1, sig2);

--- a/crates/cordial-miners-core/tests/test_sign_with_secp256k1.rs
+++ b/crates/cordial-miners-core/tests/test_sign_with_secp256k1.rs
@@ -1,5 +1,5 @@
-use cordial_miners_core::crypto::{hash_content, sign, verify};
 use cordial_miners_core::BlockContent;
+use cordial_miners_core::crypto::{hash_content, sign, verify};
 use k256::ecdsa::SigningKey;
 use rand::rngs::OsRng;
 use std::collections::HashSet;
@@ -21,7 +21,10 @@ fn secp_sign_and_verify_roundtrip() {
     };
     let hash = hash_content(&content);
     let signature = sign(&hash, &private_key);
-    assert!(verify(&hash, &public_key, &signature), "Default Secp256k1 verification failed");
+    assert!(
+        verify(&hash, &public_key, &signature),
+        "Default Secp256k1 verification failed"
+    );
 }
 
 #[test]

--- a/crates/cordial-miners-core/tests/test_validation.rs
+++ b/crates/cordial-miners-core/tests/test_validation.rs
@@ -5,7 +5,6 @@ use cordial_miners_core::consensus::{
 use cordial_miners_core::crypto::{hash_content, sign};
 use cordial_miners_core::{Block, BlockContent, BlockIdentity, NodeId};
 use ed25519_dalek::SigningKey as EdSigningKey;
-use k256::ecdsa::SigningKey as SecpSigningKey;
 use rand::rngs::OsRng;
 use std::collections::HashMap;
 use std::collections::HashSet;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+components = ["rustfmt", "clippy"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "nightly"
 components = ["rustfmt", "clippy"]

--- a/rustfmt.toml.
+++ b/rustfmt.toml.
@@ -1,0 +1,26 @@
+# Enable unstable features to allow advanced import control
+unstable_features = true
+
+# Use the edition of your project for consistent parsing
+edition = "2021"
+
+# Automatically reorder imports alphabetically
+reorder_imports = true
+
+# Merge imports from the same crate into a single line/block
+imports_granularity = "Crate"
+
+# Force Unix line endings to prevent Windows/Mac conflicts
+newline_style = "Unix"
+
+# Wrap comments that exceed the max_width
+wrap_comments = true
+
+# Standardize line length
+max_width = 100
+
+# Format code snippets inside doc comments automatically
+format_code_in_doc_comments = true
+
+# Ensures consistent trailing commas in multiline structs/enums
+trailing_comma = "Vertical"


### PR DESCRIPTION
solves issue #39 
## Summary
This PR introduces a unified formatting and linting standard across the project. It resolves the "formatting drift" issue where different editor configurations were causing noisy commits and merge conflicts.

##  Changes Made
- **Toolchain:** Added `rust-toolchain.toml` to lock the project to `nightly`. This ensures all contributors use the same compiler version and prevents errors with unstable features in dependencies (e.g., `smallvec`).
- **Formatting:** Added `rustfmt.toml` with strict rules:
  - `imports_granularity = "Crate"` to stop import shuffling.
  - `newline_style = "Unix"` to eliminate OS-specific line ending conflicts.
  - `unstable_features = true` to allow advanced formatting rules.
- **CI/CD:** Updated the GitHub Actions workflow to:
  - Automatically check formatting (`cargo fmt --check`).
  - Run Clippy as a required gate (`-D warnings`).
  - Implement `rust-cache` for significantly faster build times.
- **Style:** Performed a one-time project-wide format via `cargo fmt --all`.

## Important Note for Reviewers
Because of the `cargo fmt` overhaul, this PR contains changes in many files. **All changes are purely aesthetic** and aimed at aligning the codebase with the new `rustfmt.toml` contract.

## How to Test
1. Pull this branch.
2. Ensure you have the nightly toolchain installed: `rustup toolchain install nightly`.
3. Run `cargo fmt --check` — it should return no errors.
4. Run `cargo clippy` — it should pass with no warnings.