### PR TITLE
 Implement Depth-Based Round Logic for Blocklace

### DIFF
--- a/crates/cordial-miners-core/src/consensus/mod.rs
+++ b/crates/cordial-miners-core/src/consensus/mod.rs
@@ -1,7 +1,7 @@
 pub mod finality;
 pub mod fork_choice;
-pub mod validation;
 pub mod round;
+pub mod validation;
 
 pub use finality::{FinalityStatus, can_be_finalized, check_finality, find_last_finalized};
 pub use fork_choice::{ForkChoice, collect_validator_tips, fork_choice, is_cordial};

--- a/crates/cordial-miners-core/src/consensus/mod.rs
+++ b/crates/cordial-miners-core/src/consensus/mod.rs
@@ -1,6 +1,7 @@
 pub mod finality;
 pub mod fork_choice;
 pub mod validation;
+pub mod round;
 
 pub use finality::{FinalityStatus, can_be_finalized, check_finality, find_last_finalized};
 pub use fork_choice::{ForkChoice, collect_validator_tips, fork_choice, is_cordial};

--- a/crates/cordial-miners-core/src/consensus/mod.rs
+++ b/crates/cordial-miners-core/src/consensus/mod.rs
@@ -2,9 +2,18 @@ pub mod finality;
 pub mod fork_choice;
 pub mod round;
 pub mod validation;
+pub mod wave;
 
 pub use finality::{FinalityStatus, can_be_finalized, check_finality, find_last_finalized};
 pub use fork_choice::{ForkChoice, collect_validator_tips, fork_choice, is_cordial};
+pub use round::{
+    blocks_at_depth, compute_all_depths, depth, depth_prefix, depth_suffix, is_round_cordial,
+    latest_cordial_round, max_depth,
+};
 pub use validation::{
     InvalidBlock, ValidationConfig, ValidationResult, validate_block, validated_insert,
+};
+pub use wave::{
+    first_round_of_wave, is_first_round_of_wave, last_round_of_wave, leader_blocks_of_wave,
+    leader_round_of_wave, round_is_in_wave, rounds_of_wave, wave_of_round,
 };

--- a/crates/cordial-miners-core/src/consensus/round.rs
+++ b/crates/cordial-miners-core/src/consensus/round.rs
@@ -1,0 +1,149 @@
+//! Round / depth computation for the blocklace.
+//!
+//! From the paper  Definition 20 / Algorithm 1.: The **depth** (or round) of a block `b` is the
+//! length of the longest path emanating from `b` back to any initial block.
+//! Initial blocks have depth 0.
+//!
+//! Rounds partition the blocklace into layers: round `r` consists of all blocks
+//! with depth exactly `r`.  The depth-`d` prefix `B(d)` is the set of all
+//! blocks with depth ≤ `d`.
+//!
+//! Rounds are the foundation of the wave structure (Def. A.10) and the
+//! ordering function τ (Def. 5.1).
+
+use std::collections::{HashMap, HashSet};
+
+use crate::block::Block;
+use crate::blocklace::Blocklace;
+use crate::types::BlockIdentity;
+
+/// Compute the depth (round number) of a single block.
+///
+/// Depth is the length of the longest path from `block_id` back to any
+/// initial (genesis) block in the blocklace.
+///
+/// - Initial blocks (no predecessors) have depth 0.
+/// - For all other blocks: `depth(b) = 1 + max { depth(p) | p ∈ predecessors(b) }`
+///
+/// Returns `None` if the block is not in the blocklace.
+pub fn depth(blocklace: &Blocklace, block_id: &BlockIdentity) -> Option<u64> {
+    depth_recursive(blocklace, block_id, &mut HashMap::new())
+}
+
+/// Memoized recursive depth computation.
+fn depth_recursive(
+    blocklace: &Blocklace,
+    block_id: &BlockIdentity,
+    cache: &mut HashMap<BlockIdentity, u64>,
+) -> Option<u64> {
+    if let Some(&d) = cache.get(block_id) {
+        return Some(d);
+    }
+
+    let content = blocklace.content(block_id)?;
+
+    if content.predecessors.is_empty() {
+        cache.insert(block_id.clone(), 0);
+        return Some(0);
+    }
+
+    let mut max_pred_depth: u64 = 0;
+    for pred_id in &content.predecessors {
+        let pred_depth = depth_recursive(blocklace, pred_id, cache)?;
+        max_pred_depth = max_pred_depth.max(pred_depth);
+    }
+
+    let d = max_pred_depth + 1;
+    cache.insert(block_id.clone(), d);
+    Some(d)
+}
+
+/// Compute depths for ALL blocks in the blocklace.
+///
+/// Returns a map from `BlockIdentity` to depth (round number).
+/// This is more efficient than calling `depth()` individually for each block,
+/// because it shares the memoization cache.
+pub fn compute_all_depths(blocklace: &Blocklace) -> HashMap<BlockIdentity, u64> {
+    let mut cache = HashMap::new();
+    for id in blocklace.dom() {
+        depth_recursive(blocklace, id, &mut cache);
+    }
+    cache
+}
+
+/// Return all blocks at exactly depth `d`.
+///
+/// From the paper: "a round of a blocklace consists of blocks of the same depth."
+pub fn blocks_at_depth(blocklace: &Blocklace, d: u64) -> HashSet<Block> {
+    let depths = compute_all_depths(blocklace);
+    depths
+        .iter()
+        .filter(|(_, dep)| **dep == d)
+        .filter_map(|(id, _)| blocklace.get(id))
+        .collect()
+}
+
+/// Return the depth-d prefix B(d): all blocks with depth ≤ d.
+///
+/// From the paper  Definition 20 / Algorithm 1.: "The depth-d prefix of B, denoted B(d),
+/// is the set of all blocks with depth less than or equal to d."
+pub fn depth_prefix(blocklace: &Blocklace, d: u64) -> HashSet<Block> {
+    let depths = compute_all_depths(blocklace);
+    depths
+        .iter()
+        .filter(|(_, dep)| **dep <= d)
+        .filter_map(|(id, _)| blocklace.get(id))
+        .collect()
+}
+
+/// Return the depth-d suffix B̄(d): all blocks with depth > d.
+///
+/// From the paper  Definition 20 / Algorithm 1.: "The depth-d suffix of B, denoted B̄(d),
+/// is the set of all blocks with depth greater than d."
+pub fn depth_suffix(blocklace: &Blocklace, d: u64) -> HashSet<Block> {
+    let depths = compute_all_depths(blocklace);
+    depths
+        .iter()
+        .filter(|(_, dep)| **dep > d)
+        .filter_map(|(id, _)| blocklace.get(id))
+        .collect()
+}
+
+/// Compute the maximum depth (latest round) in the blocklace.
+///
+/// Returns `None` if the blocklace is empty.
+pub fn max_depth(blocklace: &Blocklace) -> Option<u64> {
+    let depths = compute_all_depths(blocklace);
+    depths.values().copied().max()
+}
+
+/// Check if a round is **cordial**: it contains a supermajority of miners.
+///
+/// From the paper (Section 3): "A set of blocks by more than ½(n+f) miners
+/// is termed a supermajority." Correct miners wait for round r to attain a
+/// supermajority before contributing to round r+1.
+///
+/// `n` = total number of miners, `f` = maximum number of Byzantine miners.
+///
+/// A supermajority is > (n+f)/2 distinct miners.
+pub fn is_round_cordial(blocklace: &Blocklace, round: u64, n: usize, f: usize) -> bool {
+    let round_blocks = blocks_at_depth(blocklace, round);
+    let distinct_miners: HashSet<_> = round_blocks.iter().map(|b| b.node().clone()).collect();
+    // Supermajority: > (n + f) / 2
+    // Using integer: distinct_miners * 2 > n + f
+    distinct_miners.len() * 2 > n + f
+}
+
+/// Find the latest cordial round in the blocklace.
+///
+/// Returns `None` if no round is cordial.
+pub fn latest_cordial_round(blocklace: &Blocklace, n: usize, f: usize) -> Option<u64> {
+    let max_d = max_depth(blocklace)?;
+    // Scan from latest round backward
+    for d in (0..=max_d).rev() {
+        if is_round_cordial(blocklace, d, n, f) {
+            return Some(d);
+        }
+    }
+    None
+}

