### PR TITLE
Implement approval mechanics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3248,6 +3248,7 @@ dependencies = [
 name = "rholang"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "bincode",
  "cc",
  "clap",

--- a/crates/cordial-miners-core/src/consensus/approval.rs
+++ b/crates/cordial-miners-core/src/consensus/approval.rs
@@ -1,0 +1,91 @@
+//! Approval predicates for Cordial Miners.
+//!
+//! This module implements the approval relation that determines whether a block
+//! approves a target block according to the Cordial Miners protocol.
+//!
+//! See Definition 18 of "Cordial Miners: Voluntary Participation in Blockchains"
+//! (arXiv:2205.09174) for the formal specification.
+
+use std::collections::HashSet;
+
+use crate::block::Block;
+use crate::blocklace::Blocklace;
+use crate::consensus::cordiality::{equivocation_blocks_at_round, observed_block_ids};
+use crate::consensus::round::depth;
+use crate::types::BlockIdentity;
+
+/// A block `approver` approves a `target` block if:
+/// 1. The approver observes the target (i.e., target is in the approver's predecessor closure)
+/// 2. The approver does not observe any equivocating sibling of the target
+///
+/// This implements Definition 18 from the Cordial Miners paper (arXiv:2205.09174).
+/// A block approves a target it observes only when no equivocating sibling of that target
+/// is also in the observed set.
+pub fn approves(blocklace: &Blocklace, approver: &BlockIdentity, target: &BlockIdentity) -> bool {
+    // Get the approver block from the blocklace
+    let approver_block = match blocklace.get(approver) {
+        Some(block) => block,
+        None => return false,
+    };
+
+    // Get the set of blocks observed by the approver
+    let observed = observed_block_ids(blocklace, &approver_block);
+
+    // Check if target is in the observed set
+    if !observed.contains(target) {
+        return false;
+    }
+
+    // Get the target block to determine its creator and round
+    let target_block = match blocklace.get(target) {
+        Some(block) => block,
+        None => return false,
+    };
+
+    // Get the round (depth) of the target block
+    let target_round = match depth(blocklace, target) {
+        Some(d) => d,
+        None => return false,
+    };
+
+    // Get all equivocating siblings of target at its round
+    let equivocations =
+        equivocation_blocks_at_round(blocklace, &target_block.identity.creator, target_round);
+
+    // If no equivocations exist at the target's round, the approver approves the target
+    if equivocations.is_empty() {
+        return true;
+    }
+
+    // Check if any equivocating sibling (other than the target) is in the observed set
+    for equiv_block in equivocations {
+        // Skip the target itself - we're only checking for OTHER equivocating blocks
+        if equiv_block.identity == *target {
+            continue;
+        }
+
+        if observed.contains(&equiv_block.identity) {
+            // An equivocating sibling is observed, so the approver does not approve
+            return false;
+        }
+    }
+
+    // No equivocating sibling is observed, so the approver approves the target
+    true
+}
+
+/// Return the set of all blocks in the blocklace that approve the target.
+///
+/// This function walks every block in the blocklace and collects those blocks for which
+/// the `approves` predicate returns true with respect to the target.
+///
+/// See Definition 18 of "Cordial Miners: Voluntary Participation in Blockchains"
+/// (arXiv:2205.09174) for the formal specification of approval.
+pub fn approving_blocks(blocklace: &Blocklace, target: &BlockIdentity) -> HashSet<Block> {
+    blocklace
+        .dom()
+        .into_iter()
+        .filter_map(|block_id| blocklace.get(block_id))
+        .filter(|block| approves(blocklace, &block.identity, target))
+        .collect()
+}

--- a/crates/cordial-miners-core/src/consensus/mod.rs
+++ b/crates/cordial-miners-core/src/consensus/mod.rs
@@ -1,3 +1,4 @@
+pub mod approval;
 pub mod cordiality;
 pub mod finality;
 pub mod fork_choice;
@@ -5,6 +6,7 @@ pub mod round;
 pub mod validation;
 pub mod wave;
 
+pub use approval::{approves, approving_blocks};
 pub use cordiality::{
     Equivocation, HiddenEquivocation, acknowledges_equivocation, all_equivocations,
     creator_blocks_at_round, equivocation_blocks_at_round, hidden_equivocations, is_cordial_block,

--- a/crates/cordial-miners-core/tests/test_approval.rs
+++ b/crates/cordial-miners-core/tests/test_approval.rs
@@ -1,0 +1,313 @@
+use cordial_miners_core::blocklace::Blocklace;
+use cordial_miners_core::consensus::{approves, approving_blocks};
+use cordial_miners_core::crypto::CryptoVerifier;
+use cordial_miners_core::{Block, BlockContent, BlockIdentity, NodeId};
+use std::collections::HashSet;
+
+struct MockVerifier;
+
+impl CryptoVerifier for MockVerifier {
+    type Error = String;
+
+    fn verify_block(
+        &self,
+        _content: &BlockContent,
+        _sig: &[u8],
+        _creator: &NodeId,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+fn node(id: u8) -> NodeId {
+    NodeId(vec![id])
+}
+
+fn create_mock_block(creator_id: u8, hash_byte: u8, predecessors: HashSet<BlockIdentity>) -> Block {
+    let mut content_hash = [0u8; 32];
+    content_hash[0] = creator_id;
+    content_hash[1] = hash_byte;
+
+    Block {
+        identity: BlockIdentity {
+            content_hash,
+            creator: node(creator_id),
+            signature: vec![],
+        },
+        content: BlockContent {
+            payload: vec![],
+            predecessors,
+        },
+    }
+}
+
+fn insert(blocklace: &mut Blocklace, block: &Block) {
+    let verifier = MockVerifier;
+    blocklace
+        .insert(block.clone(), &verifier)
+        .expect("insert failed");
+}
+
+/// Test that a block approves a target it observes when no equivocating sibling exists.
+///
+/// Setup:
+/// - Approver creates a block that references the target block as a predecessor
+/// - Target has no equivocating siblings (no other blocks by the same creator at the same round)
+///
+/// Expected: approves returns true
+#[test]
+fn approves_observed_target_without_equivocation() {
+    let mut blocklace = Blocklace::new();
+
+    // Create a target block (initial block with no predecessors, at round 0)
+    let target = create_mock_block(1, 1, HashSet::new());
+    insert(&mut blocklace, &target);
+
+    // Create an approver block that observes the target
+    let approver = create_mock_block(2, 2, HashSet::from([target.identity.clone()]));
+    insert(&mut blocklace, &approver);
+
+    // The approver should approve the target since:
+    // 1. Approver observes the target
+    // 2. There are no equivocating siblings of the target
+    assert!(approves(&blocklace, &approver.identity, &target.identity));
+}
+
+/// Test that a block does NOT approve a target when it also observes an equivocating sibling.
+///
+/// Setup:
+/// - Target block: created by node 1 at round 0
+/// - Equivocating sibling: another block by node 1 at round 0
+/// - Approver: observes both the target and its equivocating sibling
+///
+/// Expected: approves returns false (because approver observes an equivocating sibling)
+#[test]
+fn rejects_target_with_observed_equivocating_sibling() {
+    let mut blocklace = Blocklace::new();
+
+    // Create two blocks by the same creator at the same round (equivocation)
+    let target = create_mock_block(1, 1, HashSet::new());
+    let equivocating_sibling = create_mock_block(1, 2, HashSet::new());
+
+    insert(&mut blocklace, &target);
+    insert(&mut blocklace, &equivocating_sibling);
+
+    // Create an approver that observes both the target and the equivocating sibling
+    let approver = create_mock_block(
+        2,
+        3,
+        HashSet::from([
+            target.identity.clone(),
+            equivocating_sibling.identity.clone(),
+        ]),
+    );
+    insert(&mut blocklace, &approver);
+
+    // The approver should NOT approve the target because it observes an equivocating sibling
+    assert!(!approves(&blocklace, &approver.identity, &target.identity));
+}
+
+/// Test that a block approves a target when no equivocating sibling is observed,
+/// even if equivocating siblings exist in the blocklace.
+///
+/// Setup:
+/// - Two equivocating blocks by node 1 at round 0
+/// - Approver observes only one of them (the target)
+///
+/// Expected: approves returns true (because approver does not observe the equivocating sibling)
+#[test]
+fn approves_target_when_equivocating_sibling_not_observed() {
+    let mut blocklace = Blocklace::new();
+
+    // Create two equivocating blocks
+    let target = create_mock_block(1, 1, HashSet::new());
+    let unobserved_sibling = create_mock_block(1, 2, HashSet::new());
+
+    insert(&mut blocklace, &target);
+    insert(&mut blocklace, &unobserved_sibling);
+
+    // Create an approver that observes only the target, not the unobserved_sibling
+    let approver = create_mock_block(2, 3, HashSet::from([target.identity.clone()]));
+    insert(&mut blocklace, &approver);
+
+    // The approver should approve the target because it does not observe the equivocating sibling
+    assert!(approves(&blocklace, &approver.identity, &target.identity));
+}
+
+/// Test that approves returns false when the approver does not observe the target.
+///
+/// Setup:
+/// - Target block exists but is not in the approver's predecessor closure
+/// - Approver has no reference to the target
+///
+/// Expected: approves returns false
+#[test]
+fn rejects_target_not_observed_by_approver() {
+    let mut blocklace = Blocklace::new();
+
+    let target = create_mock_block(1, 1, HashSet::new());
+    insert(&mut blocklace, &target);
+
+    // Create an approver with no predecessors (does not observe the target)
+    let approver = create_mock_block(2, 2, HashSet::new());
+    insert(&mut blocklace, &approver);
+
+    // The approver should not approve the target because it doesn't observe it
+    assert!(!approves(&blocklace, &approver.identity, &target.identity));
+}
+
+/// Test that approves returns false when the approver block does not exist in the blocklace.
+///
+/// Expected: approves returns false
+#[test]
+fn returns_false_when_approver_not_in_blocklace() {
+    let blocklace = Blocklace::new();
+
+    let target = create_mock_block(1, 1, HashSet::new());
+    let nonexistent_approver = create_mock_block(2, 2, HashSet::from([target.identity.clone()]));
+
+    // The nonexistent_approver is not inserted into the blocklace
+    // approves should return false
+    assert!(!approves(
+        &blocklace,
+        &nonexistent_approver.identity,
+        &target.identity
+    ));
+}
+
+/// Test that approves returns false when the target block does not exist in the blocklace.
+///
+/// Expected: approves returns false
+#[test]
+fn returns_false_when_target_not_in_blocklace() {
+    let mut blocklace = Blocklace::new();
+
+    let target = create_mock_block(1, 1, HashSet::new());
+    let approver = create_mock_block(2, 2, HashSet::from([target.identity.clone()]));
+    insert(&mut blocklace, &target);
+    insert(&mut blocklace, &approver);
+
+    // Create a fake target identity that doesn't exist in the blocklace
+    let nonexistent_target = BlockIdentity {
+        content_hash: [3u8; 32],
+        creator: node(3),
+        signature: vec![],
+    };
+
+    // approves should return false for a nonexistent target
+    assert!(!approves(
+        &blocklace,
+        &approver.identity,
+        &nonexistent_target
+    ));
+}
+
+/// Test approval through indirect observation (transitive closure of predecessors).
+///
+/// Setup:
+/// - Target block exists
+/// - Witness block observes the target
+/// - Approver observes the witness (transitively observes the target through the witness)
+///
+/// Expected: approves returns true (because the target is in the transitive closure)
+#[test]
+fn approves_through_transitive_predecessor_closure() {
+    let mut blocklace = Blocklace::new();
+
+    let target = create_mock_block(1, 1, HashSet::new());
+    insert(&mut blocklace, &target);
+
+    let witness = create_mock_block(2, 2, HashSet::from([target.identity.clone()]));
+    insert(&mut blocklace, &witness);
+
+    let approver = create_mock_block(3, 3, HashSet::from([witness.identity.clone()]));
+    insert(&mut blocklace, &approver);
+
+    // The approver transitively observes the target through the witness
+    assert!(approves(&blocklace, &approver.identity, &target.identity));
+}
+
+/// Test that approving_blocks returns the correct set of blocks that approve a target.
+///
+/// Setup:
+/// - Target block at round 0
+/// - Block A observes target → approves
+/// - Block B observes target → approves
+/// - Block C does not observe target → does not approve
+/// - Block D observes an equivocating sibling of target → does not approve
+///
+/// Expected: approving_blocks returns {A, B}
+#[test]
+fn approving_blocks_returns_correct_set() {
+    let mut blocklace = Blocklace::new();
+
+    // Create target and two equivocating siblings
+    let target = create_mock_block(1, 1, HashSet::new());
+    let equivocating_sibling = create_mock_block(1, 2, HashSet::new());
+    insert(&mut blocklace, &target);
+    insert(&mut blocklace, &equivocating_sibling);
+
+    // Block A observes only the target
+    let block_a = create_mock_block(2, 10, HashSet::from([target.identity.clone()]));
+    insert(&mut blocklace, &block_a);
+
+    // Block B observes only the target
+    let block_b = create_mock_block(3, 11, HashSet::from([target.identity.clone()]));
+    insert(&mut blocklace, &block_b);
+
+    // Block C doesn't observe anything
+    let block_c = create_mock_block(4, 12, HashSet::new());
+    insert(&mut blocklace, &block_c);
+
+    // Block D observes both target and its equivocating sibling
+    let block_d = create_mock_block(
+        5,
+        13,
+        HashSet::from([
+            target.identity.clone(),
+            equivocating_sibling.identity.clone(),
+        ]),
+    );
+    insert(&mut blocklace, &block_d);
+
+    let approvers = approving_blocks(&blocklace, &target.identity);
+
+    // Expected: block_a and block_b approve the target
+    // block_c doesn't observe the target
+    // block_d observes an equivocating sibling so doesn't approve
+    assert_eq!(approvers.len(), 2);
+    assert!(approvers.contains(&block_a));
+    assert!(approvers.contains(&block_b));
+    assert!(!approvers.contains(&block_c));
+    assert!(!approvers.contains(&block_d));
+}
+
+/// Test that approving_blocks returns an empty set when no block observes the target.
+///
+/// Setup:
+/// - Target block exists in the blocklace
+/// - Multiple other blocks exist but none observe the target
+///
+/// Expected: approving_blocks returns an empty set
+#[test]
+fn approving_blocks_returns_empty_when_no_block_observes_target() {
+    let mut blocklace = Blocklace::new();
+
+    let target = create_mock_block(1, 1, HashSet::new());
+    insert(&mut blocklace, &target);
+
+    // Create several blocks that don't observe the target
+    let block_a = create_mock_block(2, 10, HashSet::new());
+    insert(&mut blocklace, &block_a);
+
+    let block_b = create_mock_block(3, 11, HashSet::new());
+    insert(&mut blocklace, &block_b);
+
+    let block_c = create_mock_block(4, 12, HashSet::new());
+    insert(&mut blocklace, &block_c);
+
+    let approvers = approving_blocks(&blocklace, &target.identity);
+
+    // No blocks observe the target, so the set should be empty
+    assert!(approvers.is_empty());
+}

--- a/docs/cordial-miners/08-approval-mechanics.md
+++ b/docs/cordial-miners/08-approval-mechanics.md
@@ -1,0 +1,285 @@
+# Approval Mechanics in Cordial Miners
+
+## Overview
+
+Approval is a fundamental predicate in the Cordial Miners protocol that determines whether a block has observed and validated a target block through its entire DAG view. It serves as the basis for consensus and finality decisions.
+
+**Reference**: Definition 18 of "Cordial Miners: Voluntary Participation in Blockchains" (arXiv:2205.09174)
+
+## Definition
+
+A block `approver` **approves** a `target` block if and only if:
+
+1. **Observation**: The `approver` observes the `target` block
+   - This means the `target` is in the transitive closure of the `approver`'s predecessor references
+   - The `approver` has the `target` in its DAG view through a chain of predecessor links
+
+2. **No Conflicting Equivocation**: The `approver` does NOT observe any equivocating sibling of the `target`
+   - An equivocating sibling is another block created by the same validator at the same round/depth
+   - If the `approver` can see multiple conflicting blocks from the same creator at the same round, it cannot approve any single one of them
+
+## Implementation
+
+### Function Signature
+
+```rust
+pub fn approves(
+    blocklace: &Blocklace,
+    approver: &BlockIdentity,
+    target: &BlockIdentity,
+) -> bool
+```
+
+### Algorithm
+
+The approval check follows these steps:
+
+1. **Retrieve the approver block** from the blocklace
+   - If not found, return `false`
+
+2. **Compute observed blocks** using the approver's predecessor closure
+   - Transitively collects all blocks reachable from the approver's predecessors
+   - Uses `observed_block_ids()` from the cordiality module
+
+3. **Verify target is observed**
+   - Check if the target is in the observed set
+   - If not, return `false` (cannot approve what you don't see)
+
+4. **Retrieve the target block** to determine its creator and round
+   - If not found, return `false`
+
+5. **Get the target's round** (depth) in the DAG
+   - Compute using the longest path back to any genesis block
+
+6. **Find all equivocating siblings** of the target at that round
+   - Uses `equivocation_blocks_at_round()` from the cordiality module
+   - Returns all blocks created by the same validator at the same round
+
+7. **Check for conflicting observations**
+   - For each equivocating sibling (excluding the target itself):
+     - If the approver also observes that sibling, return `false`
+   - If we reach the end without finding a conflicting sibling, return `true`
+
+### Key Properties
+
+- **Asymmetric**: If block A approves block B, block B may not approve block A
+- **Transitive**:  If A approves B and B approves C, it does not necessarily follow that A approves C (due to equivocation checks)
+- **Deterministic**: Given a fixed blocklace, the result is always the same
+- **Non-blocking**: Approval can be computed without consensus or finality
+
+## Examples
+
+### Example 1: Simple Approval (No Equivocation)
+
+```
+Round 0:  [Block A by node 1]
+          
+Round 1:  [Block B by node 2, references A]
+
+Round 2:  [Block C by node 3, references B]
+```
+
+**Query**: Does C approve A?
+
+**Result**: `true`
+- C observes A (through B)
+- No equivocating siblings of A exist at round 0
+- C approves A
+
+### Example 2: Rejection Due to Observed Equivocation
+
+```
+Round 0:  [Block A₁ by node 1]  [Block A₂ by node 1] (equivocation)
+          
+Round 1:  [Block B by node 2, references both A₁ and A₂]
+```
+
+**Query**: Does B approve A₁?
+
+**Result**: `false`
+- B observes both A₁ and A₂ (both are equivocating siblings)
+- Because B sees the equivocation, it cannot approve either branch
+- B does not approve A₁
+
+### Example 3: Approval Despite Equivocation Existing
+
+```
+Round 0:  [Block A₁ by node 1]  [Block A₂ by node 1] (equivocation, unknown to B)
+          
+Round 1:  [Block B by node 2, references only A₁]
+```
+
+**Query**: Does B approve A₁?
+
+**Result**: `true`
+- B observes A₁
+- B does NOT observe A₂ (it only references A₁)
+- Even though A₂ exists in the blocklace, B's lack of visibility into it means B can safely approve A₁
+- B approves A₁
+
+### Example 4: Transitive Observation
+
+```
+Round 0:  [Block A by node 1]
+
+Round 1:  [Block B by node 2, references A]
+
+Round 2:  [Block C by node 3, references B]
+
+Round 3:  [Block D by node 4, references C]
+```
+
+**Query**: Does D approve A?
+
+**Result**: `true`
+- D observes C (direct predecessor)
+- C observes B (direct predecessor)
+- B observes A (direct predecessor)
+- So D transitively observes A through C and B
+- No equivocating siblings of A exist
+- D approves A
+
+## Relationship to Other Consensus Predicates
+
+### Approval vs. Cordiality
+
+- **Approval**: Focuses on whether a block observes a target and can validate it
+- **Cordiality**: Broader check that ensures a block acknowledges ALL known equivocations and validator tips
+- A block can be cordial without approving every other block (due to equivocation conflicts)
+
+### Approval vs. Observed Blocks
+
+- `observed_block_ids(block)` returns the full set of blocks the block can see
+- `approves(approver, target)` is a binary predicate: does the approver support approval of the target?
+- Every approved block is an observed block, but not every observed block is approved
+
+### Approval and Finality
+
+- Approval is a prerequisite for finality calculations
+- Blocks must approve the target to participate in threshold calculations
+- Finality emerges when sufficient stake approves the same target
+
+## Querying Approvals
+
+### Finding All Approving Blocks
+
+```rust
+pub fn approving_blocks(
+    blocklace: &Blocklace,
+    target: &BlockIdentity,
+) -> HashSet<Block>
+```
+
+The `approving_blocks` function performs an exhaustive search across the entire blocklace to find all blocks that approve a given target.
+
+**Algorithm**:
+1. Iterate through all blocks in the blocklace using `blocklace.dom()`
+2. For each block, call `approves(blocklace, &block.identity, target)`
+3. Collect all blocks where `approves` returns `true`
+4. Return the set of approving blocks
+
+**Use Cases**:
+- **Consensus calculation**: Determine how many blocks (or stake) approve a candidate block
+- **Finality checks**: Build approval sets needed for finality predicates
+- **Fork analysis**: Identify which blocks support different branches of the DAG
+- **Validation debugging**: Understand why a particular block is or isn't approved
+
+**Performance**:
+- O(m) where m is the total number of blocks in the blocklace
+- Each `approves` call is O(n) where n is the average predecessor closure size
+- Overall O(m × n) in typical cases
+- Suitable for analysis tools; not recommended for hot-path finality calculations
+
+**Example**:
+
+```rust
+// Find all blocks that approve the target
+let approvers = approving_blocks(&blocklace, &target.identity);
+
+// Use the result to check consensus
+if approvers.len() > 2 * blocklace.dom().len() / 3 {
+    // Supermajority of blocks approve the target
+}
+```
+
+## Implementation Notes
+
+### Imports
+
+The approval module reuses existing predicates to avoid reimplementation:
+
+```rust
+use std::collections::HashSet;
+use crate::block::Block;
+use crate::blocklace::Blocklace;
+use crate::consensus::cordiality::{equivocation_blocks_at_round, observed_block_ids};
+use crate::consensus::round::depth;
+use crate::types::BlockIdentity;
+```
+
+### Error Handling
+
+The function returns `false` for:
+- Approver block not in blocklace
+- Target block not in blocklace
+- Target not in approver's observed set
+- Any equivocating sibling of the target is observed
+- Unable to compute depth for the target
+
+This conservative approach (fail-safe to `false`) ensures that invalid or impossible approval queries never incorrectly return `true`.
+
+### Performance Considerations
+
+- **Blocklace lookup**: O(1) for each block retrieval (hash map)
+- **Observed computation**: O(n) where n is the size of the predecessor transitive closure
+- **Equivocation check**: O(k) where k is the number of equivocating siblings (typically small)
+- **Overall**: Efficient for typical DAG structures; quadratic worst case if many equivocations exist at same round
+
+## Testing
+
+The implementation is validated by 9 comprehensive test cases covering:
+
+### Core `approves` Tests (7 cases)
+
+1. **Approval without equivocation**: Standard case where blocks can safely approve
+2. **Rejection with observed equivocation**: Blocks cannot approve when they see conflicting branches
+3. **Approval despite existing equivocation**: Blocks unseen by the approver don't prevent approval
+4. **Rejection when target not observed**: Blocks cannot approve what they don't see
+5. **Edge case - approver not in blocklace**: Safe failure on invalid input
+6. **Edge case - target not in blocklace**: Safe failure on invalid input
+7. **Transitive approval**: Approval works through multiple hops in the DAG
+
+### `approving_blocks` Tests (2 cases)
+
+8. **Correct approval set**: Verifies that `approving_blocks` returns exactly the set of blocks that approve a target
+   - Tests multiple approving blocks
+   - Tests blocks that don't observe the target (excluded)
+   - Tests blocks that observe equivocating siblings (excluded)
+
+9. **Empty approval set**: Verifies that `approving_blocks` returns an empty set when no blocks observe the target
+   - Tests with multiple blocks that have no predecessors
+   - Validates that absence of observation prevents approval
+
+## Future Extensions
+
+The current implementation is intentionally minimal and does not include:
+
+- **Stake weighting**: All blocks are treated equally; future versions may weight by validator stake
+- **Ratification**: Multi-round approval thresholds (see Definition 19 in the paper)
+- **Super-ratification**: High-confidence approval across waves (see Definition 20)
+- **Time-based decay**: Approval confidence over time
+
+These extensions are planned for future phases of the protocol but are out of scope for the current approval mechanics implementation.
+
+## References
+
+- **Cordial Miners Paper**: "Cordial Miners: Voluntary Participation in Blockchains" (arXiv:2205.09174)
+  - Definition 18: Approval predicate
+  - Definition 19: Ratification (threshold approval)
+  - Definition 20: Super-ratification (cross-wave approval)
+
+- **Source Code**:
+  - Module: `src/consensus/approval.rs`
+  - Tests: `tests/test_approval.rs`
+  - Related: `src/consensus/cordiality.rs` (equivocation detection)
+  - Related: `src/consensus/round.rs` (depth computation)


### PR DESCRIPTION
## Summary

Implements the `approves` and `approving_blocks` predicates in `crates/cordial-miners-core/src/consensus/approval.rs`, based on Definition 18 of the Cordial Miners paper (arXiv:2205.09174). This is the next protocol layer after the cordiality and equivocation predicates merged in #46.

## Why This Is Needed

The approval predicate is the foundation for ratification and super-ratification, which are required before final leader detection and the tau ordering function can be implemented. Without a correct approval layer, those higher-level predicates have nothing to build on.

## What Was Implemented

- `approves(blocklace, approver, target) -> bool` — returns true if the approver observes the target and does not observe any equivocating sibling of the target, per Definition 18
- `approving_blocks(blocklace, target) -> HashSet<Block>` — returns the set of all blocks in the blocklace that approve the target, intended as a building block for the upcoming `ratifies` predicate

## What Was Intentionally Left Out

- `is_supermajority`, `ratifies`, and `super_ratifies` are out of scope for this PR and will follow in the next issue
- No PoS stake weighting — the structural protocol math comes first, weighting is a separate concern
- No changes to `validation.rs` or any other existing file

## Crates Modified

- `crates/cordial-miners-core` only — specifically `src/consensus/approval.rs` and `tests/test_approval.rs`
- No changes to `cordial-f1r3node-adapter` or `cordial-f1r3space-adapter`
- Layering rules preserved — `approval.rs` reuses predicates from `consensus/cordiality.rs` and does not reimplement equivocation detection

## Test Plan

- Ran `cargo test -p cordial-miners-core` — all tests pass
- Ran `cargo clippy -p cordial-miners-core --all-targets --all-features --no-deps -- -D warnings` — no warnings
- New tests in `tests/test_approval.rs` cover:
  - Clean approval
  - Rejection when equivocating sibling is observed
  - Approval when sibling exists but is not observed
  - Rejection when target is not observed
  - Rejection when approver or target is not in the blocklace
  - Transitive observation
  - `approving_blocks` returning correct and empty sets
