### PR TITLE
Implement cordiality predicates and hidden-equivocation validation

### DIFF
--- a/crates/cordial-f1r3node-adapter/src/casper_adapter.rs
+++ b/crates/cordial-f1r3node-adapter/src/casper_adapter.rs
@@ -121,6 +121,7 @@ pub enum InvalidBlock {
     NotOfInterest,
     /// Translation failure — block didn't decode against the wire format.
     InvalidFormat,
+    HiddenEquivocation,
 }
 
 /// Mirror of f1r3node's `ValidBlock`.
@@ -346,6 +347,7 @@ where
             CoreInvalidBlock::MissingPredecessors { .. } => InvalidBlock::InvalidParents,
             CoreInvalidBlock::Equivocation { .. } => InvalidBlock::AdmissibleEquivocation,
             CoreInvalidBlock::NotCordial { .. } => InvalidBlock::NotOfInterest,
+            CoreInvalidBlock::HiddenEquivocation { .. } => InvalidBlock::HiddenEquivocation,
         }
     }
 

--- a/crates/cordial-miners-core/src/consensus/cordiality.rs
+++ b/crates/cordial-miners-core/src/consensus/cordiality.rs
@@ -160,3 +160,19 @@ pub fn hidden_equivocations(blocklace: &Blocklace, block: &Block) -> Vec<HiddenE
         })
         .collect()
 }
+
+// Return the validator tips ommitted by 'block'.
+pub fn missing_known_tips(
+    block: &Block,
+    known_tips: &HashMap<NodeId, BlockIdentity>,
+) -> Vec<BlockIdentity> {
+    let mut missing: Vec<BlockIdentity> = known_tips
+        .values()
+        .filter(|tip_id| {
+            block.identity != **tip_id && !block.content.predecessors.contains(*tip_id)
+        })
+        .cloned()
+        .collect();
+    missing.sort();
+    missing
+}

--- a/crates/cordial-miners-core/src/consensus/cordiality.rs
+++ b/crates/cordial-miners-core/src/consensus/cordiality.rs
@@ -35,3 +35,22 @@ pub struct HiddenEquivocation {
     pub round: u64,
     pub blocks: Vec<BlockIdentity>
 }
+
+/// Return all blocks  created by 'creator' at exactly 'round' in the blocklace.
+pub fn creator_blocks_at_round(blocklace: &Blocklace, creator: &NodeId, round:u64) -> HashSet<Block> {
+    blocks_at_depth(blocklace, round)
+        .into_iter()
+        .filter(|b| b.identity.creator == *creator)
+        .collect()
+}
+
+/// Return all same-round equivocation branches for `creator` at `round`.
+/// Under the user story for this task, a validator equivocates when they create at least two different blocks in the exact same round.
+pub fn equivocation_blocks_at_round(blocklace: &Blocklace, creator: &NodeId, round:u64) -> HashSet<Block>{
+    let blocks = creator_blocks_at_round(blocklace, creator, round);
+    if blocks.len() >= 2 {
+        blocks
+    } else {
+        HashSet::new()
+    }
+}

--- a/crates/cordial-miners-core/src/consensus/cordiality.rs
+++ b/crates/cordial-miners-core/src/consensus/cordiality.rs
@@ -33,7 +33,7 @@ pub struct Equivocation {
 pub struct HiddenEquivocation {
     pub creator: NodeId,
     pub round: u64,
-    pub blocks: Vec<BlockIdentity>
+    pub hidden: Vec<BlockIdentity>
 }
 
 /// Return all blocks  created by 'creator' at exactly 'round' in the blocklace.
@@ -129,3 +129,34 @@ pub fn acknowledges_equivocation(
         .all(|equiv_block| observed.contains(&equiv_block.identity))
 }
 
+/// Return the globally known equivocations hidden by `block`.
+///
+/// This uses the local blocklace as the source of knowledge. If the blocklace
+/// already contains a same-round equivocation, then a candidate block is
+/// considered to hide it when its predecessor closure does not acknowledge all
+/// branches.
+pub fn hidden_equivocations(blocklace: &Blocklace, block: &Block) -> Vec<HiddenEquivocation> {
+    let observed = observed_block_ids(blocklace, block);
+
+    all_equivocations(blocklace)
+        .into_iter()
+        .filter_map(|equivocation| {
+            let hidden: Vec<BlockIdentity> = equivocation
+                .blocks
+                .iter()
+                .filter(|id| !observed.contains(*id))
+                .cloned()
+                .collect();
+
+            if hidden.is_empty() {
+                None
+            } else {
+                Some(HiddenEquivocation {
+                    creator: equivocation.creator,
+                    round: equivocation.round,
+                    hidden,
+                })
+            }
+        })
+        .collect()
+}

--- a/crates/cordial-miners-core/src/consensus/cordiality.rs
+++ b/crates/cordial-miners-core/src/consensus/cordiality.rs
@@ -176,3 +176,17 @@ pub fn missing_known_tips(
     missing.sort();
     missing
 }
+
+
+
+/// Check whether a block is cordial with respect to:
+/// - known validator tips, and
+/// - globally known same-round equivocations already present in the blocklace.
+pub fn is_cordial_block(
+    blocklace: &Blocklace,
+    block: &Block,
+    known_tips: &HashMap<NodeId, BlockIdentity>,
+) -> bool {
+    missing_known_tips(block, known_tips).is_empty()
+        && hidden_equivocations(blocklace, block).is_empty()
+}

--- a/crates/cordial-miners-core/src/consensus/cordiality.rs
+++ b/crates/cordial-miners-core/src/consensus/cordiality.rs
@@ -27,3 +27,11 @@ pub struct Equivocation {
     pub round: u64,
     pub blocks: Vec<BlockIdentity>
 }
+
+/// A globally known equivocation that a candidate block fails to acknowledge.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HiddenEquivocation {
+    pub creator: NodeId,
+    pub round: u64,
+    pub blocks: Vec<BlockIdentity>
+}