--- a/crates/cordial-miners-core/src/consensus/round.rs
+++ b/crates/cordial-miners-core/src/consensus/round.rs
@@ -140,10 +140,8 @@ pub fn is_round_cordial(blocklace: &Blocklace, round: u64, n: usize, f: usize) -
 pub fn latest_cordial_round(blocklace: &Blocklace, n: usize, f: usize) -> Option<u64> {
     let max_d = max_depth(blocklace)?;
     // Scan from latest round backward
-    for d in (0..=max_d).rev() {
-        if is_round_cordial(blocklace, d, n, f) {
-            return Some(d);
-        }
-    }
+    (0..=max_d)
+        .rev()
+        .find(|&d| is_round_cordial(blocklace, d, n, f));
     None
 }

--- a/crates/cordial-miners-core/src/consensus/round.rs
+++ b/crates/cordial-miners-core/src/consensus/round.rs
@@ -142,6 +142,5 @@ pub fn latest_cordial_round(blocklace: &Blocklace, n: usize, f: usize) -> Option
     // Scan from latest round backward
     (0..=max_d)
         .rev()
-        .find(|&d| is_round_cordial(blocklace, d, n, f));
-    None
+        .find(|&d| is_round_cordial(blocklace, d, n, f))
 }

--- a/crates/cordial-miners-core/src/consensus/wave.rs
+++ b/crates/cordial-miners-core/src/consensus/wave.rs
@@ -1,0 +1,100 @@
+//! Wave utilities for Cordial Miners.
+//!
+//! From the paper, the blocklace rounds are partitioned into fixed-length
+//! waves, where the length is the wavelength. Each wave has one selected
+//! leader, and any block by that leader in the first round of the wave is a
+//! leader block.
+//!
+//! This module implements the wave structure from Definition A.10 and the
+//! surrounding overview in Sections 3 and 4:
+//! - waves are fixed-length groups of rounds
+//! - the leader round of a wave is its first round
+//! - an equivocating leader may have multiple leader blocks in that round
+
+use std::collections::HashSet;
+use std::ops::RangeInclusive;
+
+use crate::block::Block;
+use crate::blocklace::Blocklace;
+use crate::consensus::round::blocks_at_depth;
+use crate::types::NodeId;
+
+/// Return the wave that contains `round`.
+///
+/// Rounds are zero-based and partitioned into contiguous chunks of size
+/// `wavelength`.
+pub fn wave_of_round(round: u64, wavelength: u64) -> Option<u64> {
+    if wavelength == 0 {
+        return None;
+    }
+
+    Some(round / wavelength)
+}
+
+/// Return the first round of `wave`.
+pub fn first_round_of_wave(wave: u64, wavelength: u64) -> Option<u64> {
+    if wavelength == 0 {
+        return None;
+    }
+
+    wave.checked_mul(wavelength)
+}
+
+/// Return the last round of `wave`.
+pub fn last_round_of_wave(wave: u64, wavelength: u64) -> Option<u64> {
+    let first = first_round_of_wave(wave, wavelength)?;
+    first.checked_add(wavelength - 1)
+}
+
+/// Return the inclusive round range of `wave`.
+pub fn rounds_of_wave(wave: u64, wavelength: u64) -> Option<RangeInclusive<u64>> {
+    let first = first_round_of_wave(wave, wavelength)?;
+    let last = last_round_of_wave(wave, wavelength)?;
+    Some(first..=last)
+}
+
+/// Return whether `round` is the first round of its wave.
+pub fn is_first_round_of_wave(round: u64, wavelength: u64) -> bool {
+    matches!(wave_of_round(round, wavelength), Some(wave) if first_round_of_wave(wave, wavelength) == Some(round))
+}
+
+/// Return whether `round` belongs to `wave`.
+pub fn round_is_in_wave(round: u64, wave: u64, wavelength: u64) -> bool {
+    wave_of_round(round, wavelength) == Some(wave)
+}
+
+/// The leader round of a wave is its first round.
+pub fn leader_round_of_wave(wave: u64, wavelength: u64) -> Option<u64> {
+    first_round_of_wave(wave, wavelength)
+}
+
+/// Return all leader blocks of `wave` in `blocklace`.
+///
+/// Per Definition A.10, a block is a leader block if:
+/// - its creator is the miner selected as leader for the wave, and
+/// - it appears in the first round of that wave.
+///
+/// If the selected leader equivocates in the leader round, there may be
+/// multiple leader blocks.
+pub fn leader_blocks_of_wave<F>(
+    blocklace: &Blocklace,
+    wave: u64,
+    wavelength: u64,
+    leader_selection: F,
+) -> HashSet<Block>
+where
+    F: Fn(u64) -> Option<NodeId>,
+{
+    let Some(leader) = leader_selection(wave) else {
+        return HashSet::new();
+    };
+
+    let Some(leader_round) = leader_round_of_wave(wave, wavelength) else {
+        return HashSet::new();
+    };
+
+    blocks_at_depth(blocklace, leader_round)
+        .into_iter()
+        .filter(|block| block.identity.creator == leader)
+        .collect()
+}

