### PR TITLE
Implement Wave Leader Selection and Final-Leader Rule

### DIFF
--- a/crates/cordial-miners-core/src/consensus/finality.rs
+++ b/crates/cordial-miners-core/src/consensus/finality.rs
@@ -1,7 +1,12 @@
-use std::collections::HashMap;
-
 use crate::blocklace::Blocklace;
 use crate::types::{BlockIdentity, NodeId};
+use std::collections::HashMap;
+use std::collections::HashSet;
+
+use crate::block::Block;
+use crate::consensus::cordiality::super_ratifies;
+use crate::consensus::round::blocks_at_depth;
+use crate::consensus::wave::{last_round_of_wave, leader_round_of_wave};
 
 /// The finality status of a block in the blocklace.
 ///
@@ -200,4 +205,118 @@ pub fn can_be_finalized(
 
     // Can be finalized if max possible support > 2/3
     (supporting_stake + undecided_stake) * 3 > total_honest_stake * 2
+}
+
+/// Return the single deterministic leader block for a wave.
+///
+/// Per Definition A.10 of arXiv:2205.09174, a leader block is a block by
+/// the elected leader validator in the first round of the wave.
+///
+/// If the leader equivocated (produced multiple blocks in the leader round),
+/// tie-break deterministically by selecting the block with the
+/// lexicographically lowest `content_hash` byte value.
+///
+/// Returns `None` if:
+/// - the wavelength is zero
+/// - the leader round has no block by the elected leader
+/// - `leader_selection` returns `None` for this wave
+pub fn leader_block_for_wave<F>(
+    blocklace: &Blocklace,
+    wave: u64,
+    wavelength: u64,
+    leader_selection: F,
+) -> Option<BlockIdentity>
+where
+    F: Fn(u64) -> Option<NodeId>,
+{
+    // Find the elected leader for this wave
+    let leader = leader_selection(wave)?;
+
+    // Find the first round of the wave — that is where leader blocks live
+    let leader_round = leader_round_of_wave(wave, wavelength)?;
+
+    // Collect all blocks by the leader in the leader round
+    let mut leader_blocks: Vec<Block> = blocks_at_depth(blocklace, leader_round)
+        .into_iter()
+        .filter(|block| block.identity.creator == leader)
+        .collect();
+
+    if leader_blocks.is_empty() {
+        return None;
+    }
+
+    // Deterministic tie-break: lowest content_hash byte value
+    // This ensures identical inputs always produce identical output
+    // regardless of iteration order, even when the leader equivocated.
+    leader_blocks.sort_by_key(|a| a.identity.content_hash);
+
+    Some(leader_blocks[0].identity.clone())
+}
+
+/// Check whether a leader block has achieved finality within its wave.
+///
+/// Per Definition 24 of arXiv:2205.09174, a leader block `b` of round `r`
+/// is final if it is super-ratified within `B(r + w - 1)` — the prefix of
+/// the blocklace up to the last round of the wave.
+///
+/// This wraps `super_ratifies` using the set of all blocks within the
+/// wave's boundary as the witness set.
+///
+/// Returns `false` if:
+/// - the candidate block is not in the blocklace
+/// - the wave boundaries cannot be computed
+/// - super-ratification is not achieved
+pub fn is_final_leader<F>(
+    blocklace: &Blocklace,
+    candidate: &BlockIdentity,
+    wavelength: u64,
+    n: usize,
+    f: usize,
+    leader_selection: F,
+) -> bool
+where
+    F: Fn(u64) -> Option<NodeId>,
+{
+    // Get the candidate block
+    let candidate_block = match blocklace.get(candidate) {
+        Some(block) => block,
+        None => return false,
+    };
+
+    // Find the round of the candidate block
+    let candidate_round = match crate::consensus::round::depth(blocklace, candidate) {
+        Some(d) => d,
+        None => return false,
+    };
+
+    // The candidate must actually be the leader block for its wave
+    let wave = match crate::consensus::wave::wave_of_round(candidate_round, wavelength) {
+        Some(w) => w,
+        None => return false,
+    };
+
+    // Verify this is actually the leader block for this wave
+    let expected_leader_id = leader_block_for_wave(blocklace, wave, wavelength, &leader_selection);
+    if expected_leader_id.as_ref() != Some(candidate) {
+        return false;
+    }
+
+    // Collect all blocks within the wave boundary B(r + w - 1)
+    let last_round = match last_round_of_wave(wave, wavelength) {
+        Some(r) => r,
+        None => return false,
+    };
+
+    // PERF/PAPER NOTE:
+    // Def 24 requires checking the prefix B(r + w - 1).
+    // However, blocks created *before* candidate_round physically cannot
+    // observe the candidate, and therefore cannot ratify it.
+    // We only collect witness blocks from candidate_round up to the end
+    // of the wave, which is mathematically equivalent to B(r + w - 1).
+    let witness_blocks: HashSet<Block> = (candidate_round..=last_round)
+        .flat_map(|round| blocks_at_depth(blocklace, round))
+        .collect();
+
+    // A final leader is super-ratified within its wave
+    super_ratifies(blocklace, &witness_blocks, &candidate_block, n, f)
 }