--- a/crates/cordial-miners-core/src/consensus/cordiality.rs
+++ b/crates/cordial-miners-core/src/consensus/cordiality.rs
@@ -54,3 +54,42 @@ pub fn equivocation_blocks_at_round(blocklace: &Blocklace, creator: &NodeId, rou
         HashSet::new()
     }
 }
+
+/// Return every same-round equivocation currently present in the blocklace.
+pub fn all_equivocations(blocklace: &Blocklace) -> Vec<Equivocation> {
+    let Some(max_round) = blocklace
+        .dom()
+        .into_iter()
+        .filter_map(|id| depth(blocklace, id))
+        .max() 
+        else {
+            return Vec::new();
+        };
+    let creators: HashSet<NodeId> = blocklace
+        .dom()
+        .iter()
+        .map(|id| id.creator.clone())
+        .collect();
+
+    let mut equivocations = Vec::new();
+
+    for creator in creators {
+        for round in 0..=max_round {
+            let mut blocks:  Vec<BlockIdentity> = equivocation_blocks_at_round(blocklace, &creator, round)
+                .into_iter()
+                .map(|b| b.identity)
+                .collect();
+
+            if blocks.len() >= 2 {
+                blocks.sort();
+                equivocations.push(Equivocation {
+                    creator: creator.clone(),
+                    round,
+                    blocks,
+                });
+            }
+        }
+    }
+
+    equivocations
+}

--- a/crates/cordial-miners-core/src/consensus/cordiality.rs
+++ b/crates/cordial-miners-core/src/consensus/cordiality.rs
@@ -1,0 +1,29 @@
+//! Equivocation and cordiality predicates for Cordial Miners.
+//!
+//! This module gathers the protocol-facing DAG predicates that sit between the
+//! structural helpers (`round`, `wave`) and the enforcement layer
+//! (`validation`).
+//!
+//! The paper distinguishes:
+//! - equivocation: a validator produces multiple conflicting blocks
+//! - cordiality: a block does not hide relevant information from the DAG view
+//!
+//! In this implementation, the "known" portion of "known equivocations" is
+//! interpreted conservatively as "already present in the local blocklace".
+//! That makes these predicates usable inside block validation, where the
+//! creator's private local view is not available.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::block::Block;
+use crate::blocklace::Blocklace;
+use crate::consensus::round::{blocks_at_depth, depth};
+use crate::types::{BlockIdentity, NodeId};
+
+/// A same-round equivocation detected in the blocklace.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Equivocation {
+    pub creator: NodeId,
+    pub round: u64,
+    pub blocks: Vec<BlockIdentity>
+}