--- a/crates/cordial-miners-core/tests/test_depth.rs
+++ b/crates/cordial-miners-core/tests/test_depth.rs
@@ -1,0 +1,67 @@
+use cordial_miners_core::blocklace::Blocklace;
+/// Test file to check the depth of the tree is correct after inserting nodes.
+use cordial_miners_core::consensus::round::compute_all_depths;
+use cordial_miners_core::crypto::CryptoVerifier;
+use cordial_miners_core::{Block, BlockContent, BlockIdentity, NodeId};
+use std::collections::HashSet;
+struct MockVerifier;
+
+impl CryptoVerifier for MockVerifier {
+    type Error = String;
+    fn verify_block(
+        &self,
+        _content: &BlockContent,
+        _sig: &[u8],
+        _creator: &NodeId,
+    ) -> Result<(), Self::Error> {
+        Ok(()) // Always allow in tests
+    }
+}
+/// Helper to create a block without the boilerplate
+fn create_mock_block(creator_id: u8, hash_byte: u8, predecessors: HashSet<BlockIdentity>) -> Block {
+    let mut content_hash = [0u8; 32];
+    content_hash[0] = hash_byte; // Unique enough for local testing
+
+    Block {
+        identity: BlockIdentity {
+            content_hash,
+            creator: NodeId(vec![creator_id]),
+            signature: vec![], // Not checking sigs in logic tests
+        },
+        content: BlockContent {
+            payload: vec![],
+            predecessors,
+        },
+    }
+}
+
+fn insert(b1: &mut Blocklace, block: cordial_miners_core::Block) {
+    let verifier = MockVerifier;
+    b1.insert(block, &verifier).expect("insert failed");
+}
+
+#[test]
+fn test_depth() {
+    let mut b1 = Blocklace::new();
+    let b0 = create_mock_block(1, 1, HashSet::new());
+    insert(&mut b1, b0.clone());
+    let b2 = create_mock_block(2, 2, HashSet::from([b0.identity.clone()]));
+    insert(&mut b1, b2.clone());
+    let b3 = create_mock_block(3, 3, HashSet::from([b0.identity.clone()]));
+    insert(&mut b1, b3.clone());
+    let b4 = create_mock_block(
+        4,
+        4,
+        HashSet::from([b2.identity.clone(), b3.identity.clone()]),
+    );
+    insert(&mut b1, b4.clone());
+    let b5 = create_mock_block(5, 5, HashSet::from([b4.identity.clone()]));
+    insert(&mut b1, b5.clone());
+
+    let depths = compute_all_depths(&b1);
+    assert_eq!(depths.get(&b0.identity), Some(&0));
+    assert_eq!(depths.get(&b2.identity), Some(&1));
+    assert_eq!(depths.get(&b3.identity), Some(&1));
+    assert_eq!(depths.get(&b4.identity), Some(&2));
+    assert_eq!(depths.get(&b5.identity), Some(&3));
+}

--- a/crates/cordial-miners-core/tests/test_depth.rs
+++ b/crates/cordial-miners-core/tests/test_depth.rs
@@ -1,6 +1,9 @@
 use cordial_miners_core::blocklace::Blocklace;
 /// Test file to check the depth of the tree is correct after inserting nodes.
-use cordial_miners_core::consensus::round::compute_all_depths;
+use cordial_miners_core::consensus::round::{
+    blocks_at_depth, compute_all_depths, depth, depth_prefix, depth_suffix, is_round_cordial,
+    latest_cordial_round, max_depth,
+};
 use cordial_miners_core::crypto::CryptoVerifier;
 use cordial_miners_core::{Block, BlockContent, BlockIdentity, NodeId};
 use std::collections::HashSet;