--- a/crates/cordial-miners-core/src/consensus/mod.rs
+++ b/crates/cordial-miners-core/src/consensus/mod.rs
@@ -12,7 +12,10 @@ pub use cordiality::{
     creator_blocks_at_round, equivocation_blocks_at_round, hidden_equivocations, is_cordial_block,
     is_supermajority, missing_known_tips, observed_block_ids, ratifies, super_ratifies,
 };
-pub use finality::{FinalityStatus, can_be_finalized, check_finality, find_last_finalized};
+pub use finality::{
+    FinalityStatus, can_be_finalized, check_finality, find_last_finalized, is_final_leader,
+    leader_block_for_wave,
+};
 pub use fork_choice::{ForkChoice, collect_validator_tips, fork_choice, is_cordial};
 pub use round::{
     blocks_at_depth, compute_all_depths, depth, depth_prefix, depth_suffix, is_round_cordial,

--- a/crates/cordial-miners-core/tests/test_finality.rs
+++ b/crates/cordial-miners-core/tests/test_finality.rs
@@ -1,6 +1,7 @@
 use cordial_miners_core::blocklace::Blocklace;
 use cordial_miners_core::consensus::{
-    FinalityStatus, can_be_finalized, check_finality, find_last_finalized,
+    FinalityStatus, can_be_finalized, check_finality, find_last_finalized, is_final_leader,
+    leader_block_for_wave,
 };
 use cordial_miners_core::crypto::CryptoVerifier;
 use cordial_miners_core::{Block, BlockContent, BlockIdentity, NodeId};
@@ -69,6 +70,17 @@ fn bonds(entries: &[(u8, u64)]) -> HashMap<NodeId, u64> {
         .iter()
         .map(|(id, stake)| (node(*id), *stake))
         .collect()
+}
+
+// Always elect node(1) as leader
+fn leader_node1(wave: u64) -> Option<NodeId> {
+    let _ = wave;
+    Some(node(1))
+}
+
+// No leader ever elected
+fn no_leader(_wave: u64) -> Option<NodeId> {
+    None
 }
 
 // ── check_finality tests ──
@@ -328,4 +340,151 @@ fn finality_status_helpers() {
 
     assert!(!unknown.is_finalized());
     assert!(!unknown.is_pending());
+}
+
+// ── leader_block_for_wave tests ──
+
+/// leader_block_for_wave returns the correct block when
+/// the leader has exactly one block in the leader round.
+#[test]
+fn leader_block_for_wave_returns_correct_block() {
+    let mut bl = Blocklace::new();
+    let wavelength = 3u64;
+    let wave = 0u64; // leader round = 0
+
+    // Leader (node 1) creates a genesis block at round 0
+    let v1 = node(1);
+    let leader_block = genesis(&v1, 10);
+    insert(&mut bl, &leader_block);
+
+    let result = leader_block_for_wave(&bl, wave, wavelength, leader_node1);
+    assert_eq!(result, Some(leader_block.identity));
+}
+
+/// leader_block_for_wave returns None when no leader is elected.
+#[test]
+fn leader_block_for_wave_returns_none_when_no_leader() {
+    let mut bl = Blocklace::new();
+    let v1 = node(1);
+    let block = genesis(&v1, 1);
+    insert(&mut bl, &block);
+
+    let result = leader_block_for_wave(&bl, 0, 3, no_leader);
+    assert!(result.is_none());
+}
+
+/// leader_block_for_wave returns None when the leader has
+/// no block in the leader round.
+#[test]
+fn leader_block_for_wave_returns_none_when_leader_has_no_block() {
+    let mut bl = Blocklace::new();
+
+    // Only node 2 has a block — not the elected leader (node 1)
+    let v2 = node(2);
+    let block = genesis(&v2, 1);
+    insert(&mut bl, &block);
+
+    let result = leader_block_for_wave(&bl, 0, 3, leader_node1);
+    assert!(result.is_none());
+}
+
+/// leader_block_for_wave is deterministic: same inputs always
+/// produce the same output even when leader equivocated.
+#[test]
+fn leader_block_for_wave_is_deterministic_on_equivocation() {
+    let mut bl = Blocklace::new();
+    let wavelength = 3u64;
+    let wave = 0u64;
+
+    // Leader equivocates — two blocks at round 0
+    // hash [1, 20, 0...] vs [1, 10, 0...] — lower hash wins
+    let v1 = node(1);
+    let block_a = genesis(&v1, 20);
+    let block_b = genesis(&v1, 10);
+    insert(&mut bl, &block_a);
+    insert(&mut bl, &block_b);
+
+    let result1 = leader_block_for_wave(&bl, wave, wavelength, leader_node1);
+    let result2 = leader_block_for_wave(&bl, wave, wavelength, leader_node1);
+
+    // Must be equal across calls — deterministic
+    assert_eq!(result1, result2);
+
+    // Must pick block_b — it has the lower content_hash
+    assert_eq!(result1, Some(block_b.identity));
+}
+
+// ── is_final_leader tests ──
+
+/// is_final_leader returns true when the leader block is
+/// super-ratified within its wave.
+#[test]
+fn is_final_leader_returns_true_when_super_ratified() {
+    let mut bl = Blocklace::new();
+    let wavelength = 3u64;
+    let n = 4;
+    let f = 1;
+
+    // Wave 0: rounds 0, 1, 2
+    // Round 0: leader block by node 1
+    let v1 = node(1);
+    let v2 = node(2);
+    let v3 = node(3);
+    let v4 = node(4);
+    let leader = genesis(&v1, 1);
+    insert(&mut bl, &leader);
+
+    // Round 1: nodes 2, 3, 4 all observe leader
+    let b2r1 = child(&v2, 2, &[&leader]);
+    let b3r1 = child(&v3, 3, &[&leader]);
+    let b4r1 = child(&v4, 4, &[&leader]);
+    insert(&mut bl, &b2r1);
+    insert(&mut bl, &b3r1);
+    insert(&mut bl, &b4r1);
+
+    // Round 2: nodes 2, 3, 4 observe all of round 1
+    let b2r2 = child(&v2, 5, &[&b2r1, &b3r1, &b4r1]);
+    let b3r2 = child(&v3, 6, &[&b2r1, &b3r1, &b4r1]);
+    let b4r2 = child(&v4, 7, &[&b2r1, &b3r1, &b4r1]);
+    insert(&mut bl, &b2r2);
+    insert(&mut bl, &b3r2);
+    insert(&mut bl, &b4r2);
+
+    let result = is_final_leader(&bl, &leader.identity, wavelength, n, f, leader_node1);
+    assert!(result);
+}
+
+/// is_final_leader returns false when super-ratification is not achieved.
+#[test]
+fn is_final_leader_returns_false_when_not_super_ratified() {
+    let mut bl = Blocklace::new();
+    let wavelength = 3u64;
+    let n = 4;
+    let f = 1;
+
+    // Only the leader block exists — no ratifying blocks at all
+    let v1 = node(1);
+    let leader = genesis(&v1, 1);
+    insert(&mut bl, &leader);
+
+    let result = is_final_leader(&bl, &leader.identity, wavelength, n, f, leader_node1);
+    assert!(!result);
+}
+
+/// is_final_leader returns false for a block that is not
+/// the elected leader block for its wave.
+#[test]
+fn is_final_leader_returns_false_for_non_leader_block() {
+    let mut bl = Blocklace::new();
+    let wavelength = 3u64;
+    let n = 4;
+    let f = 1;
+
+    // node 2 is NOT the elected leader — node 1 is
+    let v2 = node(2);
+    let non_leader = genesis(&v2, 1);
+    insert(&mut bl, &non_leader);
+
+    let result = is_final_leader(&bl, &non_leader.identity, wavelength, n, f, leader_node1);
+    assert!(!result);
 }

--- a/docs/cordial-miners/10-leader-finality.md
+++ b/docs/cordial-miners/10-leader-finality.md
@@ -1,0 +1,118 @@
+# 10 — Wave Leader Selection and Leader Finality
+
+## Paper Reference
+
+Sections 3 and 5, Definition 24 of the Cordial Miners paper
+(arXiv:2205.09174).
+
+## Wave Structure
+
+The blocklace rounds are partitioned into fixed-length waves of size
+`wavelength`. Each wave has exactly one elected leader validator. Any
+block by that leader in the first round of the wave is a **leader block**.
+
+## Leader Block Selection
+
+`leader_block_for_wave` finds the leader block for a wave by:
+
+1. Asking `leader_selection(wave)` for the elected validator
+2. Finding the first round of the wave (the leader round)
+3. Collecting all blocks by that validator in that round
+4. Returning the single block with the lowest `content_hash` byte value
+
+### Deterministic Tie-Breaking
+
+If the elected leader equivocated (produced multiple blocks in the leader
+round), there is more than one candidate leader block. To ensure all
+validators agree on the same leader block without extra communication,
+tie-breaking is done deterministically by selecting the block with the
+lexicographically lowest `content_hash`.
+
+This means:
+- Same inputs always produce the same output
+- No randomness or network communication needed
+- All correct validators independently arrive at the same choice
+
+## Leader Finality
+
+`is_final_leader` checks whether a leader block has achieved finality
+within its wave.
+
+### Paper Definition
+
+Per Definition 24 of arXiv:2205.09174:
+
+> "A leader block b of round r is final in B if it is
+> super-ratified in B(r + w − 1)"
+
+Where `B(r + w - 1)` is the depth prefix of the entire blocklace up
+to the last round of the wave.
+
+### Implementation
+
+The check proceeds as:
+
+1. Verify the candidate is the deterministically selected leader block
+   for its wave — if not, return false immediately
+2. Find the wave boundaries using `wave_of_round` and
+   `last_round_of_wave`
+3. Collect witness blocks within the bounded round range
+4. Call `super_ratifies(witness_blocks, candidate)` — if true, the
+   block is a Final Leader
+
+### Performance Note
+
+Definition 24 technically requires checking `B(r + w - 1)` — the
+entire depth prefix of the blocklace up to the last round of the wave.
+This would include all blocks from round 0 up to that point.
+
+However, the implementation only collects blocks from
+`candidate_round` up to `last_round` of the wave, not from round 0.
+This is mathematically equivalent because:
+
+- A block created **before** `candidate_round` cannot have a hash
+  pointer to the candidate block — hash pointers only go backward
+  in time
+- A block that cannot observe the candidate cannot approve it
+- A block that cannot approve the candidate cannot ratify it
+- A block that cannot ratify the candidate cannot contribute to
+  super-ratification
+
+Therefore, scanning blocks before `candidate_round` adds zero to the
+super-ratification result. Excluding them is mathematically equivalent
+to the full `B(r + w - 1)` check.
+
+This optimization keeps finality checking O(wave size) rather than
+O(total chain history), which is critical for a live consensus engine
+processing thousands of blocks.
+
+## Why Finality Is Locked In
+
+Once a leader block is super-ratified:
+- A supermajority of blocks ratify it
+- Each ratifying block has a supermajority of approving blocks in
+  its closure
+- By the properties of supermajority intersection, no conflicting
+  block can also achieve super-ratification
+- The tau ordering function uses final leaders as anchors — once
+  a block is a final leader its position in the total order is
+  permanent and will never be undone by a subsequent call to tau
+
+## Relationship to tau
+
+Final leaders are the anchors of the tau ordering function described
+in Section 5 of the paper. Each final leader triggers a topological
+sort of the blocks it observes that have not yet been ordered,
+producing the next fragment of the total output sequence. The
+monotonicity of tau guarantees that once a fragment is output it
+is never retracted.
+
+## Relationship to Other Modules
+
+| Module | Role |
+|---|---|
+| `consensus/wave.rs` | Wave boundaries and leader round computation |
+| `consensus/round.rs` | Depth computation and `blocks_at_depth` |
+| `consensus/approval.rs` | `approves` — the base approval predicate |
+| `consensus/cordiality.rs` | `ratifies`, `super_ratifies`, `is_supermajority` |
+| `consensus/finality.rs` | `leader_block_for_wave`, `is_final_leader` (this module) |


### PR DESCRIPTION
## Summary

Implements wave leader selection and leader finality predicates in `crates/cordial-miners-core/src/consensus/finality.rs`, based on Definitions 23 and 24 of the Cordial Miners paper (arXiv:2205.09174). This is the next protocol layer after the approval and ratification predicates merged previously.

## What Was Implemented

- `leader_block_for_wave(blocklace, wave, wavelength, leader_selection)` - returns the single deterministic leader block for a wave by finding the elected validator's block in the first round of the wave.  Tie-breaks deterministically on lowest `content_hash` when the leader equivocated, ensuring all validators independently arrive at the same choice without extra communication.
- `is_final_leader(blocklace, candidate, wavelength, n, f, leader_selection)` -  checks whether a leader block achieved super-ratification within its wave boundaries, implementing Definition 24. Verifies the candidate is the elected leader before running the super-ratification check.

## Dependencies on Existing Modules

### `consensus/wave.rs`
- `leader_round_of_wave(wave, wavelength)` — finds the first round of a wave, which is where leader blocks live
- `last_round_of_wave(wave, wavelength)` — finds the last round of a wave, used as the upper boundary of the witness block collection
- `wave_of_round(round, wavelength)` — determines which wave a candidate block belongs to

### `consensus/round.rs`
- `blocks_at_depth(blocklace, round)` — collects all blocks at a specific round, used to find leader blocks and witness blocks
- `depth(blocklace, block_id)` — computes the round number of the candidate block

### `consensus/cordiality.rs`
- `super_ratifies(blocklace, witness_blocks, candidate, n, f)` — the two-level super-ratification check that determines whether a leader block is final within its wave

### `consensus/approval.rs`
- `approves` — used indirectly via `super_ratifies` → `ratifies` → `approves` chain

## Performance Note

Definition 24 technically requires checking the full depth prefix `B(r + w - 1)`. The implementation instead collects only blocks from `candidate_round` to `last_round` of the wave. This is mathematically equivalent because blocks created before the candidate round cannot observe it, cannot approve it, and therefore contribute nothing to super-ratification. This keeps finality checking O(wave size) rather than O(total chain history).

## What Was Intentionally Left Out

- tau ordering function — follows after final leader detection
- leader selection strategy — the actual election logic (round-robin for ES, shared random coin for asynchrony per Algorithm 4 of the paper) is caller-provided via the `leader_selection` closure and will be implemented in a future issue
- PoS stake weighting — not part of this layer

## Crates Modified

- `crates/cordial-miners-core` only — `src/consensus/finality.rs` and `tests/test_finality.rs`
- No changes to `cordial-f1r3node-adapter` or `cordial-f1r3space-adapter`
- Layering rules preserved — builds directly on `super_ratifies` from `consensus/cordiality.rs` and wave helpers from `consensus/wave.rs`

## Test Plan

- Ran `cargo test -p cordial-miners-core` — all tests pass
- Ran `cargo clippy -p cordial-miners-core --all-targets --all-features
  --no-deps -- -D warnings` — no warnings
- New tests in `tests/test_finality.rs` cover:
  - Correct leader block returned for a wave
  - Returns `None` when no leader is elected
  - Returns `None` when leader has no block in the leader round
  - Deterministic output on equivocation — same result across calls,
    lowest `content_hash` wins
  - `is_final_leader` returns `true` when super-ratified
  - `is_final_leader` returns `false` when not super-ratified
  - `is_final_leader` returns `false` for a non-leader block

## Docs

Added `docs/cordial-miners/10-leader-finality.md` explaining wave
leader selection, deterministic tie-breaking, the finality check, and
the performance optimization with paper citation.

## Related Issues

- Closes #19 
- Follows approval and ratification PR