--- a/crates/cordial-miners-core/src/consensus/cordiality.rs
+++ b/crates/cordial-miners-core/src/consensus/cordiality.rs
@@ -108,12 +108,11 @@ pub fn all_equivocations(blocklace: &Blocklace) -> Vec<Equivocation> {
 ///
 /// This is the reconstructed DAG view induced by the candidate's declared
 /// predecessors, without inserting the candidate into the blocklace.
-
 pub fn observed_block_ids(blocklace: &Blocklace, block: &Block) -> HashSet<BlockIdentity> {
     let mut observed = HashSet::new();
 
     for pred_id in &block.content.predecessors {
-        observed.extend(blocklace.observe(pred_id).into_iter());
+        observed.extend(blocklace.observe(pred_id));
     }
 
     observed

--- a/crates/cordial-miners-core/src/consensus/cordiality.rs
+++ b/crates/cordial-miners-core/src/consensus/cordiality.rs
@@ -25,7 +25,7 @@ use crate::types::{BlockIdentity, NodeId};
 pub struct Equivocation {
     pub creator: NodeId,
     pub round: u64,
-    pub blocks: Vec<BlockIdentity>
+    pub blocks: Vec<BlockIdentity>,
 }
 
 /// A globally known equivocation that a candidate block fails to acknowledge.
@@ -33,11 +33,15 @@ pub struct Equivocation {
 pub struct HiddenEquivocation {
     pub creator: NodeId,
     pub round: u64,
-    pub hidden: Vec<BlockIdentity>
+    pub hidden: Vec<BlockIdentity>,
 }
 
 /// Return all blocks  created by 'creator' at exactly 'round' in the blocklace.
-pub fn creator_blocks_at_round(blocklace: &Blocklace, creator: &NodeId, round:u64) -> HashSet<Block> {
+pub fn creator_blocks_at_round(
+    blocklace: &Blocklace,
+    creator: &NodeId,
+    round: u64,
+) -> HashSet<Block> {
     blocks_at_depth(blocklace, round)
         .into_iter()
         .filter(|b| b.identity.creator == *creator)
@@ -46,7 +50,11 @@ pub fn creator_blocks_at_round(blocklace: &Blocklace, creator: &NodeId, round:u6
 
 /// Return all same-round equivocation branches for `creator` at `round`.
 /// Under the user story for this task, a validator equivocates when they create at least two different blocks in the exact same round.
-pub fn equivocation_blocks_at_round(blocklace: &Blocklace, creator: &NodeId, round:u64) -> HashSet<Block>{
+pub fn equivocation_blocks_at_round(
+    blocklace: &Blocklace,
+    creator: &NodeId,
+    round: u64,
+) -> HashSet<Block> {
     let blocks = creator_blocks_at_round(blocklace, creator, round);
     if blocks.len() >= 2 {
         blocks
@@ -61,10 +69,10 @@ pub fn all_equivocations(blocklace: &Blocklace) -> Vec<Equivocation> {
         .dom()
         .into_iter()
         .filter_map(|id| depth(blocklace, id))
-        .max() 
-        else {
-            return Vec::new();
-        };
+        .max()
+    else {
+        return Vec::new();
+    };
     let creators: HashSet<NodeId> = blocklace
         .dom()
         .iter()
@@ -75,10 +83,11 @@ pub fn all_equivocations(blocklace: &Blocklace) -> Vec<Equivocation> {
 
     for creator in creators {
         for round in 0..=max_round {
-            let mut blocks:  Vec<BlockIdentity> = equivocation_blocks_at_round(blocklace, &creator, round)
-                .into_iter()
-                .map(|b| b.identity)
-                .collect();
+            let mut blocks: Vec<BlockIdentity> =
+                equivocation_blocks_at_round(blocklace, &creator, round)
+                    .into_iter()
+                    .map(|b| b.identity)
+                    .collect();
 
             if blocks.len() >= 2 {
                 blocks.sort();
@@ -176,8 +185,6 @@ pub fn missing_known_tips(
     missing.sort();
     missing
 }
-
-
 
 /// Check whether a block is cordial with respect to:
 /// - known validator tips, and

--- a/crates/cordial-miners-core/src/consensus/cordiality.rs
+++ b/crates/cordial-miners-core/src/consensus/cordiality.rs
@@ -93,3 +93,39 @@ pub fn all_equivocations(blocklace: &Blocklace) -> Vec<Equivocation> {
 
     equivocations
 }
+
+/// Return the set of block ids acknowledged by a candidate block through its
+/// predecessor closure.
+///
+/// This is the reconstructed DAG view induced by the candidate's declared
+/// predecessors, without inserting the candidate into the blocklace.
+
+pub fn observed_block_ids(blocklace: &Blocklace, block: &Block) -> HashSet<BlockIdentity> {
+    let mut observed = HashSet::new();
+
+    for pred_id in &block.content.predecessors {
+        observed.extend(blocklace.observe(pred_id).into_iter());
+    }
+
+    observed
+}
+
+/// Return whether `block` acknowledges every branch of the same-round
+/// equivocation by `creator` at `round`.
+pub fn acknowledges_equivocation(
+    blocklace: &Blocklace,
+    block: &Block,
+    creator: &NodeId,
+    round: u64,
+) -> bool {
+    let equivocation = equivocation_blocks_at_round(blocklace, creator, round);
+    if equivocation.is_empty() {
+        return true;
+    }
+
+    let observed = observed_block_ids(blocklace, block);
+    equivocation
+        .iter()
+        .all(|equiv_block| observed.contains(&equiv_block.identity))
+}
+

--- a/crates/cordial-miners-core/src/consensus/mod.rs
+++ b/crates/cordial-miners-core/src/consensus/mod.rs
@@ -1,9 +1,15 @@
+pub mod cordiality;
 pub mod finality;
 pub mod fork_choice;
 pub mod round;
 pub mod validation;
 pub mod wave;
 
+pub use cordiality::{
+    Equivocation, HiddenEquivocation, acknowledges_equivocation, all_equivocations,
+    creator_blocks_at_round, equivocation_blocks_at_round, hidden_equivocations, is_cordial_block,
+    missing_known_tips, observed_block_ids,
+};
 pub use finality::{FinalityStatus, can_be_finalized, check_finality, find_last_finalized};
 pub use fork_choice::{ForkChoice, collect_validator_tips, fork_choice, is_cordial};
 pub use round::{

--- a/crates/cordial-miners-core/src/consensus/validation.rs
+++ b/crates/cordial-miners-core/src/consensus/validation.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 
 use crate::block::Block;
 use crate::blocklace::Blocklace;
+use crate::consensus::cordiality::{hidden_equivocations, is_cordial_block, missing_known_tips};
+use crate::consensus::fork_choice::collect_validator_tips;
 use crate::crypto;
 use crate::types::{BlockIdentity, NodeId};
 
@@ -34,6 +36,13 @@ pub enum InvalidBlock {
 
     /// Block does not satisfy the cordial condition (does not reference all known tips).
     NotCordial { missing_tips: Vec<BlockIdentity> },
+
+    /// Block hides a same-round equivocation already known to the local DAG view.
+    HiddenEquivocation {
+        creator: NodeId,
+        round: u64,
+        hidden: Vec<BlockIdentity>,
+    },
 }
 
 /// Result of block validation.
@@ -196,23 +205,25 @@ pub fn validate_block(
         }
     }
 
-    // 6. Cordial condition — block references all known tips
+    // 6. Cordial condition — block references known tips and does not hide
+    //    globally known equivocations already present in the local DAG view.
     if config.check_cordial {
-        let equivocators = blocklace.find_equivacators();
-        let missing_tips: Vec<BlockIdentity> = bonds
-            .keys()
-            .filter(|node| !equivocators.contains(node))
-            .filter_map(|node| blocklace.tip_of(node))
-            .filter(|tip| {
-                !block.content.predecessors.contains(&tip.identity)
-                    && block.identity != tip.identity
-            })
-            .map(|tip| tip.identity)
-            .collect();
+        let known_tips = collect_validator_tips(blocklace, bonds);
+        let missing_tips = missing_known_tips(block, &known_tips);
 
         if !missing_tips.is_empty() {
             errors.push(InvalidBlock::NotCordial { missing_tips });
         }
+
+        for hidden in hidden_equivocations(blocklace, block) {
+            errors.push(InvalidBlock::HiddenEquivocation {
+                creator: hidden.creator,
+                round: hidden.round,
+                hidden: hidden.hidden,
+            });
+        }
+
+        let _ = is_cordial_block(blocklace, block, &known_tips);
     }
 
     if errors.is_empty() {

--- a/crates/cordial-miners-core/tests/test_cordiality.rs
+++ b/crates/cordial-miners-core/tests/test_cordiality.rs
@@ -172,3 +172,19 @@ fn cordiality_requires_tips_and_no_hidden_equivocations() {
     assert!(is_cordial_block(&blocklace, &cordial, &known_tips));
 
 }
+
+// Test that all_equivocations returns the correct creator, round, and blocks for each equivocation. We create multiple equivocations by different creators at different rounds and check that they are all reported correctly by the all_equivocations function.
+#[test]
+fn all_equivocations_reports_creator_and_round() {
+    let mut blocklace = Blocklace::new();
+    let e1 = create_mock_block(1, 1, HashSet::new());
+    let e2 = create_mock_block(1, 2, HashSet::new());
+    insert(&mut blocklace, &e1);
+    insert(&mut blocklace, &e2);
+
+    let equivocations = all_equivocations(&blocklace);
+    assert_eq!(equivocations.len(), 1);
+    assert_eq!(equivocations[0].creator, node(1));
+    assert_eq!(equivocations[0].round, 0);
+    assert_eq!(equivocations[0].blocks.len(), 2);
+}

--- a/crates/cordial-miners-core/tests/test_cordiality.rs
+++ b/crates/cordial-miners-core/tests/test_cordiality.rs
@@ -52,7 +52,6 @@ fn insert(blocklace: &mut Blocklace, block: &Block) {
         .expect("insert failed");
 }
 
-
 // Test that we can detect same-round equivocation by a creator. We create two blocks by the same creator at the same round and check that they are both detected as equivocations.
 #[test]
 fn detects_same_round_equivocation() {
@@ -64,7 +63,7 @@ fn detects_same_round_equivocation() {
     insert(&mut blocklace, &e2);
 
     // this cause equivocation because both blocks are created by the same creator (node 1) and they are at the same round (round 0, since they have no predecessors). We check that both blocks are detected as equivocations by calling the equivocation_blocks_at_round function and verifying that it returns both blocks.
-    let equivocation = equivocation_blocks_at_round(&blocklace, &node(1), 0); 
+    let equivocation = equivocation_blocks_at_round(&blocklace, &node(1), 0);
     assert_eq!(equivocation.len(), 2);
     assert!(equivocation.contains(&e1));
     assert!(equivocation.contains(&e2));
@@ -82,7 +81,6 @@ fn different_rounds_are_not_same_round_equivocations() {
 
     assert!(equivocation_blocks_at_round(&blocklace, &node(1), 0).is_empty());
     assert!(equivocation_blocks_at_round(&blocklace, &node(1), 1).is_empty());
-
 }
 
 // Test that different creators at the same round do not count as equivocation. We create two blocks by different creators at the same round and check that they are not detected as equivocations.
@@ -91,30 +89,38 @@ fn predecessor_closure_can_acknowledge_equivocation() {
     let mut blocklace = Blocklace::new();
     let e1 = create_mock_block(1, 1, HashSet::new());
     let e2 = create_mock_block(1, 2, HashSet::new());
-    
+
     insert(&mut blocklace, &e1);
     insert(&mut blocklace, &e2);
 
-    let witness = create_mock_block(2,3, HashSet::from([e1.identity.clone(), e2.identity.clone()]));
+    let witness = create_mock_block(
+        2,
+        3,
+        HashSet::from([e1.identity.clone(), e2.identity.clone()]),
+    );
     insert(&mut blocklace, &witness);
 
-    let candidate = create_mock_block(3, 4,HashSet::from([witness.identity.clone()]));
+    let candidate = create_mock_block(3, 4, HashSet::from([witness.identity.clone()]));
 
     let observed = observed_block_ids(&blocklace, &candidate);
 
     // The candidate block acknowledges the witness block, which in turn acknowledges both equivocation blocks e1 and e2. Therefore, the candidate block should be considered as acknowledging the equivocation by node 1 at round 0, and the observed block ids should include both e1 and e2.
     assert!(observed.contains(&e1.identity));
     assert!(observed.contains(&e2.identity));
-    assert!(acknowledges_equivocation(&blocklace, &candidate, &node(1), 0));
+    assert!(acknowledges_equivocation(
+        &blocklace,
+        &candidate,
+        &node(1),
+        0
+    ));
 }
-
 
 #[test]
 fn candidate_can_hide_known_equivocation() {
     let mut blocklace = Blocklace::new();
     let e1 = create_mock_block(1, 1, HashSet::new());
     let e2 = create_mock_block(1, 2, HashSet::new());
-    
+
     insert(&mut blocklace, &e1);
     insert(&mut blocklace, &e2);
 
@@ -127,23 +133,25 @@ fn candidate_can_hide_known_equivocation() {
     assert_eq!(hidden[0].creator, node(1));
     assert_eq!(hidden[0].round, 0);
     assert_eq!(hidden[0].hidden, vec![e2.identity.clone()]);
-
 }
-
 
 // Test that cordiality requires acknowledging all known tips and no hidden equivocations. We create a candidate block that is missing a known tip and check that it is not cordial, then we create a candidate block that acknowledges all known tips and has no hidden equivocations and check that it is cordial.
 #[test]
 fn cordiality_requires_tips_and_no_hidden_equivocations() {
     let mut blocklace = Blocklace::new();
     let e1 = create_mock_block(1, 1, HashSet::new());
-    let e2 = create_mock_block(1,2, HashSet::new());
+    let e2 = create_mock_block(1, 2, HashSet::new());
     let g2 = create_mock_block(2, 3, HashSet::new());
 
     insert(&mut blocklace, &e1);
     insert(&mut blocklace, &e2);
     insert(&mut blocklace, &g2);
 
-    let witness = create_mock_block(4, 4, HashSet::from([e1.identity.clone(), e2.identity.clone()]));
+    let witness = create_mock_block(
+        4,
+        4,
+        HashSet::from([e1.identity.clone(), e2.identity.clone()]),
+    );
     insert(&mut blocklace, &witness);
 
     let known_tips: HashMap<NodeId, BlockIdentity> = [
@@ -170,7 +178,6 @@ fn cordiality_requires_tips_and_no_hidden_equivocations() {
     );
     // The cordial block acknowledges both known tips (witness and g2) and does not have any hidden equivocations, so it should be considered cordial according to the definition of cordiality. Therefore, the is_cordial_block function should return true for the cordial block when we pass in the blocklace and the known_tips.
     assert!(is_cordial_block(&blocklace, &cordial, &known_tips));
-
 }
 
 // Test that all_equivocations returns the correct creator, round, and blocks for each equivocation. We create multiple equivocations by different creators at different rounds and check that they are all reported correctly by the all_equivocations function.

--- a/crates/cordial-miners-core/tests/test_cordiality.rs
+++ b/crates/cordial-miners-core/tests/test_cordiality.rs
@@ -6,6 +6,7 @@ use cordial_miners_core::consensus::cordiality::{
 use cordial_miners_core::crypto::CryptoVerifier;
 use cordial_miners_core::{Block, BlockContent, BlockIdentity, NodeId};
 use std::collections::{HashMap, HashSet};
+use std::vec;
 
 struct MockVerifier;
 
@@ -81,5 +82,50 @@ fn different_rounds_are_not_same_round_equivocations() {
 
     assert!(equivocation_blocks_at_round(&blocklace, &node(1), 0).is_empty());
     assert!(equivocation_blocks_at_round(&blocklace, &node(1), 1).is_empty());
+
+}
+
+// Test that different creators at the same round do not count as equivocation. We create two blocks by different creators at the same round and check that they are not detected as equivocations.
+#[test]
+fn predecessor_closure_can_acknowledge_equivocation() {
+    let mut blocklace = Blocklace::new();
+    let e1 = create_mock_block(1, 1, HashSet::new());
+    let e2 = create_mock_block(1, 2, HashSet::new());
+    
+    insert(&mut blocklace, &e1);
+    insert(&mut blocklace, &e2);
+
+    let witness = create_mock_block(2,3, HashSet::from([e1.identity.clone(), e2.identity.clone()]));
+    insert(&mut blocklace, &witness);
+
+    let candidate = create_mock_block(3, 4,HashSet::from([witness.identity.clone()]));
+
+    let observed = observed_block_ids(&blocklace, &candidate);
+
+    // The candidate block acknowledges the witness block, which in turn acknowledges both equivocation blocks e1 and e2. Therefore, the candidate block should be considered as acknowledging the equivocation by node 1 at round 0, and the observed block ids should include both e1 and e2.
+    assert!(observed.contains(&e1.identity));
+    assert!(observed.contains(&e2.identity));
+    assert!(acknowledges_equivocation(&blocklace, &candidate, &node(1), 0));
+}
+
+
+#[test]
+fn candidate_can_hide_known_equivocation() {
+    let mut blocklace = Blocklace::new();
+    let e1 = create_mock_block(1, 1, HashSet::new());
+    let e2 = create_mock_block(1, 2, HashSet::new());
+    
+    insert(&mut blocklace, &e1);
+    insert(&mut blocklace, &e2);
+
+    let candidate = create_mock_block(3, 3, HashSet::from([e1.identity.clone()]));
+    insert(&mut blocklace, &candidate);
+    let hidden = hidden_equivocations(&blocklace, &candidate);
+    // The candidate block does not acknowledge any of the equivocation blocks e1 and e2, so both of them should be considered as hidden equivocations by the candidate block.
+
+    assert_eq!(hidden.len(), 1);
+    assert_eq!(hidden[0].creator, node(1));
+    assert_eq!(hidden[0].round, 0);
+    assert_eq!(hidden[0].hidden, vec![e2.identity.clone()]);
 
 }

--- a/crates/cordial-miners-core/tests/test_cordiality.rs
+++ b/crates/cordial-miners-core/tests/test_cordiality.rs
@@ -1,0 +1,52 @@
+use cordial_miners_core::blocklace::Blocklace;
+use cordial_miners_core::consensus::cordiality::{
+    acknowledges_equivocation, all_equivocations, equivocation_blocks_at_round,
+    hidden_equivocations, is_cordial_block, missing_known_tips, observed_block_ids,
+};
+use cordial_miners_core::crypto::CryptoVerifier;
+use cordial_miners_core::{Block, BlockContent, BlockIdentity, NodeId};
+use std::collections::{HashMap, HashSet};
+
+struct MockVerifier;
+
+impl CryptoVerifier for MockVerifier {
+    type Error = String;
+
+    fn verify_block(
+        &self,
+        _content: &BlockContent,
+        _sig: &[u8],
+        _creator: &NodeId,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+fn node(id: u8) -> NodeId {
+    NodeId(vec![id])
+}
+
+fn create_mock_block(creator_id: u8, hash_byte: u8, predecessors: HashSet<BlockIdentity>) -> Block {
+    let mut content_hash = [0u8; 32];
+    content_hash[0] = creator_id;
+    content_hash[1] = hash_byte;
+
+    Block {
+        identity: BlockIdentity {
+            content_hash,
+            creator: node(creator_id),
+            signature: vec![],
+        },
+        content: BlockContent {
+            payload: vec![],
+            predecessors,
+        },
+    }
+}
+
+fn insert(blocklace: &mut Blocklace, block: &Block) {
+    let verifier = MockVerifier;
+    blocklace
+        .insert(block.clone(), &verifier)
+        .expect("insert failed");
+}

--- a/crates/cordial-miners-core/tests/test_cordiality.rs
+++ b/crates/cordial-miners-core/tests/test_cordiality.rs
@@ -129,3 +129,46 @@ fn candidate_can_hide_known_equivocation() {
     assert_eq!(hidden[0].hidden, vec![e2.identity.clone()]);
 
 }
+
+
+// Test that cordiality requires acknowledging all known tips and no hidden equivocations. We create a candidate block that is missing a known tip and check that it is not cordial, then we create a candidate block that acknowledges all known tips and has no hidden equivocations and check that it is cordial.
+#[test]
+fn cordiality_requires_tips_and_no_hidden_equivocations() {
+    let mut blocklace = Blocklace::new();
+    let e1 = create_mock_block(1, 1, HashSet::new());
+    let e2 = create_mock_block(1,2, HashSet::new());
+    let g2 = create_mock_block(2, 3, HashSet::new());
+
+    insert(&mut blocklace, &e1);
+    insert(&mut blocklace, &e2);
+    insert(&mut blocklace, &g2);
+
+    let witness = create_mock_block(4, 4, HashSet::from([e1.identity.clone(), e2.identity.clone()]));
+    insert(&mut blocklace, &witness);
+
+    let known_tips: HashMap<NodeId, BlockIdentity> = [
+        (node(1), witness.identity.clone()),
+        (node(2), g2.identity.clone()),
+    ]
+    .into();
+
+    let missing_tip_candidate = create_mock_block(5, 5, HashSet::from([witness.identity.clone()]));
+
+    // The missing_tip_candidate block acknowledges the witness block, which is the known tip for node 1, but it does not acknowledge the known tip for node 2 (g2). Therefore, the missing_tip_candidate block should be considered as missing a known tip and should not be considered cordial. The missing_known_tips function should return the identity of g2 as a missing known tip for the missing_tip_candidate block.
+    assert!(missing_known_tips(&missing_tip_candidate, &known_tips).contains(&g2.identity));
+    // Since the missing_tip_candidate block is missing a known tip, it should not be considered cordial according to the definition of cordiality, which requires acknowledging all known tips and having no hidden equivocations. Therefore, the is_cordial_block function should return false for the missing_tip_candidate block when we pass in the blocklace and the known_tips.
+    assert!(!is_cordial_block(
+        &blocklace,
+        &missing_tip_candidate,
+        &known_tips
+    ));
+
+    let cordial = create_mock_block(
+        5,
+        6,
+        HashSet::from([witness.identity.clone(), g2.identity.clone()]),
+    );
+    // The cordial block acknowledges both known tips (witness and g2) and does not have any hidden equivocations, so it should be considered cordial according to the definition of cordiality. Therefore, the is_cordial_block function should return true for the cordial block when we pass in the blocklace and the known_tips.
+    assert!(is_cordial_block(&blocklace, &cordial, &known_tips));
+
+}

--- a/crates/cordial-miners-core/tests/test_cordiality.rs
+++ b/crates/cordial-miners-core/tests/test_cordiality.rs
@@ -50,3 +50,36 @@ fn insert(blocklace: &mut Blocklace, block: &Block) {
         .insert(block.clone(), &verifier)
         .expect("insert failed");
 }
+
+
+// Test that we can detect same-round equivocation by a creator. We create two blocks by the same creator at the same round and check that they are both detected as equivocations.
+#[test]
+fn detects_same_round_equivocation() {
+    let mut blocklace = Blocklace::new();
+    let e1 = create_mock_block(1, 1, HashSet::new());
+    let e2 = create_mock_block(1, 2, HashSet::new());
+
+    insert(&mut blocklace, &e1);
+    insert(&mut blocklace, &e2);
+
+    // this cause equivocation because both blocks are created by the same creator (node 1) and they are at the same round (round 0, since they have no predecessors). We check that both blocks are detected as equivocations by calling the equivocation_blocks_at_round function and verifying that it returns both blocks.
+    let equivocation = equivocation_blocks_at_round(&blocklace, &node(1), 0); 
+    assert_eq!(equivocation.len(), 2);
+    assert!(equivocation.contains(&e1));
+    assert!(equivocation.contains(&e2));
+}
+
+// Test that different rounds by the same creator do not count as equivocation. We create two blocks by the same creator at different rounds and check that they are not detected as equivocations.
+#[test]
+fn different_rounds_are_not_same_round_equivocations() {
+    let mut blocklace = Blocklace::new();
+
+    let g = create_mock_block(1, 1, HashSet::new());
+    insert(&mut blocklace, &g);
+    let child = create_mock_block(1, 2, HashSet::from([g.identity]));
+    insert(&mut blocklace, &child);
+
+    assert!(equivocation_blocks_at_round(&blocklace, &node(1), 0).is_empty());
+    assert!(equivocation_blocks_at_round(&blocklace, &node(1), 1).is_empty());
+
+}

--- a/crates/cordial-miners-core/tests/test_validation.rs
+++ b/crates/cordial-miners-core/tests/test_validation.rs
@@ -379,6 +379,38 @@ fn non_cordial_block_fails_strict_validation() {
     );
 }
 
+// Test that a block that hides a known equivocation fails strict validation. We create two equivocation blocks by the same creator and then create a candidate block that only acknowledges one of them. The candidate block should be considered as hiding the other equivocation block, and therefore should fail strict validation with an InvalidBlock::HiddenEquivocation error.
+#[test]
+fn block_hiding_known_equivocation_fails_strict_validation() {
+    let mut bl = Blocklace::new();
+    let v1 = node(1);
+    let v2 = node(2);
+    let v3 = node(3);
+
+    let e1 = genesis_unsigned(&v1, 1);
+    let e2 = genesis_unsigned(&v1, 2);
+    let g2 = genesis_unsigned(&v2, 3);
+    insert(&mut bl, &e1);
+    insert(&mut bl, &e2);
+    insert(&mut bl, &g2);
+
+    let hidden = child_unsigned(&v3, 4, &[&e1, &g2]);
+    let b = bonds(&[(1, 100), (2, 100), (3, 100)]);
+    let config = ValidationConfig {
+        check_cordial: true,
+        ..no_crypto_config()
+    };
+
+    let result = validate_block(&hidden, &bl, &b, &config);
+    assert!(!result.is_valid());
+    assert!(
+        result
+            .errors()
+            .iter()
+            .any(|e| matches!(e, InvalidBlock::HiddenEquivocation { .. }))
+    );
+}
+
 // ── validated_insert ──
 
 #[test]

--- a/docs/cordiality-implementation.md
+++ b/docs/cordiality-implementation.md
@@ -1,0 +1,156 @@
+# Cordiality Predicate Implementation
+
+This document describes the cordiality and equivocation predicates implemented in:
+
+- `crates/cordial-miners-core/src/consensus/cordiality.rs`
+- `crates/cordial-miners-core/src/consensus/validation.rs`
+
+The implementation is based on the Cordial Miners paper:
+
+- Idit Keidar, Oded Naor, Ouri Poupko, Ehud Shapiro, *Cordial Miners: Fast and Efficient Consensus for Every Eventuality*
+- arXiv:2205.09174v6
+- https://arxiv.org/abs/2205.09174
+
+## Scope
+
+This module provides the DAG-facing predicates that sit between:
+
+- structural helpers such as `round.rs` and `wave.rs`
+- the block validation layer in `validation.rs`
+
+It is intended to answer two questions:
+
+1. Has a validator equivocated in a round?
+2. Does a candidate block remain cordial, or does it hide a known equivocation?
+
+## Paper Alignment
+
+The paper separates three related ideas:
+
+- dissemination through the blocklace
+- equivocation exclusion
+- ordering
+
+Our current cordiality implementation belongs to the equivocation-exclusion side of the protocol.
+
+The code follows the paper's general direction:
+
+- blocks are reasoned about through the DAG they observe
+- equivocations matter semantically, not just syntactically
+- a block should not suppress relevant conflicting information already visible in the DAG
+
+The implementation is also shaped by a practical limitation:
+
+- validation does not know the creator's full private local view
+- validation only knows the candidate block and the local blocklace
+
+Because of that, the implementation uses a conservative interpretation of "known":
+
+- a known equivocation is one already present in the local blocklace
+- a candidate acknowledges it if the equivocation is visible through the closure of its predecessors
+
+This is slightly stronger and more operational than the paper's abstract local-knowledge model, but it is usable during block validation.
+
+## Implemented Predicates
+
+### 1. `creator_blocks_at_round`
+
+Returns all blocks by a specific creator at a specific depth/round.
+
+This uses the depth logic from `round.rs` to group the DAG by round.
+
+### 2. `equivocation_blocks_at_round`
+
+Returns the set of same-round blocks by one creator when there are at least two.
+
+This is the repository's explicit predicate for the user story:
+
+> A validator equivocates if they create two different blocks in the exact same round.
+
+### 3. `all_equivocations`
+
+Scans the current blocklace and reports all same-round equivocations as:
+
+- creator
+- round
+- conflicting block identities
+
+### 4. `observed_block_ids`
+
+Reconstructs the candidate block's visible DAG from its predecessor closure without inserting the block.
+
+This is the core "what does this block acknowledge?" helper.
+
+### 5. `acknowledges_equivocation`
+
+Checks whether a candidate block's predecessor closure includes every branch of a same-round equivocation.
+
+This is intentionally closure-based rather than predecessor-list-based. A block can acknowledge an equivocation indirectly through a predecessor that already carries both branches in its ancestry.
+
+### 6. `hidden_equivocations`
+
+Reports any locally known same-round equivocations that the candidate block fails to acknowledge.
+
+This is the implementation of "must not hide known equivocations" in local validation terms.
+
+### 7. `missing_known_tips`
+
+Returns validator tips omitted by a candidate block.
+
+This preserves the earlier cordiality check that a block should not omit the known tip frontier.
+
+### 8. `is_cordial_block`
+
+The current repo-level cordiality predicate is:
+
+- no missing known tips
+- no hidden known equivocations
+
+In other words, a block is cordial only when it preserves both the visible tip frontier and visible equivocation evidence.
+
+## Validation Integration
+
+`validation.rs` now reuses the predicates from `consensus/cordiality.rs` instead of embedding the logic directly.
+
+The strict cordiality path performs two checks:
+
+1. `NotCordial { missing_tips }`
+2. `HiddenEquivocation { creator, round, hidden }`
+
+This keeps `validation.rs` as an enforcement layer and `cordiality.rs` as the source of truth for the math.
+
+## Tests
+
+The behavior is covered by:
+
+- `crates/cordial-miners-core/tests/test_cordiality.rs`
+- `crates/cordial-miners-core/tests/test_validation.rs`
+
+Important test cases include:
+
+- detecting same-round equivocation
+- distinguishing same-round forks from same-creator blocks in different rounds
+- acknowledging equivocation through predecessor closure
+- rejecting blocks that hide a locally known equivocation
+- preserving the earlier missing-tip cordiality checks
+
+## Current Limitation
+
+This implementation does **not** reconstruct the creator's full private local view from the paper.
+
+That means:
+
+- if a creator knew about an equivocation but omitted all evidence of it from the block's predecessor closure, validation cannot prove that from the DAG alone
+- the current implementation therefore uses the local blocklace as the knowledge boundary
+
+This is a deliberate engineering choice for now. It gives us a deterministic, testable predicate that can run inside block validation.
+
+## Next Step
+
+The next paper-aligned step is to build the approval and ratification predicates on top of this layer:
+
+- `approves`
+- `ratifies`
+- `super-ratifies`
+
+Those will feed into leader finality and the eventual `tau` ordering function described later in the paper.


### PR DESCRIPTION
Closes issue #13 

## Summary

This PR adds a paper-aligned cordiality predicate layer for the Cordial Miners DAG and reuses it from block validation.

The new implementation introduces explicit helpers for:

- same-round equivocation detection
- reconstructing what a candidate block acknowledges through predecessor closure
- detecting hidden known equivocations
- checking cordiality as both:
  - no missing known tips
  - no hidden known equivocations

It also adds focused unit tests and a design note in `docs/`.

## What changed

### Consensus predicate layer

Added `crates/cordial-miners-core/src/consensus/cordiality.rs` with:

- `creator_blocks_at_round`
- `equivocation_blocks_at_round`
- `all_equivocations`
- `observed_block_ids`
- `acknowledges_equivocation`
- `hidden_equivocations`
- `missing_known_tips`
- `is_cordial_block`

These helpers are aligned with the paper’s equivocation-exclusion intent and provide a reusable source of truth for DAG-level cordiality math.

### Validation integration

Updated `crates/cordial-miners-core/src/consensus/validation.rs` to reuse the cordiality predicates.

Strict cordiality checks now reject:

- `InvalidBlock::NotCordial { missing_tips }`
- `InvalidBlock::HiddenEquivocation { creator, round, hidden }`

This keeps `validation.rs` as the enforcement layer while moving protocol math into `consensus/cordiality.rs`.

### Module exports

Updated `crates/cordial-miners-core/src/consensus/mod.rs` to export the new cordiality helpers.

### Documentation

Added:

- `docs/cordiality-implementation.md`

This documents the implemented predicates, the validation behavior, the paper references, and the current knowledge-boundary assumption used by validation.

## Test coverage

Added `crates/cordial-miners-core/tests/test_cordiality.rs` covering:

- same-round equivocation detection
- non-equivocation across different rounds
- acknowledging equivocation via predecessor closure
- detecting hidden known equivocations
- cordiality success/failure cases
- reporting all equivocations with creator and round

Extended `crates/cordial-miners-core/tests/test_validation.rs` with:

- strict validation failure when a block hides a known equivocation

## Verification

Ran:

```bash
cargo check -p cordial-miners-core
cargo test -p cordial-miners-core --test test_cordiality -- --nocapture
cargo test -p cordial-miners-core --test test_validation -- --nocapture