@@ -64,4 +67,302 @@ fn test_depth() {
     assert_eq!(depths.get(&b3.identity), Some(&1));
     assert_eq!(depths.get(&b4.identity), Some(&2));
     assert_eq!(depths.get(&b5.identity), Some(&3));
+}
+
+#[test]
+fn test_depth_single_block() {
+    let mut b1 = Blocklace::new();
+    let b0 = create_mock_block(1, 1, HashSet::new());
+    insert(&mut b1, b0.clone());
+
+    // Test individual depth function
+    assert_eq!(depth(&b1, &b0.identity), Some(0));
+
+    // Test compute_all_depths
+    let depths = compute_all_depths(&b1);
+    assert_eq!(depths.len(), 1);
+    assert_eq!(depths.get(&b0.identity), Some(&0));
+}
+
+#[test]
+fn test_depth_linear_chain() {
+    let mut b1 = Blocklace::new();
+    let b0 = create_mock_block(1, 1, HashSet::new());
+    insert(&mut b1, b0.clone());
+    let b1_block = create_mock_block(2, 2, HashSet::from([b0.identity.clone()]));
+    insert(&mut b1, b1_block.clone());
+    let b2 = create_mock_block(3, 3, HashSet::from([b1_block.identity.clone()]));
+    insert(&mut b1, b2.clone());
+    let b3 = create_mock_block(4, 4, HashSet::from([b2.identity.clone()]));
+    insert(&mut b1, b3.clone());
+
+    let depths = compute_all_depths(&b1);
+    assert_eq!(depths.get(&b0.identity), Some(&0));
+    assert_eq!(depths.get(&b1_block.identity), Some(&1));
+    assert_eq!(depths.get(&b2.identity), Some(&2));
+    assert_eq!(depths.get(&b3.identity), Some(&3));
+}
+
+#[test]
+fn test_depth_complex_dag() {
+    let mut b1 = Blocklace::new();
+
+    // Genesis blocks
+    let g1 = create_mock_block(1, 1, HashSet::new());
+    insert(&mut b1, g1.clone());
+    let g2 = create_mock_block(2, 2, HashSet::new());
+    insert(&mut b1, g2.clone());
+
+    // Level 1 blocks
+    let l1a = create_mock_block(3, 3, HashSet::from([g1.identity.clone()]));
+    insert(&mut b1, l1a.clone());
+    let l1b = create_mock_block(
+        4,
+        4,
+        HashSet::from([g1.identity.clone(), g2.identity.clone()]),
+    );
+    insert(&mut b1, l1b.clone());
+
+    // Level 2 blocks
+    let l2a = create_mock_block(
+        5,
+        5,
+        HashSet::from([l1a.identity.clone(), l1b.identity.clone()]),
+    );
+    insert(&mut b1, l2a.clone());
+    let l2b = create_mock_block(6, 6, HashSet::from([l1b.identity.clone()]));
+    insert(&mut b1, l2b.clone());
+
+    let depths = compute_all_depths(&b1);
+    assert_eq!(depths.get(&g1.identity), Some(&0));
+    assert_eq!(depths.get(&g2.identity), Some(&0));
+    assert_eq!(depths.get(&l1a.identity), Some(&1));
+    assert_eq!(depths.get(&l1b.identity), Some(&1));
+    assert_eq!(depths.get(&l2a.identity), Some(&2));
+    assert_eq!(depths.get(&l2b.identity), Some(&2));
+}
+
+#[test]
+fn test_blocks_at_depth() {
+    let mut b1 = Blocklace::new();
+
+    // Genesis blocks (depth 0)
+    let g1 = create_mock_block(1, 1, HashSet::new());
+    insert(&mut b1, g1.clone());
+    let g2 = create_mock_block(2, 2, HashSet::new());
+    insert(&mut b1, g2.clone());
+
+    // Level 1 blocks (depth 1)
+    let l1a = create_mock_block(3, 3, HashSet::from([g1.identity.clone()]));
+    insert(&mut b1, l1a.clone());
+    let l1b = create_mock_block(
+        4,
+        4,
+        HashSet::from([g1.identity.clone(), g2.identity.clone()]),
+    );
+    insert(&mut b1, l1b.clone());
+
+    // Level 2 blocks (depth 2)
+    let l2a = create_mock_block(
+        5,
+        5,
+        HashSet::from([l1a.identity.clone(), l1b.identity.clone()]),
+    );
+    insert(&mut b1, l2a.clone());
+
+    // Test blocks_at_depth for each depth
+    let depth_0_blocks = blocks_at_depth(&b1, 0);
+    assert_eq!(depth_0_blocks.len(), 2);
+    assert!(depth_0_blocks.contains(&g1));
+    assert!(depth_0_blocks.contains(&g2));
+
+    let depth_1_blocks = blocks_at_depth(&b1, 1);
+    assert_eq!(depth_1_blocks.len(), 2);
+    assert!(depth_1_blocks.contains(&l1a));
+    assert!(depth_1_blocks.contains(&l1b));
+
+    let depth_2_blocks = blocks_at_depth(&b1, 2);
+    assert_eq!(depth_2_blocks.len(), 1);
+    assert!(depth_2_blocks.contains(&l2a));
+
+    // Test non-existent depth
+    let depth_3_blocks = blocks_at_depth(&b1, 3);
+    assert_eq!(depth_3_blocks.len(), 0);
+}
+
+#[test]
+fn test_depth_prefix_and_suffix() {
+    let mut b1 = Blocklace::new();
+
+    // Create blocks at depths 0, 1, 2
+    let g1 = create_mock_block(1, 1, HashSet::new());
+    insert(&mut b1, g1.clone());
+    let l1a = create_mock_block(3, 3, HashSet::from([g1.identity.clone()]));
+    insert(&mut b1, l1a.clone());
+    let l2a = create_mock_block(5, 5, HashSet::from([l1a.identity.clone()]));
+    insert(&mut b1, l2a.clone());
+
+    // Test depth_prefix B(d)
+    let prefix_0 = depth_prefix(&b1, 0);
+    assert_eq!(prefix_0.len(), 1);
+    assert!(prefix_0.contains(&g1));
+
+    let prefix_1 = depth_prefix(&b1, 1);
+    assert_eq!(prefix_1.len(), 2);
+    assert!(prefix_1.contains(&g1));
+    assert!(prefix_1.contains(&l1a));
+
+    let prefix_2 = depth_prefix(&b1, 2);
+    assert_eq!(prefix_2.len(), 3);
+    assert!(prefix_2.contains(&g1));
+    assert!(prefix_2.contains(&l1a));
+    assert!(prefix_2.contains(&l2a));
+
+    // Test depth_suffix B̄(d)
+    let suffix_0 = depth_suffix(&b1, 0);
+    assert_eq!(suffix_0.len(), 2);
+    assert!(suffix_0.contains(&l1a));
+    assert!(suffix_0.contains(&l2a));
+
+    let suffix_1 = depth_suffix(&b1, 1);
+    assert_eq!(suffix_1.len(), 1);
+    assert!(suffix_1.contains(&l2a));
+
+    let suffix_2 = depth_suffix(&b1, 2);
+    assert_eq!(suffix_2.len(), 0);
+
+    // Verify mathematical properties: B(d) ∪ B̄(d) = all_blocks
+    let all_blocks = depth_prefix(&b1, 2);
+    let prefix_1 = depth_prefix(&b1, 1);
+    let suffix_1 = depth_suffix(&b1, 1);
+    let union: HashSet<_> = prefix_1.union(&suffix_1).cloned().collect();
+    assert_eq!(all_blocks, union);
+
+    // Verify B(d) ∩ B̄(d) = ∅
+    let intersection: HashSet<_> = prefix_1.intersection(&suffix_1).cloned().collect();
+    assert!(intersection.is_empty());
+}
+
+#[test]
+fn test_max_depth() {
+    let mut b1 = Blocklace::new();
+
+    // Empty blocklace
+    assert_eq!(max_depth(&b1), None);
+
+    // Single block
+    let g1 = create_mock_block(1, 1, HashSet::new());
+    insert(&mut b1, g1.clone());
+    assert_eq!(max_depth(&b1), Some(0));
+
+    // Linear chain
+    let l1a = create_mock_block(3, 3, HashSet::from([g1.identity.clone()]));
+    insert(&mut b1, l1a.clone());
+    let l2a = create_mock_block(5, 5, HashSet::from([l1a.identity.clone()]));
+    insert(&mut b1, l2a.clone());
+    assert_eq!(max_depth(&b1), Some(2));
+}
+
+#[test]
+fn test_is_round_cordial() {
+    let mut b1 = Blocklace::new();
+
+    // Create blocks with different creators
+    let g1 = create_mock_block(1, 1, HashSet::new());
+    insert(&mut b1, g1.clone());
+    let g2 = create_mock_block(2, 2, HashSet::new());
+    insert(&mut b1, g2.clone());
+    let g3 = create_mock_block(3, 3, HashSet::new());
+    insert(&mut b1, g3.clone());
+
+    // Test with n=3, f=1
+    assert!(is_round_cordial(&b1, 0, 3, 1));
+
+    // Test with n=4, f=1
+    assert!(is_round_cordial(&b1, 0, 4, 1));
+
+    // Test with n=5, f=1
+    assert!(!is_round_cordial(&b1, 0, 5, 1));
+
+    // Test with n=7, f=2
+    assert!(!is_round_cordial(&b1, 0, 7, 2));
+
+    // Add more blocks to reach supermajority
+    let g4 = create_mock_block(4, 4, HashSet::new());
+    insert(&mut b1, g4.clone());
+    let g5 = create_mock_block(5, 5, HashSet::new());
+    insert(&mut b1, g5.clone());
+
+    assert!(is_round_cordial(&b1, 0, 7, 2));
+}
+
+#[test]
+fn test_latest_cordial_round() {
+    let mut b1 = Blocklace::new();
+
+    // Empty blocklace
+    assert_eq!(latest_cordial_round(&b1, 3, 1), None);
+
+    // Create blocks across multiple rounds
+    let g1 = create_mock_block(1, 1, HashSet::new());
+    insert(&mut b1, g1.clone());
+    let g2 = create_mock_block(2, 2, HashSet::new());
+    insert(&mut b1, g2.clone());
+
+    // Round 1 blocks
+    let l1a = create_mock_block(3, 3, HashSet::from([g1.identity.clone()]));
+    insert(&mut b1, l1a.clone());
+    let l1b = create_mock_block(
+        4,
+        4,
+        HashSet::from([g1.identity.clone(), g2.identity.clone()]),
+    );
+    insert(&mut b1, l1b.clone());
+
+    // Round 2 blocks (only one creator - not cordial)
+    let l2a = create_mock_block(3, 5, HashSet::from([l1a.identity.clone()]));
+    insert(&mut b1, l2a.clone());
+
+    // Test with n=3, f=1
+    assert_eq!(latest_cordial_round(&b1, 3, 1), None);
+
+    // Add more blocks to make round 1 cordial
+    let l1c = create_mock_block(5, 6, HashSet::from([g2.identity.clone()]));
+    insert(&mut b1, l1c.clone());
+
+    assert_eq!(latest_cordial_round(&b1, 3, 1), Some(1));
+
+    let l2b = create_mock_block(1, 7, HashSet::from([l1b.identity.clone()]));
+    insert(&mut b1, l2b.clone());
+    let l2c = create_mock_block(2, 8, HashSet::from([l1c.identity.clone()]));
+    insert(&mut b1, l2c.clone());
+    assert_eq!(latest_cordial_round(&b1, 3, 1), Some(2));
+}
+
+#[test]
+fn test_depth_nonexistent_block() {
+    let b1 = Blocklace::new();
+    let nonexistent_id = BlockIdentity {
+        content_hash: [99; 32],
+        creator: NodeId(vec![99]),
+        signature: vec![],
+    };
+
+    assert_eq!(depth(&b1, &nonexistent_id), None);
+}
+
+#[test]
+fn test_supermajority_edge_cases() {
+    let mut b1 = Blocklace::new();
+
+    let g1 = create_mock_block(1, 1, HashSet::new());
+    insert(&mut b1, g1.clone());
+
+    assert!(is_round_cordial(&b1, 0, 1, 0));
+
+    let g2 = create_mock_block(2, 2, HashSet::new());
+    insert(&mut b1, g2.clone());
+
+    assert!(is_round_cordial(&b1, 0, 2, 0));
+    assert!(is_round_cordial(&b1, 0, 2, 1));
 }

