### PR TITLE
feat: Implement CryptoVerifier for F1r3flyCryptoAdapter (Ed25519 + Secp256k1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,6 +429,7 @@ dependencies = [
  "hex",
  "imbl",
  "lz4_flex",
+ "metrics",
  "models",
  "once_cell",
  "proptest",
@@ -488,7 +489,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "lz4_flex",
- "metrics 0.23.1",
+ "metrics",
  "models",
  "num_cpus",
  "proptest",
@@ -622,7 +623,7 @@ dependencies = [
  "hyper 1.9.0",
  "igd-next",
  "local-ip-address",
- "metrics 0.23.1",
+ "metrics",
  "models",
  "p256",
  "paste",
@@ -648,6 +649,18 @@ dependencies = [
  "url",
  "webpki",
  "x509-parser",
+]
+
+[[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1123,6 +1136,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -2259,16 +2278,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "metrics"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
-dependencies = [
- "ahash",
- "portable-atomic",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3249,10 +3258,12 @@ dependencies = [
 name = "rholang"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "bincode",
  "cc",
  "clap",
+ "console",
  "crypto",
  "dotenv",
  "futures",
@@ -3261,7 +3272,7 @@ dependencies = [
  "itertools",
  "k256",
  "lazy_static",
- "metrics 0.24.3",
+ "metrics",
  "models",
  "num-bigint",
  "num-integer",
@@ -3362,7 +3373,7 @@ dependencies = [
  "hex",
  "itertools",
  "lazy_static",
- "metrics 0.23.1",
+ "metrics",
  "monadic",
  "multiset",
  "once_cell",
@@ -3729,7 +3740,7 @@ dependencies = [
  "http-body-util",
  "indexmap",
  "lz4_flex",
- "metrics 0.24.3",
+ "metrics",
  "proptest",
  "prost",
  "rand 0.9.4",
@@ -3837,7 +3848,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -4444,6 +4454,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"

--- a/crates/cordial-f1r3node-adapter/src/crypto_impl.rs
+++ b/crates/cordial-f1r3node-adapter/src/crypto_impl.rs
@@ -1,0 +1,129 @@
+// This CryptoImpl's is teaching the adapter HOW to check if a block's signature for encryption is real.
+
+// The core (cordial-miners-core) already defined the RULE: so in here We must be able to verify a block signature.
+// That rule that mentioned in cordial-miners-core is the CryptoVerifier trait.
+
+// This file FOLLOWS that rule using F1R3FLY's actual crypto tools.
+
+
+// We need to bring tools from core crate (project) like importing
+use cordial_miners_core::crypto::CryptoVerifier; // The trait that defines the rule for verifying signatures
+
+use cordial_miners_core::crypto::{
+    hash_content,     // turns block content into a 32-byte fingerprint
+    Ed25519Scheme,    // Algorithm checker for Ed25519 signatures
+    Secp256k1Scheme,  // Algorithm checker for Secp256k1 signatures
+    SignatureScheme,  // A  shared interface both checkers follow
+};
+
+use cordial_miners_core::types::{BlockContent, NodeId}; // The data types we need to work with
+
+//-------------------------------------------------------------------
+// An enum to remember which Algorithm to use
+//--------------------------------------------------------------------
+// Using enum is like choosing a between provided Algorithms; we store this inside our adapter so it knows which checker to call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CryptoAlgorithm {
+    Ed25519,
+    Secp256k1,  // the defualt algotihm for F1R3FLY node 
+}
+
+
+//-------------------------------------------------------------------
+// The Adapter Struct
+//-------------------------------------------------------------------
+// This struct (a box in rust)will implement the CryptoVerifier trait, and it will use the chosen algorithm to verify signatures.
+#[derive(Debug)]
+pub struct F1r3flyCryptoAdapter {
+    algorithm: CryptoAlgorithm, // which algorithm to use for verification choosen from the enum above
+}
+
+// This implementation in here are the functions that belong to F1r3flyCryptoAdapter struct".
+impl F1r3flyCryptoAdapter {
+    // Constructor 1: make the adapter that use Secp256k1 by default
+    pub fn secp256k1() -> Self {
+        Self { algorithm: CryptoAlgorithm::Secp256k1 }
+    }
+    // Constructor 2: make the adapter that use Ed25519
+    pub fn ed25519() -> Self {
+        Self { algorithm: CryptoAlgorithm::Ed25519 }
+    }
+    // Constructor 3: Create adapter from algorithm string ("secp256k1", "ed25519") which is sent by network.
+    // Returns Ok(adapter) or Err if the algorithm is unknown.
+    pub fn from_algorithm_str(s: &str) -> Result<Self, String> {
+        // .to_lowercase() makes the input case-insensitive because of diffrent forms of writing.
+        match s.to_lowercase().as_str() {
+            // empty string is treated as secp256k1 by default, matching f1r3node's behavior.
+            ""          => Ok(Self::secp256k1()),
+            "secp256k1" => Ok(Self::secp256k1()),
+            "ed25519"   => Ok(Self::ed25519()),
+            // anything else is an error
+            other       => Err(format!("Unknown algorithm: '{}' — expected 'secp256k1' or 'ed25519'", other)),
+        }
+    }
+    // A simple getter so tests can check which algorithm the adapter is using.
+    pub fn algorithm(&self) -> CryptoAlgorithm {
+        self.algorithm
+    }
+}
+
+
+//--------------------------------------------------------------------
+// The Actual Verification Logic
+//--------------------------------------------------------------------
+// This is where we implement the CryptoVerifier trait for our adapter, which means 
+// we have to write the code that checks if a block's signature is valid according to the chosen algorithm.
+// The compiler will error if we don't provide verify_block — it's required.
+impl CryptoVerifier for F1r3flyCryptoAdapter {
+    // The type of error when verification fails. We use String for Human Readable,
+    // more structured error handling could be added later if needed.
+    type Error = String;
+
+    // Verify block is function blocklace calls on every new block.
+    // Parameters: content (block data), signature (proof byte), creator (public key).
+    // Returns: Ok(()) if valid, Err(msg) if invalid.
+    fn verify_block(
+        &self,
+        content: &BlockContent,
+        signature: &[u8],
+        creator: &NodeId,
+    ) -> Result<(), Self::Error> {
+        // First: recompute the block hash from content with Blake2b-256.
+        // The creator signed that hash, so we verify the signature against it.
+        // Since we don’t trust any stored hash in the block; recomputing prevents tampering.
+
+        let hash: [u8; 32] = hash_content(content); // Get the 32-byte hash of the block content.
+
+        // Make sure to reject empty signatures right away, as they are invalid.
+        if signature.is_empty() {
+            return Err("Signature is empty".to_string());
+        }
+
+        // Verify the signature with the chosen algorithm.
+        // `creator.0` unwraps NodeId to raw public-key bytes.
+        // Call the selected scheme’s (algorithms) `verify()` functions and use its result for further processing.
+        let is_valid = match self.algorithm {
+            CryptoAlgorithm::Secp256k1 => {
+                // Verifies a Secp256k1 ECDSA signature over the hash using the public key.
+                Secp256k1Scheme.verify(&hash, &creator.0, signature)
+            }
+            CryptoAlgorithm::Ed25519 =>{
+                // Verifies an Ed25519 EdDSA signature over the hash using the public key.
+                Ed25519Scheme.verify(&hash, &creator.0, signature)
+            }
+            
+        };
+        // Return Ok if valid in the above is true, Err with message if is_valid is false.
+        if is_valid {
+            Ok(())
+        } else {
+            Err(format!(
+                "Block signature verification failed (public_key={:?}, algorithm={:?})",
+                creator.0,
+                self.algorithm
+            ))
+        }
+
+    }
+}
+    

--- a/crates/cordial-f1r3node-adapter/src/crypto_impl.rs
+++ b/crates/cordial-f1r3node-adapter/src/crypto_impl.rs
@@ -5,15 +5,14 @@
 
 // This file FOLLOWS that rule using F1R3FLY's actual crypto tools.
 
-
 // We need to bring tools from core crate (project) like importing
 use cordial_miners_core::crypto::CryptoVerifier; // The trait that defines the rule for verifying signatures
 
 use cordial_miners_core::crypto::{
-    hash_content,     // turns block content into a 32-byte fingerprint
-    Ed25519Scheme,    // Algorithm checker for Ed25519 signatures
-    Secp256k1Scheme,  // Algorithm checker for Secp256k1 signatures
-    SignatureScheme,  // A  shared interface both checkers follow
+    Ed25519Scheme,   // Algorithm checker for Ed25519 signatures
+    Secp256k1Scheme, // Algorithm checker for Secp256k1 signatures
+    SignatureScheme, // A  shared interface both checkers follow
+    hash_content,    // turns block content into a 32-byte fingerprint
 };
 
 use cordial_miners_core::types::{BlockContent, NodeId}; // The data types we need to work with
@@ -25,9 +24,8 @@ use cordial_miners_core::types::{BlockContent, NodeId}; // The data types we nee
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CryptoAlgorithm {
     Ed25519,
-    Secp256k1,  // the defualt algotihm for F1R3FLY node 
+    Secp256k1, // the defualt algotihm for F1R3FLY node
 }
-
 
 //-------------------------------------------------------------------
 // The Adapter Struct
@@ -42,11 +40,15 @@ pub struct F1r3flyCryptoAdapter {
 impl F1r3flyCryptoAdapter {
     // Constructor 1: make the adapter that use Secp256k1 by default
     pub fn secp256k1() -> Self {
-        Self { algorithm: CryptoAlgorithm::Secp256k1 }
+        Self {
+            algorithm: CryptoAlgorithm::Secp256k1,
+        }
     }
     // Constructor 2: make the adapter that use Ed25519
     pub fn ed25519() -> Self {
-        Self { algorithm: CryptoAlgorithm::Ed25519 }
+        Self {
+            algorithm: CryptoAlgorithm::Ed25519,
+        }
     }
     // Constructor 3: Create adapter from algorithm string ("secp256k1", "ed25519") which is sent by network.
     // Returns Ok(adapter) or Err if the algorithm is unknown.
@@ -54,11 +56,14 @@ impl F1r3flyCryptoAdapter {
         // .to_lowercase() makes the input case-insensitive because of diffrent forms of writing.
         match s.to_lowercase().as_str() {
             // empty string is treated as secp256k1 by default, matching f1r3node's behavior.
-            ""          => Ok(Self::secp256k1()),
+            "" => Ok(Self::secp256k1()),
             "secp256k1" => Ok(Self::secp256k1()),
-            "ed25519"   => Ok(Self::ed25519()),
+            "ed25519" => Ok(Self::ed25519()),
             // anything else is an error
-            other       => Err(format!("Unknown algorithm: '{}' — expected 'secp256k1' or 'ed25519'", other)),
+            other => Err(format!(
+                "Unknown algorithm: '{}' — expected 'secp256k1' or 'ed25519'",
+                other
+            )),
         }
     }
     // A simple getter so tests can check which algorithm the adapter is using.
@@ -67,11 +72,10 @@ impl F1r3flyCryptoAdapter {
     }
 }
 
-
 //--------------------------------------------------------------------
 // The Actual Verification Logic
 //--------------------------------------------------------------------
-// This is where we implement the CryptoVerifier trait for our adapter, which means 
+// This is where we implement the CryptoVerifier trait for our adapter, which means
 // we have to write the code that checks if a block's signature is valid according to the chosen algorithm.
 // The compiler will error if we don't provide verify_block — it's required.
 impl CryptoVerifier for F1r3flyCryptoAdapter {
@@ -107,11 +111,10 @@ impl CryptoVerifier for F1r3flyCryptoAdapter {
                 // Verifies a Secp256k1 ECDSA signature over the hash using the public key.
                 Secp256k1Scheme.verify(&hash, &creator.0, signature)
             }
-            CryptoAlgorithm::Ed25519 =>{
+            CryptoAlgorithm::Ed25519 => {
                 // Verifies an Ed25519 EdDSA signature over the hash using the public key.
                 Ed25519Scheme.verify(&hash, &creator.0, signature)
             }
-            
         };
         // Return Ok if valid in the above is true, Err with message if is_valid is false.
         if is_valid {
@@ -119,11 +122,8 @@ impl CryptoVerifier for F1r3flyCryptoAdapter {
         } else {
             Err(format!(
                 "Block signature verification failed (public_key={:?}, algorithm={:?})",
-                creator.0,
-                self.algorithm
+                creator.0, self.algorithm
             ))
         }
-
     }
 }
-    

--- a/crates/cordial-f1r3node-adapter/src/lib.rs
+++ b/crates/cordial-f1r3node-adapter/src/lib.rs
@@ -22,6 +22,7 @@
 pub mod block_translation;
 pub mod casper_adapter;
 pub mod crypto_bridge;
+pub mod crypto_impl;
 pub mod grpc_ingest;
 pub mod proposer;
 pub mod repository;

--- a/crates/cordial-f1r3node-adapter/tests/test_crypto_adapter.rs
+++ b/crates/cordial-f1r3node-adapter/tests/test_crypto_adapter.rs
@@ -9,7 +9,7 @@ use cordial_f1r3node_adapter::crypto_impl::{CryptoAlgorithm, F1r3flyCryptoAdapte
 
 // Import the tools we need to create test data
 use cordial_miners_core::{
-    crypto::{hash_content,sign, CryptoVerifier},
+    crypto::{CryptoVerifier, hash_content, sign},
     types::{BlockContent, NodeId},
 };
 
@@ -21,7 +21,6 @@ fn make_content(payload: &[u8]) -> BlockContent {
     BlockContent {
         payload: payload.to_vec(), // the data we want to put in the block changed to vec of bytes
         predecessors: HashSet::new(), // no parent blocks for simplicity (for testing)
-        
     }
 }
 
@@ -29,7 +28,7 @@ fn make_content(payload: &[u8]) -> BlockContent {
 // Private key = 32 bytes (the secret, used to sign)
 // Public key  = 33 bytes compressed (the shareable one, used to verify
 
-fn secp256k1_keypair() -> (Vec<u8>, Vec<u8>){
+fn secp256k1_keypair() -> (Vec<u8>, Vec<u8>) {
     use k256::ecdsa::SigningKey;
 
     // Generate a random signing key (private key) using OS randomness
@@ -43,11 +42,9 @@ fn secp256k1_keypair() -> (Vec<u8>, Vec<u8>){
         .as_bytes()
         .to_vec();
 
-
-    // Return the key pair as (private_key, public_key)    
+    // Return the key pair as (private_key, public_key)
     (private_key, public_key)
 }
-
 
 // Generates a fresh Ed25519 key pair. Returns: (private_key, public_key)
 // Private key = 32 bytes (the secret, used to sign)
@@ -60,15 +57,11 @@ fn ed25519_keypair() -> (Vec<u8>, Vec<u8>) {
     // Get Private Key as bytes
     let private_key = signing_key.to_bytes().to_vec();
     // Get Public Key as bytes
-    let public_key = signing_key
-        .verifying_key()
-        .to_bytes()
-        .to_vec();
+    let public_key = signing_key.verifying_key().to_bytes().to_vec();
 
     // Return the key pair as (private_key, public_key)
     (private_key, public_key)
 }
-
 
 //----------------------------------------------------
 // SECP256K1 TESTS
@@ -99,10 +92,12 @@ fn secp256k1_valid_signature_returns_ok() {
     let result = adapter.verify_block(&content, &signature, &creator);
 
     // Assert that the result is Ok(()), meaning the signature was valid.
-    assert!(result.is_ok(), "Expected Ok(()), got Err: {:?}", result.err());
+    assert!(
+        result.is_ok(),
+        "Expected Ok(()), got Err: {:?}",
+        result.err()
+    );
 }
-
-
 
 // TEST 2 — Acceptance Criterion 2: "Adapter returns Err(msg) for an corrupted signature."
 // "The adapter returns Err for a block with a corrupted signature."
@@ -124,7 +119,7 @@ fn secp256k1_corrupted_signature_returns_err() {
 
     // Flip the last byte intentionally.
     let last_byte = signature.last_mut().unwrap(); // safe because signature should never be empty as we defined out logic inside crypto_impl.rs to return error if signature is empty.
-    *last_byte = last_byte.wrapping_add(1); 
+    *last_byte = last_byte.wrapping_add(1);
 
     // Create the adapter configured for Secp256k1 and verify the block.
     let adapter = F1r3flyCryptoAdapter::secp256k1();
@@ -134,7 +129,6 @@ fn secp256k1_corrupted_signature_returns_err() {
     // Assert that the result is Err, meaning the signature was invalid.
     assert!(result.is_err(), "Expected Err, got Ok(())");
 }
-
 
 // TEST 3 — acceptance criterion 2:
 // "The adapter returns Err for a block with a forged signature."
@@ -146,21 +140,23 @@ fn secp256k1_forged_signature_returns_err() {
     let content = make_content(b" This is test block we made for testing the secp256k1 signature verification in F1r3flyCryptoAdapter."); // using byte string literal for payload(content data)
     let hash = hash_content(&content);
 
-    // Real creator's key pair and signature 
+    // Real creator's key pair and signature
     let (_real_private_key, real_public_key) = secp256k1_keypair();
 
     // Forger's key pair and signature (forging the content)
     let (forger_private_key, _forger_public_key) = secp256k1_keypair();
-    let forged_signature = sign(&hash, &forger_private_key); 
+    let forged_signature = sign(&hash, &forger_private_key);
 
     // The block is claiming to be from the real creator, but the signature is from the forger.
     let creator = NodeId(real_public_key);
     let adapter = F1r3flyCryptoAdapter::secp256k1();
     let result = adapter.verify_block(&content, &forged_signature, &creator);
 
-    assert!(result.is_err(), "Expected Err for forged signature, got Ok(())");
+    assert!(
+        result.is_err(),
+        "Expected Err for forged signature, got Ok(())"
+    );
 }
-
 
 // TEST 4:
 // An empty signature slice (zero bytes) must always be rejected.
@@ -173,14 +169,18 @@ fn secp256k1_empty_signature_returns_err() {
     let adapter = F1r3flyCryptoAdapter::secp256k1();
     let result = adapter.verify_block(&content, &[], &creator); // empty signature
 
-    assert!(result.is_err(), "Expected Err for empty signature, got Ok(())");
+    assert!(
+        result.is_err(),
+        "Expected Err for empty signature, got Ok(())"
+    );
 
     // check the error message contains the word "empty" so it's readable.
     let err_msg = result.unwrap_err();
-    assert!(err_msg.contains("empty"), "Error should say 'empty', got: {err_msg}");
+    assert!(
+        err_msg.contains("empty"),
+        "Error should say 'empty', got: {err_msg}"
+    );
 }
-
-
 
 // TEST 5:
 //If the content was tampered with after signing, verification fails.
@@ -199,11 +199,11 @@ fn secp256k1_tampered_content_returns_err() {
     let adapter = F1r3flyCryptoAdapter::secp256k1();
     let result = adapter.verify_block(&tampered_content, &signature, &creator);
 
-    assert!(result.is_err(), "Expected Err for tampered content, got Ok(())");
+    assert!(
+        result.is_err(),
+        "Expected Err for tampered content, got Ok(())"
+    );
 }
-
-
-
 
 //----------------------------------------------------
 // ED25519 TESTS
@@ -213,23 +213,20 @@ fn secp256k1_tampered_content_returns_err() {
 #[test]
 fn ed25519_valid_signature_returns_ok() {
     use ed25519_dalek::Signer; // needed to call .sign() on an Ed25519 key
- 
+
     let content = make_content(b"ed25519 test block");
     let hash = hash_content(&content);
- 
+
     // Generate a key pair and sign.
     let (private_key_bytes, public_key_bytes) = ed25519_keypair();
     let key_array: [u8; 32] = private_key_bytes.try_into().unwrap();
     let signing_key = ed25519_dalek::SigningKey::from_bytes(&key_array);
-    let signature = signing_key
-        .sign(&hash)
-        .to_bytes()
-        .to_vec();
- 
+    let signature = signing_key.sign(&hash).to_bytes().to_vec();
+
     let creator = NodeId(public_key_bytes);
     let adapter = F1r3flyCryptoAdapter::ed25519();
     let result = adapter.verify_block(&content, &signature, &creator);
- 
+
     assert!(result.is_ok(), "Expected Ok(()), got: {:?}", result);
 }
 
@@ -245,20 +242,19 @@ fn ed25519_corrupted_signature_returns_err() {
     let (private_key, public_key) = ed25519_keypair();
     let key_array: [u8; 32] = private_key.try_into().unwrap();
     let signing_key = ed25519_dalek::SigningKey::from_bytes(&key_array);
-    let mut signature = signing_key
-        .sign(&hash)
-        .to_bytes()
-        .to_vec();
+    let mut signature = signing_key.sign(&hash).to_bytes().to_vec();
 
-     // Flip the first byte.
+    // Flip the first byte.
     signature[0] = signature[0].wrapping_add(1);
     let creator = NodeId(public_key);
     let adapter = F1r3flyCryptoAdapter::ed25519();
-    let result  = adapter.verify_block(&content, &signature, &creator); 
+    let result = adapter.verify_block(&content, &signature, &creator);
 
-    assert!(result.is_err(), "Expected Err for corrupted Ed25519 signature");
+    assert!(
+        result.is_err(),
+        "Expected Err for corrupted Ed25519 signature"
+    );
 }
-
 
 //----------------------------------------------------
 // from_algorithm_str TESTS
@@ -268,7 +264,6 @@ fn ed25519_corrupted_signature_returns_err() {
 fn from_str_secp256k1_gives_secp256k1_adapter() {
     let adapter = F1r3flyCryptoAdapter::from_algorithm_str("secp256k1").unwrap();
     assert_eq!(adapter.algorithm(), CryptoAlgorithm::Secp256k1);
-
 }
 
 // TEST 9: "ed25519" string → Ed25519 adapter.
@@ -293,6 +288,8 @@ fn from_str_unknown_returns_err() {
 
     let err = result.unwrap_err();
     // The error should mention what we received as its mentioned.
-    assert!(err.contains("rsa"), "Error should mention 'rsa', got: {err}");
+    assert!(
+        err.contains("rsa"),
+        "Error should mention 'rsa', got: {err}"
+    );
 }
-

--- a/crates/cordial-f1r3node-adapter/tests/test_crypto_adapter.rs
+++ b/crates/cordial-f1r3node-adapter/tests/test_crypto_adapter.rs
@@ -1,0 +1,298 @@
+// Tests for F1r3flyCryptoAdapter.
+// Each test: create & sign block then run verify then check result.
+// Run: cargo test -p cordial-f1r3node-adapter --test test_crypto_adapter (for test file)
+
+use std::collections::HashSet;
+
+// Import the things we want to test.
+use cordial_f1r3node_adapter::crypto_impl::{CryptoAlgorithm, F1r3flyCryptoAdapter};
+
+// Import the tools we need to create test data
+use cordial_miners_core::{
+    crypto::{hash_content,sign, CryptoVerifier},
+    types::{BlockContent, NodeId},
+};
+
+//--------------------------------------------------------------------
+// Helper function used to create a simple block content with a given payload and no parent block
+//--------------------------------------------------------------------
+//instead of writing the same setup in every test,we implemented this make content function.
+fn make_content(payload: &[u8]) -> BlockContent {
+    BlockContent {
+        payload: payload.to_vec(), // the data we want to put in the block changed to vec of bytes
+        predecessors: HashSet::new(), // no parent blocks for simplicity (for testing)
+        
+    }
+}
+
+// Generates a new Secp256k1 key pair which Returns: (private_key as bytes, public_key as bytes)
+// Private key = 32 bytes (the secret, used to sign)
+// Public key  = 33 bytes compressed (the shareable one, used to verify
+
+fn secp256k1_keypair() -> (Vec<u8>, Vec<u8>){
+    use k256::ecdsa::SigningKey;
+
+    // Generate a random signing key (private key) using OS randomness
+    let signing_key = SigningKey::random(&mut rand::rngs::OsRng);
+    // Get Private Key as bytes
+    let private_key = signing_key.to_bytes().to_vec();
+    // Get the corresponding public key as 33-byte compressed format
+    let public_key = signing_key
+        .verifying_key()
+        .to_encoded_point(true) // true means compressed representation
+        .as_bytes()
+        .to_vec();
+
+
+    // Return the key pair as (private_key, public_key)    
+    (private_key, public_key)
+}
+
+
+// Generates a fresh Ed25519 key pair. Returns: (private_key, public_key)
+// Private key = 32 bytes (the secret, used to sign)
+// Public key  = 32 bytes (the shareable one, used to verify)
+fn ed25519_keypair() -> (Vec<u8>, Vec<u8>) {
+    use ed25519_dalek::SigningKey;
+
+    // Generate a random signing key (private key) using OS randomness
+    let signing_key = SigningKey::generate(&mut rand::rngs::OsRng);
+    // Get Private Key as bytes
+    let private_key = signing_key.to_bytes().to_vec();
+    // Get Public Key as bytes
+    let public_key = signing_key
+        .verifying_key()
+        .to_bytes()
+        .to_vec();
+
+    // Return the key pair as (private_key, public_key)
+    (private_key, public_key)
+}
+
+
+//----------------------------------------------------
+// SECP256K1 TESTS
+//----------------------------------------------------
+// TEST 1 — Acceptance Criterion 1: "Adapter returns Ok(()) for a valid signature."
+// Technical Steps:
+//   - Generate key pair (private , public)
+//   - Sign content
+//   - Verify with adapter
+//   - Expect Ok(())
+
+#[test]
+fn secp256k1_valid_signature_returns_ok() {
+    // Create Content and hash it
+    let content = make_content(b" This is test block we made for testing the secp256k1 signature verification in F1r3flyCryptoAdapter."); // using byte string literal for payload(content data)
+    let hash = hash_content(&content);
+
+    // Generate a real key pair and sign.
+    // `sign()` is found in cordial_miners_core::crypto and  It uses Secp256k1Scheme internally and returns DER-encoded bytes
+    let (private_key, public_key) = secp256k1_keypair();
+    let signature = sign(&hash, &private_key);
+
+    // Wrap the public key in a NodeId struct, as expected by the adapter.
+    let creator = NodeId(public_key);
+
+    // Create the adapter configured for Secp256k1 and verify the block.
+    let adapter = F1r3flyCryptoAdapter::secp256k1();
+    let result = adapter.verify_block(&content, &signature, &creator);
+
+    // Assert that the result is Ok(()), meaning the signature was valid.
+    assert!(result.is_ok(), "Expected Ok(()), got Err: {:?}", result.err());
+}
+
+
+
+// TEST 2 — Acceptance Criterion 2: "Adapter returns Err(msg) for an corrupted signature."
+// "The adapter returns Err for a block with a corrupted signature."
+//
+// Technical Steps:
+//   - Same setup as test 1
+//   - But flip one byte in the signature before verifying
+//   - Expect Err
+
+#[test]
+fn secp256k1_corrupted_signature_returns_err() {
+    // Create Content and hash it
+    let content = make_content(b" This is test block we made for testing the secp256k1 signature verification in F1r3flyCryptoAdapter."); // using byte string literal for payload(content data)
+    let hash = hash_content(&content);
+
+    // Generate a real key pair and sign.
+    let (private_key, public_key) = secp256k1_keypair();
+    let mut signature = sign(&hash, &private_key);
+
+    // Flip the last byte intentionally.
+    let last_byte = signature.last_mut().unwrap(); // safe because signature should never be empty as we defined out logic inside crypto_impl.rs to return error if signature is empty.
+    *last_byte = last_byte.wrapping_add(1); 
+
+    // Create the adapter configured for Secp256k1 and verify the block.
+    let adapter = F1r3flyCryptoAdapter::secp256k1();
+    let creator = NodeId(public_key);
+    let result = adapter.verify_block(&content, &signature, &creator);
+
+    // Assert that the result is Err, meaning the signature was invalid.
+    assert!(result.is_err(), "Expected Err, got Ok(())");
+}
+
+
+// TEST 3 — acceptance criterion 2:
+// "The adapter returns Err for a block with a forged signature."
+// "Forged" in this context means: someone else signed it pretending to be the real creator.
+// The signature bytes are valid on their own, but for a different key.
+
+#[test]
+fn secp256k1_forged_signature_returns_err() {
+    let content = make_content(b" This is test block we made for testing the secp256k1 signature verification in F1r3flyCryptoAdapter."); // using byte string literal for payload(content data)
+    let hash = hash_content(&content);
+
+    // Real creator's key pair and signature 
+    let (_real_private_key, real_public_key) = secp256k1_keypair();
+
+    // Forger's key pair and signature (forging the content)
+    let (forger_private_key, _forger_public_key) = secp256k1_keypair();
+    let forged_signature = sign(&hash, &forger_private_key); 
+
+    // The block is claiming to be from the real creator, but the signature is from the forger.
+    let creator = NodeId(real_public_key);
+    let adapter = F1r3flyCryptoAdapter::secp256k1();
+    let result = adapter.verify_block(&content, &forged_signature, &creator);
+
+    assert!(result.is_err(), "Expected Err for forged signature, got Ok(())");
+}
+
+
+// TEST 4:
+// An empty signature slice (zero bytes) must always be rejected.
+#[test]
+fn secp256k1_empty_signature_returns_err() {
+    let content = make_content(b" This is test block we made for testing the secp256k1 signature verification in F1r3flyCryptoAdapter."); // using byte string literal for payload(content data)
+    let (_private_key, public_key) = secp256k1_keypair();
+    let creator = NodeId(public_key);
+
+    let adapter = F1r3flyCryptoAdapter::secp256k1();
+    let result = adapter.verify_block(&content, &[], &creator); // empty signature
+
+    assert!(result.is_err(), "Expected Err for empty signature, got Ok(())");
+
+    // check the error message contains the word "empty" so it's readable.
+    let err_msg = result.unwrap_err();
+    assert!(err_msg.contains("empty"), "Error should say 'empty', got: {err_msg}");
+}
+
+
+
+// TEST 5:
+//If the content was tampered with after signing, verification fails.
+// This covers the scenario where an attacker modifies the block data
+// but keeps the original signature. The hash won't match anymore.
+#[test]
+fn secp256k1_tampered_content_returns_err() {
+    let orginal_content = make_content(b" This is test block we made for testing the secp256k1 signature verification in F1r3flyCryptoAdapter."); // using byte string literal for payload(content data)
+    let hash = hash_content(&orginal_content);
+    let (private_key, public_key) = secp256k1_keypair();
+    let signature = sign(&hash, &private_key);
+
+    // Try to verify same signature but with tampered content
+    let tampered_content = make_content(b" Tampered content"); // different content
+    let creator = NodeId(public_key);
+    let adapter = F1r3flyCryptoAdapter::secp256k1();
+    let result = adapter.verify_block(&tampered_content, &signature, &creator);
+
+    assert!(result.is_err(), "Expected Err for tampered content, got Ok(())");
+}
+
+
+
+
+//----------------------------------------------------
+// ED25519 TESTS
+//----------------------------------------------------
+// TEST 6 — Acceptance criterion 1 for Ed25519:
+// A valid Ed25519 signature must return Ok(())
+#[test]
+fn ed25519_valid_signature_returns_ok() {
+    use ed25519_dalek::Signer; // needed to call .sign() on an Ed25519 key
+ 
+    let content = make_content(b"ed25519 test block");
+    let hash = hash_content(&content);
+ 
+    // Generate a key pair and sign.
+    let (private_key_bytes, public_key_bytes) = ed25519_keypair();
+    let key_array: [u8; 32] = private_key_bytes.try_into().unwrap();
+    let signing_key = ed25519_dalek::SigningKey::from_bytes(&key_array);
+    let signature = signing_key
+        .sign(&hash)
+        .to_bytes()
+        .to_vec();
+ 
+    let creator = NodeId(public_key_bytes);
+    let adapter = F1r3flyCryptoAdapter::ed25519();
+    let result = adapter.verify_block(&content, &signature, &creator);
+ 
+    assert!(result.is_ok(), "Expected Ok(()), got: {:?}", result);
+}
+
+// TEST 7 — Acceptance criterion 2 for Ed25519:
+// A corrupted Ed25519 signature must return Err.
+#[test]
+fn ed25519_corrupted_signature_returns_err() {
+    use ed25519_dalek::Signer;
+
+    let content = make_content(b"This is test block we made for testing the ed25519 signature verification in F1r3flyCryptoAdapter.");
+    let hash = hash_content(&content);
+
+    let (private_key, public_key) = ed25519_keypair();
+    let key_array: [u8; 32] = private_key.try_into().unwrap();
+    let signing_key = ed25519_dalek::SigningKey::from_bytes(&key_array);
+    let mut signature = signing_key
+        .sign(&hash)
+        .to_bytes()
+        .to_vec();
+
+     // Flip the first byte.
+    signature[0] = signature[0].wrapping_add(1);
+    let creator = NodeId(public_key);
+    let adapter = F1r3flyCryptoAdapter::ed25519();
+    let result  = adapter.verify_block(&content, &signature, &creator); 
+
+    assert!(result.is_err(), "Expected Err for corrupted Ed25519 signature");
+}
+
+
+//----------------------------------------------------
+// from_algorithm_str TESTS
+//----------------------------------------------------
+// TEST 8: "secp256k1" string → Secp256k1 adapter.
+#[test]
+fn from_str_secp256k1_gives_secp256k1_adapter() {
+    let adapter = F1r3flyCryptoAdapter::from_algorithm_str("secp256k1").unwrap();
+    assert_eq!(adapter.algorithm(), CryptoAlgorithm::Secp256k1);
+
+}
+
+// TEST 9: "ed25519" string → Ed25519 adapter.
+#[test]
+fn from_str_ed25519_gives_ed25519_adapter() {
+    let adapter = F1r3flyCryptoAdapter::from_algorithm_str("ed25519").unwrap();
+    assert_eq!(adapter.algorithm(), CryptoAlgorithm::Ed25519);
+}
+
+// TEST 10: empty string is defaults to Secp256k1.
+#[test]
+fn from_str_empty_defaults_to_secp256k1() {
+    let adapter = F1r3flyCryptoAdapter::from_algorithm_str("").unwrap();
+    assert_eq!(adapter.algorithm(), CryptoAlgorithm::Secp256k1);
+}
+
+// TEST 11: unknown algorithm string → Err.
+#[test]
+fn from_str_unknown_returns_err() {
+    let result = F1r3flyCryptoAdapter::from_algorithm_str("rsa");
+    assert!(result.is_err(), "Expected Err for unknown algorithm 'rsa'");
+
+    let err = result.unwrap_err();
+    // The error should mention what we received as its mentioned.
+    assert!(err.contains("rsa"), "Error should mention 'rsa', got: {err}");
+}
+


### PR DESCRIPTION
## In this PR 

Implements the `CryptoVerifier` trait for `F1r3flyCryptoAdapter` in the
`cordial-f1r3node-adapter` crate, so the node can reject forged or
corrupted blocks before they enter the blocklace.

## Changes

- `crates/cordial-f1r3node-adapter/src/crypto_impl.rs` — new file
  - `CryptoAlgorithm` enum (Secp256k1 / Ed25519)
  - `F1r3flyCryptoAdapter` struct with three constructors:
    `secp256k1()`, `ed25519()`, `from_algorithm_str()`
  - `impl CryptoVerifier for F1r3flyCryptoAdapter` — recomputes
    Blake2b-256 hash from content, dispatches to the correct scheme

- `crates/cordial-f1r3node-adapter/tests/test_crypto_adapter.rs` — new file
  - 11 tests covering both algorithms

- `docs/cordial-miners/14-crypto-adapter.md` — new file
  - Explains the delegation chain, algorithm table, usage examples,
    why we recompute the hash, and full test matrix

## How to test

cargo test -p cordial-f1r3node-adapter --test test_crypto_adapter

All 11 tests pass.

## Acceptance criteria

- [x] Ok(()) for a mapped block with a known-good signature
- [x] Err for a mapped block with a corrupted or forged signature
- [x] docs/cordial-miners/14-crypto-adapter.md written and included
<img width="1098" height="473" alt="Screenshot from 2026-05-11 21-02-52" src="https://github.com/user-attachments/assets/523f2d41-d425-4841-a466-b566eb669369" />