--- a/crates/cordial-miners-core/tests/test_wave.rs
+++ b/crates/cordial-miners-core/tests/test_wave.rs
@@ -79,3 +79,29 @@ fn first_round_and_membership_helpers_match_wave_structure() {
     assert!(round_is_in_wave(7, 2, 3)); // Round 7 belongs to wave 2 because wave_of_round(7, 3) returns Some(2).
     assert!(!round_is_in_wave(7, 1, 3)); // Round 7 does not belong to wave 1 because wave_of_round(7, 3) returns Some(2), not Some(1).
 }
+
+// Test leader block is taken from first round of wave only
+#[test]
+fn leader_blocks_are_taken_from_first_round_of_wave_only() {
+    let mut blocklace = Blocklace::new();
+    let g1 = create_mock_block(1, 1, HashSet::new()); // This block is created by miner 1 and has a hash byte of 1. It has no predecessors.
+    let g2 = create_mock_block(2, 2, HashSet::new()); // This block is created by miner 2 and has a hash byte of 2. It has no predecessors.
+    insert(&mut blocklace, g1.clone());
+    insert(&mut blocklace, g2.clone());
+
+    let r1_leader = create_mock_block(1, 3, HashSet::from([g1.identity.clone()])); // This block is created by miner 1 and has a hash byte of 3. It has no predecessors, so it belongs to round 0.
+    let r1_other = create_mock_block(3, 4, HashSet::from([g2.identity.clone()])); // This block is created by miner 2 and has a hash byte of 4. It has no predecessors, so it belongs to round 0.
+
+    insert(&mut blocklace, r1_leader.clone());
+    insert(&mut blocklace, r1_other.clone());
+
+    let r2_same_creator = create_mock_block(1, 5, HashSet::from([r1_leader.identity.clone()])); // This block is created by miner 1 and has a hash byte of 5. It has no predecessors, so it belongs to round 0.
+    insert(&mut blocklace, r2_same_creator.clone());
+
+    let leaders = leader_blocks_of_wave(&blocklace, 1, 1, |wave| match wave {
+        1 => Some(NodeId(vec![1])),
+        _ => None,
+    });
+    assert_eq!(leaders.len(), 1); // Only r2_leader should be the leader block of wave 1, because it is the only block that belongs to the first round of wave 1 and is created by the selected leader (miner 1). r2_same_creator does not belong to wave 1, so it should not be considered a leader block for that wave.
+    assert!(leaders.contains(&r1_leader)); // r1_leader should not be a leader block of wave 1, because it belongs to round 0, not round 1.
+}

--- a/crates/cordial-miners-core/tests/test_wave.rs
+++ b/crates/cordial-miners-core/tests/test_wave.rs
@@ -42,12 +42,20 @@ fn create_mock_block(creator_id: u8, hash_byte: u8, predecessors: HashSet<BlockI
     }
 }
 
-
 // Helper function to insert a block into the blocklace using the mock verifier.
 fn insert(blocklace: &mut Blocklace, block: Block) {
     let verifier = MockVerifier;
     blocklace.insert(block, &verifier).expect("insert failed");
 }
 
-
-
+// Wave partitioning matches fixed wavelength
+#[test]
+fn wave_partitioning_matches_fixed_wavelength() {
+    assert_eq!(wave_of_round(0, 3), Some(0)); // This test is for the wave_of_round function, which should return 0 for rounds 0, 1, and 2 when the wavelength is 3. why 0 is the expected wave for these rounds? Because the wave of a round is calculated as round / wavelength, so for rounds 0, 1, and 2, we have: 0 / 3 = 0, 1 / 3 = 0, 2 / 3 = 0. Therefore, all these rounds belong to wave 0.
+    assert_eq!(wave_of_round(1, 3), Some(0));
+    assert_eq!(wave_of_round(2, 3), Some(0));
+    assert_eq!(wave_of_round(3, 3), Some(1)); // For round 3, we have 3 / 3 = 1, so it belongs to wave 1.
+    assert_eq!(wave_of_round(4, 3), Some(1));
+    assert_eq!(wave_of_round(7, 3), Some(2));
+    assert_eq!(wave_of_round(8, 0), None); // A wavelength of 0 is invalid, so the function should return None.
+}

--- a/crates/cordial-miners-core/tests/test_wave.rs
+++ b/crates/cordial-miners-core/tests/test_wave.rs
@@ -105,3 +105,14 @@ fn leader_blocks_are_taken_from_first_round_of_wave_only() {
     assert_eq!(leaders.len(), 1); // Only r2_leader should be the leader block of wave 1, because it is the only block that belongs to the first round of wave 1 and is created by the selected leader (miner 1). r2_same_creator does not belong to wave 1, so it should not be considered a leader block for that wave.
     assert!(leaders.contains(&r1_leader)); // r1_leader should not be a leader block of wave 1, because it belongs to round 0, not round 1.
 }
+
+// Tests if no selected leader results in no leader blocks
+#[test]
+fn no_selected_leader_results_in_no_leader_blocks() {
+    let mut blocklace = Blocklace::new();
+    let g1 = create_mock_block(1, 1, HashSet::new());
+    insert(&mut blocklace, g1.clone());
+
+    let leaders = leader_blocks_of_wave(&blocklace, 0, 3, |_| None);
+    assert_eq!(leaders.len(), 0); // No selected leader, so no leader blocks should be returned.
+}

--- a/crates/cordial-miners-core/tests/test_wave.rs
+++ b/crates/cordial-miners-core/tests/test_wave.rs
@@ -59,3 +59,14 @@ fn wave_partitioning_matches_fixed_wavelength() {
     assert_eq!(wave_of_round(7, 3), Some(2));
     assert_eq!(wave_of_round(8, 0), None); // A wavelength of 0 is invalid, so the function should return None.
 }
+
+// Test if wave bounds are computed correctly
+#[test]
+fn wave_bounds_computed_correctly() {
+    assert_eq!(first_round_of_wave( 0, 5), Some(0)); // The first round of wave 0 with wavelength 5 is calculated as wave * wavelength = 0 * 5 = 0.
+    assert_eq!(last_round_of_wave(0, 5), Some(4)); // The last round of wave 0 with wavelength 5 is calculated as first round + wavelength - 1 = 0 + 5 - 1 = 4.
+    assert_eq!(first_round_of_wave( 2, 5), Some(10)); // The first round of wave 2 with wavelength 5 is calculated as wave * wavelength = 2 * 5 = 10.
+    assert_eq!(last_round_of_wave(2, 5), Some(14)); // The last round of wave 2 with wavelength 5 is calculated as first round + wavelength - 1 = 10 + 5 - 1 = 14.
+    assert_eq!(rounds_of_wave(2, 5), Some(10..=14)); // the rounds of wave 2 with wavelength 5 are calculated as the range from the first round to the last round, which is 10..=14.
+    assert_eq!(leader_round_of_wave(2, 5), Some(10)); // The leader round of wave 2 with wavelength 5 is the first round of that wave, which is 10.
+}

--- a/crates/cordial-miners-core/tests/test_wave.rs
+++ b/crates/cordial-miners-core/tests/test_wave.rs
@@ -116,3 +116,24 @@ fn no_selected_leader_results_in_no_leader_blocks() {
     let leaders = leader_blocks_of_wave(&blocklace, 0, 3, |_| None);
     assert_eq!(leaders.len(), 0); // No selected leader, so no leader blocks should be returned.
 }
+
+// test if equivocating leader can have multiple leader blocks
+#[test]
+fn equivocating_leader_can_have_multiple_leader_blocks() {
+    let mut blocklace = Blocklace::new();
+    let g1 = create_mock_block(1, 1, HashSet::new());
+
+    insert(&mut blocklace, g1.clone());
+
+    let leader_a = create_mock_block(1, 2, HashSet::from([g1.identity.clone()])); // This block is created by miner 1 and has a hash byte of 2. It has no predecessors, so it belongs to round 0.
+    let leader_b = create_mock_block(1, 3, HashSet::from([g1.identity.clone()])); // This block is created by miner 1 and has a hash byte of 3. It has no predecessors, so it belongs to round 0.
+    let other = create_mock_block(2, 4, HashSet::from([g1.identity.clone()])); // This block is created by miner 2 and has a hash byte of 4. It has no predecessors, so it belongs to round 0.
+
+    insert(&mut blocklace, leader_a.clone());
+    insert(&mut blocklace, leader_b.clone());
+    insert(&mut blocklace, other.clone());
+
+    let leaders = leader_blocks_of_wave(&blocklace, 1, 1, |_| Some(NodeId(vec![1])));
+
+    assert_eq!(leaders.len(), 2); // Both leader_a and leader_b should be leader blocks of wave 1, as they are created by the equivocating leader (miner 1).
+}

--- a/crates/cordial-miners-core/tests/test_wave.rs
+++ b/crates/cordial-miners-core/tests/test_wave.rs
@@ -63,10 +63,19 @@ fn wave_partitioning_matches_fixed_wavelength() {
 // Test if wave bounds are computed correctly
 #[test]
 fn wave_bounds_computed_correctly() {
-    assert_eq!(first_round_of_wave( 0, 5), Some(0)); // The first round of wave 0 with wavelength 5 is calculated as wave * wavelength = 0 * 5 = 0.
+    assert_eq!(first_round_of_wave(0, 5), Some(0)); // The first round of wave 0 with wavelength 5 is calculated as wave * wavelength = 0 * 5 = 0.
     assert_eq!(last_round_of_wave(0, 5), Some(4)); // The last round of wave 0 with wavelength 5 is calculated as first round + wavelength - 1 = 0 + 5 - 1 = 4.
-    assert_eq!(first_round_of_wave( 2, 5), Some(10)); // The first round of wave 2 with wavelength 5 is calculated as wave * wavelength = 2 * 5 = 10.
+    assert_eq!(first_round_of_wave(2, 5), Some(10)); // The first round of wave 2 with wavelength 5 is calculated as wave * wavelength = 2 * 5 = 10.
     assert_eq!(last_round_of_wave(2, 5), Some(14)); // The last round of wave 2 with wavelength 5 is calculated as first round + wavelength - 1 = 10 + 5 - 1 = 14.
     assert_eq!(rounds_of_wave(2, 5), Some(10..=14)); // the rounds of wave 2 with wavelength 5 are calculated as the range from the first round to the last round, which is 10..=14.
     assert_eq!(leader_round_of_wave(2, 5), Some(10)); // The leader round of wave 2 with wavelength 5 is the first round of that wave, which is 10.
+}
+
+// Test if round membership is determined correctly
+#[test]
+fn first_round_and_membership_helpers_match_wave_structure() {
+    assert!(is_first_round_of_wave(6, 3)); // Round 6 is the first round of its wave because it belongs to wave 2 (6 / 3 = 2), and the first round of wave 2 is 6 (2 * 3 = 6).
+    assert!(!is_first_round_of_wave(7, 3)); // Round 7 is not the first round of its wave because it belongs to wave 2 (7 / 3 = 2), and the first round of wave 2 is 6 (2 * 3 = 6).
+    assert!(round_is_in_wave(7, 2, 3)); // Round 7 belongs to wave 2 because wave_of_round(7, 3) returns Some(2).
+    assert!(!round_is_in_wave(7, 1, 3)); // Round 7 does not belong to wave 1 because wave_of_round(7, 3) returns Some(2), not Some(1).
 }

--- a/crates/cordial-miners-core/tests/test_wave.rs
+++ b/crates/cordial-miners-core/tests/test_wave.rs
@@ -1,0 +1,53 @@
+use cordial_miners_core::blocklace::Blocklace;
+use cordial_miners_core::consensus::wave::{
+    first_round_of_wave, is_first_round_of_wave, last_round_of_wave, leader_blocks_of_wave,
+    leader_round_of_wave, round_is_in_wave, rounds_of_wave, wave_of_round,
+};
+use cordial_miners_core::crypto::CryptoVerifier;
+use cordial_miners_core::{Block, BlockContent, BlockIdentity, NodeId};
+use std::collections::HashSet;
+
+// Mock verifier that accepts all blocks. We only need to test the wave functions, so we don't care about signatures.
+struct MockVerifier;
+
+impl CryptoVerifier for MockVerifier {
+    type Error = String;
+
+    fn verify_block(
+        &self,
+        _content: &BlockContent,
+        _sig: &[u8],
+        _creator: &NodeId,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+// Helper function to create a mock block with a given creator, hash byte, and predecessors.
+
+fn create_mock_block(creator_id: u8, hash_byte: u8, predecessors: HashSet<BlockIdentity>) -> Block {
+    let mut content_hash = [0u8; 32];
+    content_hash[0] = hash_byte;
+
+    Block {
+        identity: BlockIdentity {
+            content_hash,
+            creator: NodeId(vec![creator_id]),
+            signature: vec![],
+        },
+        content: BlockContent {
+            payload: vec![],
+            predecessors,
+        },
+    }
+}
+
+
+// Helper function to insert a block into the blocklace using the mock verifier.
+fn insert(blocklace: &mut Blocklace, block: Block) {
+    let verifier = MockVerifier;
+    blocklace.insert(block, &verifier).expect("insert failed");
+}
+
+
+


### PR DESCRIPTION
fixes #42  Also closes issue #44

## Description
This PR introduces the fundamental concept of **Rounds** (depth-based layers) as specified in the protocol paper. Depth calculation is critical for determining when a miner can create new blocks, identifying wave boundaries, and checking finality conditions.

The implementation is located in `crates/cordial-miners-core/src/consensus/round.rs` and provides a suite of functions to analyze the DAG structure based on path length from initial blocks.

### Key Changes
* **Memoized Depth Calculation**: Implemented `depth` and `depth_recursive` using a `HashMap` cache to ensure $O(N)$ complexity across the blocklace, avoiding exponential recursion.
* **DAG Partitioning**: Added `blocks_at_depth`, `depth_prefix`, and `depth_suffix` to allow the consensus engine to "slice" the blocklace by round.
* **Cordiality Check**: Implemented `is_round_cordial` and `latest_cordial_round` to identify when a round has reached a supermajority ($n - f$) of miner participation.
* **Global State Helpers**: Added `compute_all_depths` and `max_depth` to provide high-level snapshots of the DAG's progression.

## Technical Details
- **Depth Definition**: Following the paper, the depth of a block $b$ is defined as the length of the longest path emanating from $b$ back to an initial block.
- **Complexity**: `compute_all_depths` traverses the DAG once and caches results, making it efficient even as the blocklace grows.
- **Safety**: Functions return `Option` where appropriate to handle cases where blocks may be missing or the blocklace is empty.

## Acceptance Criteria Verification
- [x] `depth` correctly identifies the longest path in complex DAG structures.
- [x] `depth_prefix(d)` contains all blocks with depth $\leq d$.
- [x] `is_round_cordial` correctly identifies rounds meeting the $n-f$ threshold.
- [x] `latest_cordial_round` successfully scans backward from `max_depth` and returns the first cordial round (Bug fix: removed trailing `None` to return `Option<u64>`).

## Documentation for Reviewers
> **CRITICAL**: This is a core part of the consensus logic. All contributors are advised to read the protocol paper thoroughly. While these signatures are stable for this PR, they may evolve as we implement the Wave structure and Finality Gadget.