### PR TITLE
Add weighted ratification variants

### DIFF
--- a/crates/cordial-miners-core/src/consensus/approval.rs
+++ b/crates/cordial-miners-core/src/consensus/approval.rs
@@ -6,11 +6,11 @@
 //! See Definition 18 of "Cordial Miners: Voluntary Participation in Blockchains"
 //! (arXiv:2205.09174) for the formal specification.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use crate::block::Block;
 use crate::blocklace::Blocklace;
-use crate::types::BlockIdentity;
+use crate::types::{BlockIdentity, NodeId};
 
 /// A block `approver` approves a `target` block if:
 /// 1. The approver observes the target (i.e., target is in the approver's predecessor closure)
@@ -75,5 +75,29 @@ pub fn approving_blocks(blocklace: &Blocklace, target: &BlockIdentity) -> HashSe
         .into_iter()
         .filter_map(|block_id| blocklace.get(block_id))
         .filter(|block| approves(blocklace, &block.identity, target))
+        .collect()
+}
+
+/// Return the bonded creators in `blocks` whose blocks approve `target`.
+///
+/// This helper does not redefine approval. It delegates to the paper-native
+/// [`approves`] predicate and only changes support accounting from creator
+/// cardinality to positive bonded stake.
+pub fn weighted_approving_creators(
+    blocklace: &Blocklace,
+    blocks: &HashSet<Block>,
+    target: &BlockIdentity,
+    bonds: &HashMap<NodeId, u64>,
+) -> HashSet<NodeId> {
+    blocks
+        .iter()
+        .filter(|block| approves(blocklace, &block.identity, target))
+        .filter_map(|block| {
+            let creator = &block.identity.creator;
+            match bonds.get(creator).copied() {
+                Some(weight) if weight > 0 => Some(creator.clone()),
+                _ => None,
+            }
+        })
         .collect()
 }

--- a/crates/cordial-miners-core/src/consensus/cordiality.rs
+++ b/crates/cordial-miners-core/src/consensus/cordiality.rs
@@ -360,13 +360,13 @@ pub fn is_weighted_supermajority(creators: &HashSet<NodeId>, bonds: &HashMap<Nod
     strict_two_thirds(support_weight, total_weight)
 }
 
-fn checked_bond_weight(weights: impl IntoIterator<Item = u64>) -> Option<u64> {
+fn checked_bond_weight(weights: impl IntoIterator<Item = u64>) -> Option<u128> {
     weights
         .into_iter()
-        .try_fold(0u64, |total, weight| total.checked_add(weight))
+        .try_fold(0u128, |total, weight| total.checked_add(u128::from(weight)))
 }
 
-fn strict_two_thirds(support_weight: u64, total_weight: u64) -> bool {
+fn strict_two_thirds(support_weight: u128, total_weight: u128) -> bool {
     let Some(weighted_support) = support_weight.checked_mul(3) else {
         return false;
     };

--- a/crates/cordial-miners-core/src/consensus/cordiality.rs
+++ b/crates/cordial-miners-core/src/consensus/cordiality.rs
@@ -17,7 +17,7 @@ use std::collections::{HashMap, HashSet};
 
 use crate::block::Block;
 use crate::blocklace::Blocklace;
-use crate::consensus::approval::approves;
+use crate::consensus::approval::{approves, weighted_approving_creators};
 use crate::consensus::round::{blocks_at_depth, depth};
 use crate::types::{BlockIdentity, NodeId};
 
@@ -35,6 +35,11 @@ pub struct HiddenEquivocation {
     pub creator: NodeId,
     pub round: u64,
     pub hidden: Vec<BlockIdentity>,
+}
+
+#[derive(Default)]
+struct WeightedRatificationMemo {
+    weighted_ratifies_cache: HashMap<(BlockIdentity, BlockIdentity), bool>,
 }
 
 /// Return all blocks  created by 'creator' at exactly 'round' in the blocklace.
@@ -241,6 +246,135 @@ pub fn super_ratifies(
         .collect();
 
     is_supermajority(&ratifying_blocks, n, f)
+}
+
+/// Check whether `ratifier` ratifies `target` using bonded stake.
+///
+/// This is the f1r3node-compatible weighted variant of [`ratifies`]. It keeps
+/// the same approval relation and inclusive ratifier closure, but measures a
+/// strict two-thirds threshold over `bonds` instead of creator cardinality.
+pub fn weighted_ratifies(
+    blocklace: &Blocklace,
+    ratifier: &Block,
+    target: &Block,
+    bonds: &HashMap<NodeId, u64>,
+) -> bool {
+    let mut memo = WeightedRatificationMemo::default();
+    weighted_ratifies_with_memo(blocklace, ratifier, target, bonds, &mut memo)
+}
+
+fn weighted_ratifies_with_memo(
+    blocklace: &Blocklace,
+    ratifier: &Block,
+    target: &Block,
+    bonds: &HashMap<NodeId, u64>,
+    memo: &mut WeightedRatificationMemo,
+) -> bool {
+    let cache_key = (ratifier.identity.clone(), target.identity.clone());
+    if let Some(result) = memo.weighted_ratifies_cache.get(&cache_key) {
+        return *result;
+    }
+
+    let result = if blocklace.get(&ratifier.identity).is_none()
+        || blocklace.get(&target.identity).is_none()
+    {
+        false
+    } else {
+        let observed_ids = blocklace.observe(&ratifier.identity);
+        let observed_blocks: HashSet<Block> = observed_ids
+            .iter()
+            .filter_map(|id| blocklace.get(id))
+            .collect();
+
+        let approving_creators =
+            weighted_approving_creators(blocklace, &observed_blocks, &target.identity, bonds);
+
+        is_weighted_supermajority(&approving_creators, bonds)
+    };
+
+    memo.weighted_ratifies_cache.insert(cache_key, result);
+    result
+}
+
+/// Check whether the supplied witness set super-ratifies `target` using bonded
+/// stake.
+///
+/// The caller must pass the block set for the relevant round, wave, or
+/// f1r3node adapter context. This function does not select leaders, waves, or
+/// finality windows.
+pub fn weighted_super_ratifies(
+    blocklace: &Blocklace,
+    blocks: &HashSet<Block>,
+    target: &Block,
+    bonds: &HashMap<NodeId, u64>,
+) -> bool {
+    let mut memo = WeightedRatificationMemo::default();
+    weighted_super_ratifies_with_memo(blocklace, blocks, target, bonds, &mut memo)
+}
+
+fn weighted_super_ratifies_with_memo(
+    blocklace: &Blocklace,
+    blocks: &HashSet<Block>,
+    target: &Block,
+    bonds: &HashMap<NodeId, u64>,
+    memo: &mut WeightedRatificationMemo,
+) -> bool {
+    let ratifying_creators: HashSet<NodeId> = blocks
+        .iter()
+        .filter(|block| weighted_ratifies_with_memo(blocklace, block, target, bonds, memo))
+        .filter_map(|block| {
+            let creator = &block.identity.creator;
+            match bonds.get(creator).copied() {
+                Some(weight) if weight > 0 => Some(creator.clone()),
+                _ => None,
+            }
+        })
+        .collect();
+
+    is_weighted_supermajority(&ratifying_creators, bonds)
+}
+
+/// Check whether `creators` hold strictly more than two-thirds of total bonded
+/// stake.
+///
+/// `bonds` is the full active validator set for the decision context. Unknown
+/// creators do not contribute support. Overflow returns `false`.
+pub fn is_weighted_supermajority(creators: &HashSet<NodeId>, bonds: &HashMap<NodeId, u64>) -> bool {
+    let Some(total_weight) = checked_bond_weight(bonds.values().copied()) else {
+        return false;
+    };
+
+    if total_weight == 0 {
+        return false;
+    }
+
+    let Some(support_weight) = checked_bond_weight(
+        creators
+            .iter()
+            .filter_map(|creator| bonds.get(creator))
+            .copied(),
+    ) else {
+        return false;
+    };
+
+    strict_two_thirds(support_weight, total_weight)
+}
+
+fn checked_bond_weight(weights: impl IntoIterator<Item = u64>) -> Option<u64> {
+    weights
+        .into_iter()
+        .try_fold(0u64, |total, weight| total.checked_add(weight))
+}
+
+fn strict_two_thirds(support_weight: u64, total_weight: u64) -> bool {
+    let Some(weighted_support) = support_weight.checked_mul(3) else {
+        return false;
+    };
+    let Some(threshold) = total_weight.checked_mul(2) else {
+        return false;
+    };
+
+    weighted_support > threshold
 }
 
 /// Check if a set of blocks constitutes a supermajority.

--- a/crates/cordial-miners-core/src/consensus/mod.rs
+++ b/crates/cordial-miners-core/src/consensus/mod.rs
@@ -6,11 +6,12 @@ pub mod round;
 pub mod validation;
 pub mod wave;
 
-pub use approval::{approves, approving_blocks};
+pub use approval::{approves, approving_blocks, weighted_approving_creators};
 pub use cordiality::{
     Equivocation, HiddenEquivocation, acknowledges_equivocation, all_equivocations,
     creator_blocks_at_round, equivocation_blocks_at_round, hidden_equivocations, is_cordial_block,
-    is_supermajority, missing_known_tips, observed_block_ids, ratifies, super_ratifies,
+    is_supermajority, is_weighted_supermajority, missing_known_tips, observed_block_ids, ratifies,
+    super_ratifies, weighted_ratifies, weighted_super_ratifies,
 };
 pub use finality::{
     final_leader_for_wave, is_final_leader, latest_final_leader, leader_block_for_wave,

--- a/crates/cordial-miners-core/tests/test_weighted_ratification.rs
+++ b/crates/cordial-miners-core/tests/test_weighted_ratification.rs
@@ -171,6 +171,9 @@ fn weighted_ratifies_uses_inclusive_ratifier_closure() {
 
     let weights = bonds(&[(2, 7), (3, 3)]);
 
+    // This intentionally follows paper-native approval semantics. The
+    // ratifier's own block contributes when it is in the inclusive closure and
+    // approves the target under `approves(...)`.
     assert!(weighted_ratifies(&blocklace, &ratifier, &target, &weights));
 }
 
@@ -406,6 +409,40 @@ fn weighted_supermajority_returns_false_for_zero_total_weight() {
 }
 
 #[test]
+fn weighted_supermajority_denominator_is_supplied_bond_map_only() {
+    let weights = bonds(&[(1, 4), (2, 3), (3, 3)]);
+
+    assert!(is_weighted_supermajority(
+        &HashSet::from([node(1), node(2), node(9)]),
+        &weights,
+    ));
+
+    assert!(!is_weighted_supermajority(
+        &HashSet::from([node(1), node(9)]),
+        &weights,
+    ));
+}
+
+#[test]
+fn weighted_supermajority_handles_large_u64_weights_with_u128_math() {
+    let weights = HashMap::from([
+        (node(1), u64::MAX),
+        (node(2), u64::MAX),
+        (node(3), u64::MAX),
+    ]);
+
+    assert!(!is_weighted_supermajority(
+        &HashSet::from([node(1), node(2)]),
+        &weights,
+    ));
+
+    assert!(is_weighted_supermajority(
+        &HashSet::from([node(1), node(2), node(3)]),
+        &weights,
+    ));
+}
+
+#[test]
 fn weighted_super_ratifies_same_creator_conflicts_cannot_both_pass() {
     let mut blocklace = Blocklace::new();
 
@@ -429,6 +466,45 @@ fn weighted_super_ratifies_same_creator_conflicts_cannot_both_pass() {
     let x_prime_super = weighted_super_ratifies(&blocklace, &witnesses, &x_prime, &weights);
 
     assert!(!x_super);
+    assert!(!x_prime_super);
+    assert!(!(x_super && x_prime_super));
+}
+
+#[test]
+fn weighted_super_ratifies_one_side_of_conflict_but_not_both() {
+    let mut blocklace = Blocklace::new();
+
+    let x = block(1, 1, HashSet::new());
+    let x_prime = block(1, 2, HashSet::new());
+    insert(&mut blocklace, &x);
+    insert(&mut blocklace, &x_prime);
+
+    let approver2 = block(2, 3, HashSet::from([x.identity.clone()]));
+    let approver3 = block(3, 4, HashSet::from([x.identity.clone()]));
+    let approver4 = block(4, 5, HashSet::from([x.identity.clone()]));
+    insert(&mut blocklace, &approver2);
+    insert(&mut blocklace, &approver3);
+    insert(&mut blocklace, &approver4);
+
+    let predecessors = HashSet::from([
+        approver2.identity.clone(),
+        approver3.identity.clone(),
+        approver4.identity.clone(),
+    ]);
+    let ratifier2 = block(2, 6, predecessors.clone());
+    let ratifier3 = block(3, 7, predecessors.clone());
+    let ratifier4 = block(4, 8, predecessors);
+    insert(&mut blocklace, &ratifier2);
+    insert(&mut blocklace, &ratifier3);
+    insert(&mut blocklace, &ratifier4);
+
+    let witnesses = HashSet::from([ratifier2, ratifier3, ratifier4]);
+    let weights = bonds(&[(2, 4), (3, 3), (4, 3)]);
+
+    let x_super = weighted_super_ratifies(&blocklace, &witnesses, &x, &weights);
+    let x_prime_super = weighted_super_ratifies(&blocklace, &witnesses, &x_prime, &weights);
+
+    assert!(x_super);
     assert!(!x_prime_super);
     assert!(!(x_super && x_prime_super));
 }

--- a/crates/cordial-miners-core/tests/test_weighted_ratification.rs
+++ b/crates/cordial-miners-core/tests/test_weighted_ratification.rs
@@ -1,0 +1,470 @@
+use cordial_miners_core::{
+    Block, BlockContent, BlockIdentity, Blocklace, NodeId,
+    consensus::{
+        approves, is_supermajority, is_weighted_supermajority, ratifies, super_ratifies,
+        weighted_approving_creators, weighted_ratifies, weighted_super_ratifies,
+    },
+    crypto::CryptoVerifier,
+};
+use std::collections::{HashMap, HashSet};
+
+struct MockVerifier;
+
+impl CryptoVerifier for MockVerifier {
+    type Error = String;
+
+    fn verify_block(
+        &self,
+        _content: &BlockContent,
+        _sig: &[u8],
+        _creator: &NodeId,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+fn node(id: u8) -> NodeId {
+    NodeId(vec![id])
+}
+
+fn block(creator_id: u8, hash_byte: u8, predecessors: HashSet<BlockIdentity>) -> Block {
+    let mut content_hash = [0u8; 32];
+    content_hash[0] = creator_id;
+    content_hash[1] = hash_byte;
+
+    Block {
+        identity: BlockIdentity {
+            content_hash,
+            creator: node(creator_id),
+            signature: vec![],
+        },
+        content: BlockContent {
+            payload: vec![],
+            predecessors,
+        },
+    }
+}
+
+fn insert(blocklace: &mut Blocklace, block: &Block) {
+    let verifier = MockVerifier;
+    blocklace
+        .insert(block.clone(), &verifier)
+        .expect("insert failed");
+}
+
+fn bonds(entries: &[(u8, u64)]) -> HashMap<NodeId, u64> {
+    entries
+        .iter()
+        .map(|(creator, weight)| (node(*creator), *weight))
+        .collect()
+}
+
+struct WeightedFixture {
+    blocklace: Blocklace,
+    target: Block,
+    approver2: Block,
+    approver3: Block,
+    approver4: Block,
+    weights: HashMap<NodeId, u64>,
+}
+
+fn target_with_weighted_approvers() -> WeightedFixture {
+    let mut blocklace = Blocklace::new();
+
+    let target = block(1, 1, HashSet::new());
+    insert(&mut blocklace, &target);
+
+    let approver2 = block(2, 2, HashSet::from([target.identity.clone()]));
+    let approver3 = block(3, 3, HashSet::from([target.identity.clone()]));
+    let approver4 = block(4, 4, HashSet::from([target.identity.clone()]));
+    insert(&mut blocklace, &approver2);
+    insert(&mut blocklace, &approver3);
+    insert(&mut blocklace, &approver4);
+
+    WeightedFixture {
+        blocklace,
+        target,
+        approver2,
+        approver3,
+        approver4,
+        weights: bonds(&[(2, 4), (3, 3), (4, 3)]),
+    }
+}
+
+#[test]
+fn weighted_approving_creators_returns_positive_weight_supporters() {
+    let mut blocklace = Blocklace::new();
+
+    let target = block(1, 1, HashSet::new());
+    insert(&mut blocklace, &target);
+
+    let bonded = block(2, 2, HashSet::from([target.identity.clone()]));
+    let unknown = block(3, 3, HashSet::from([target.identity.clone()]));
+    let zero_weight = block(4, 4, HashSet::from([target.identity.clone()]));
+    insert(&mut blocklace, &bonded);
+    insert(&mut blocklace, &unknown);
+    insert(&mut blocklace, &zero_weight);
+
+    let blocks = HashSet::from([bonded, unknown, zero_weight]);
+    let result = weighted_approving_creators(
+        &blocklace,
+        &blocks,
+        &target.identity,
+        &bonds(&[(2, 5), (4, 0)]),
+    );
+
+    assert_eq!(result, HashSet::from([node(2)]));
+}
+
+#[test]
+fn weighted_ratifies_succeeds_with_strict_two_thirds_stake() {
+    let WeightedFixture {
+        mut blocklace,
+        target,
+        approver2,
+        approver3,
+        approver4,
+        weights,
+    } = target_with_weighted_approvers();
+
+    let ratifier = block(
+        2,
+        5,
+        HashSet::from([
+            approver2.identity.clone(),
+            approver3.identity.clone(),
+            approver4.identity.clone(),
+        ]),
+    );
+    insert(&mut blocklace, &ratifier);
+
+    assert!(weighted_ratifies(&blocklace, &ratifier, &target, &weights));
+}
+
+#[test]
+fn weighted_ratifies_fails_below_strict_two_thirds_stake() {
+    let mut blocklace = Blocklace::new();
+
+    let target = block(1, 1, HashSet::new());
+    insert(&mut blocklace, &target);
+
+    let approver = block(2, 2, HashSet::from([target.identity.clone()]));
+    insert(&mut blocklace, &approver);
+
+    let ratifier = block(4, 3, HashSet::from([approver.identity.clone()]));
+    insert(&mut blocklace, &ratifier);
+
+    let weights = bonds(&[(2, 4), (3, 4), (4, 2)]);
+
+    assert!(!weighted_ratifies(&blocklace, &ratifier, &target, &weights));
+}
+
+#[test]
+fn weighted_ratifies_uses_inclusive_ratifier_closure() {
+    let mut blocklace = Blocklace::new();
+
+    let target = block(1, 1, HashSet::new());
+    insert(&mut blocklace, &target);
+
+    let ratifier = block(2, 2, HashSet::from([target.identity.clone()]));
+    insert(&mut blocklace, &ratifier);
+
+    let weights = bonds(&[(2, 7), (3, 3)]);
+
+    assert!(weighted_ratifies(&blocklace, &ratifier, &target, &weights));
+}
+
+#[test]
+fn weighted_ratifies_counts_each_approving_creator_once() {
+    let mut blocklace = Blocklace::new();
+
+    let target = block(1, 1, HashSet::new());
+    insert(&mut blocklace, &target);
+
+    let first_approval = block(2, 2, HashSet::from([target.identity.clone()]));
+    insert(&mut blocklace, &first_approval);
+
+    let second_approval = block(2, 3, HashSet::from([first_approval.identity.clone()]));
+    insert(&mut blocklace, &second_approval);
+
+    let ratifier = block(5, 4, HashSet::from([second_approval.identity.clone()]));
+    insert(&mut blocklace, &ratifier);
+
+    let weights = bonds(&[(2, 4), (3, 3), (4, 3)]);
+
+    assert!(!weighted_ratifies(&blocklace, &ratifier, &target, &weights));
+}
+
+#[test]
+fn weighted_super_ratifies_succeeds_with_weighted_ratifier_majority() {
+    let WeightedFixture {
+        mut blocklace,
+        target,
+        approver2,
+        approver3,
+        approver4,
+        weights,
+    } = target_with_weighted_approvers();
+
+    let predecessors = HashSet::from([
+        approver2.identity.clone(),
+        approver3.identity.clone(),
+        approver4.identity.clone(),
+    ]);
+    let ratifier2 = block(2, 5, predecessors.clone());
+    let ratifier3 = block(3, 6, predecessors.clone());
+    let ratifier4 = block(4, 7, predecessors);
+    insert(&mut blocklace, &ratifier2);
+    insert(&mut blocklace, &ratifier3);
+    insert(&mut blocklace, &ratifier4);
+
+    let witnesses = HashSet::from([ratifier2, ratifier3, ratifier4]);
+
+    assert!(weighted_super_ratifies(
+        &blocklace, &witnesses, &target, &weights
+    ));
+}
+
+#[test]
+fn weighted_super_ratifies_fails_below_weighted_ratifier_majority() {
+    let WeightedFixture {
+        mut blocklace,
+        target,
+        approver2,
+        approver3,
+        approver4,
+        weights,
+    } = target_with_weighted_approvers();
+
+    let ratifier = block(
+        2,
+        5,
+        HashSet::from([
+            approver2.identity.clone(),
+            approver3.identity.clone(),
+            approver4.identity.clone(),
+        ]),
+    );
+    insert(&mut blocklace, &ratifier);
+
+    let witnesses = HashSet::from([ratifier]);
+
+    assert!(!weighted_super_ratifies(
+        &blocklace, &witnesses, &target, &weights
+    ));
+}
+
+#[test]
+fn weighted_super_ratifies_counts_each_ratifying_creator_once() {
+    let WeightedFixture {
+        mut blocklace,
+        target,
+        approver2,
+        approver3,
+        approver4,
+        weights,
+    } = target_with_weighted_approvers();
+
+    let first_ratifier = block(
+        2,
+        5,
+        HashSet::from([
+            approver2.identity.clone(),
+            approver3.identity.clone(),
+            approver4.identity.clone(),
+        ]),
+    );
+    insert(&mut blocklace, &first_ratifier);
+
+    let second_ratifier = block(2, 6, HashSet::from([first_ratifier.identity.clone()]));
+    insert(&mut blocklace, &second_ratifier);
+
+    let witnesses = HashSet::from([first_ratifier, second_ratifier]);
+
+    assert!(!weighted_super_ratifies(
+        &blocklace, &witnesses, &target, &weights
+    ));
+}
+
+#[test]
+fn weighted_super_ratifies_ignores_unknown_and_zero_weight_ratifiers() {
+    let mut blocklace = Blocklace::new();
+
+    let target = block(1, 1, HashSet::new());
+    insert(&mut blocklace, &target);
+
+    let approver2 = block(2, 2, HashSet::from([target.identity.clone()]));
+    let approver3 = block(3, 3, HashSet::from([target.identity.clone()]));
+    let approver5 = block(5, 4, HashSet::from([target.identity.clone()]));
+    insert(&mut blocklace, &approver2);
+    insert(&mut blocklace, &approver3);
+    insert(&mut blocklace, &approver5);
+
+    let predecessors = HashSet::from([
+        approver2.identity.clone(),
+        approver3.identity.clone(),
+        approver5.identity.clone(),
+    ]);
+    let unknown_ratifier = block(9, 5, predecessors.clone());
+    let zero_weight_ratifier = block(4, 6, predecessors);
+    insert(&mut blocklace, &unknown_ratifier);
+    insert(&mut blocklace, &zero_weight_ratifier);
+
+    let weights = bonds(&[(2, 4), (3, 3), (4, 0), (5, 3)]);
+    let witnesses = HashSet::from([unknown_ratifier, zero_weight_ratifier]);
+
+    assert!(!weighted_super_ratifies(
+        &blocklace, &witnesses, &target, &weights
+    ));
+}
+
+#[test]
+fn weighted_ratifies_returns_false_when_target_missing() {
+    let mut blocklace = Blocklace::new();
+
+    let ratifier = block(2, 1, HashSet::new());
+    insert(&mut blocklace, &ratifier);
+
+    let missing_target = block(1, 2, HashSet::new());
+
+    assert!(!weighted_ratifies(
+        &blocklace,
+        &ratifier,
+        &missing_target,
+        &bonds(&[(2, 10)])
+    ));
+}
+
+#[test]
+fn weighted_ratifies_returns_false_when_ratifier_missing() {
+    let mut blocklace = Blocklace::new();
+
+    let target = block(1, 1, HashSet::new());
+    insert(&mut blocklace, &target);
+
+    let missing_ratifier = block(2, 2, HashSet::from([target.identity.clone()]));
+
+    assert!(!weighted_ratifies(
+        &blocklace,
+        &missing_ratifier,
+        &target,
+        &bonds(&[(2, 10)])
+    ));
+}
+
+#[test]
+fn weighted_super_ratifies_returns_false_for_empty_block_set() {
+    let mut blocklace = Blocklace::new();
+
+    let target = block(1, 1, HashSet::new());
+    insert(&mut blocklace, &target);
+
+    assert!(!weighted_super_ratifies(
+        &blocklace,
+        &HashSet::new(),
+        &target,
+        &bonds(&[(1, 10)])
+    ));
+}
+
+#[test]
+fn weighted_supermajority_is_strictly_more_than_two_thirds() {
+    let weights = bonds(&[(1, 3), (2, 3), (3, 3)]);
+
+    assert!(!is_weighted_supermajority(
+        &HashSet::from([node(1), node(2)]),
+        &weights,
+    ));
+
+    assert!(is_weighted_supermajority(
+        &HashSet::from([node(1), node(2), node(3)]),
+        &weights,
+    ));
+}
+
+#[test]
+fn weighted_supermajority_rejects_six_of_ten_and_accepts_seven_of_ten() {
+    let weights = bonds(&[(1, 4), (2, 2), (3, 1), (4, 3)]);
+
+    assert!(!is_weighted_supermajority(
+        &HashSet::from([node(1), node(2)]),
+        &weights,
+    ));
+
+    assert!(is_weighted_supermajority(
+        &HashSet::from([node(1), node(2), node(3)]),
+        &weights,
+    ));
+}
+
+#[test]
+fn weighted_supermajority_returns_false_for_zero_total_weight() {
+    assert!(!is_weighted_supermajority(
+        &HashSet::from([node(1)]),
+        &bonds(&[(1, 0)]),
+    ));
+}
+
+#[test]
+fn weighted_super_ratifies_same_creator_conflicts_cannot_both_pass() {
+    let mut blocklace = Blocklace::new();
+
+    let x = block(1, 1, HashSet::new());
+    let x_prime = block(1, 2, HashSet::new());
+    insert(&mut blocklace, &x);
+    insert(&mut blocklace, &x_prime);
+
+    let predecessors = HashSet::from([x.identity.clone(), x_prime.identity.clone()]);
+    let witness2 = block(2, 3, predecessors.clone());
+    let witness3 = block(3, 4, predecessors.clone());
+    let witness4 = block(4, 5, predecessors);
+    insert(&mut blocklace, &witness2);
+    insert(&mut blocklace, &witness3);
+    insert(&mut blocklace, &witness4);
+
+    let witnesses = HashSet::from([witness2, witness3, witness4]);
+    let weights = bonds(&[(2, 4), (3, 3), (4, 3)]);
+
+    let x_super = weighted_super_ratifies(&blocklace, &witnesses, &x, &weights);
+    let x_prime_super = weighted_super_ratifies(&blocklace, &witnesses, &x_prime, &weights);
+
+    assert!(!x_super);
+    assert!(!x_prime_super);
+    assert!(!(x_super && x_prime_super));
+}
+
+#[test]
+fn paper_native_ratification_predicates_are_preserved() {
+    let mut blocklace = Blocklace::new();
+
+    let target = block(1, 1, HashSet::new());
+    insert(&mut blocklace, &target);
+
+    let approver2 = block(2, 2, HashSet::from([target.identity.clone()]));
+    let approver3 = block(3, 3, HashSet::from([target.identity.clone()]));
+    let approver4 = block(4, 4, HashSet::from([target.identity.clone()]));
+    insert(&mut blocklace, &approver2);
+    insert(&mut blocklace, &approver3);
+    insert(&mut blocklace, &approver4);
+
+    let approvers = HashSet::from([approver2.clone(), approver3.clone(), approver4.clone()]);
+    assert!(approves(&blocklace, &approver2.identity, &target.identity));
+    assert!(is_supermajority(&approvers, 4, 1));
+
+    let predecessors = HashSet::from([
+        approver2.identity.clone(),
+        approver3.identity.clone(),
+        approver4.identity.clone(),
+    ]);
+    let ratifier2 = block(2, 5, predecessors.clone());
+    let ratifier3 = block(3, 6, predecessors.clone());
+    let ratifier4 = block(4, 7, predecessors);
+    insert(&mut blocklace, &ratifier2);
+    insert(&mut blocklace, &ratifier3);
+    insert(&mut blocklace, &ratifier4);
+
+    assert!(ratifies(&blocklace, &ratifier2, &target, 4, 1));
+
+    let ratifiers = HashSet::from([ratifier2, ratifier3, ratifier4]);
+    assert!(super_ratifies(&blocklace, &ratifiers, &target, 4, 1));
+}

--- a/docs/cordial-miners/09-ratification-math.md
+++ b/docs/cordial-miners/09-ratification-math.md
@@ -1,0 +1,86 @@
+# Ratification Math
+
+This note documents the ratification scope for Issue 2. It keeps the
+paper-native Cordial Miners predicates intact and adds weighted variants for the
+f1r3node validator model.
+
+## Paper-Native Predicates
+
+The existing implementation keeps the paper-native functions as the source of
+truth:
+
+- `approves(...)`
+- `ratifies(...)`
+- `super_ratifies(...)`
+- `is_supermajority(...)`
+
+The Cordial Miners paper defines approval through the observed block closure and
+equivocation relation. It defines ratification over the inclusive closure of the
+ratifier, and super-ratification over a supermajority of ratifying blocks. The
+implementation preserves those predicates and does not change their threshold
+semantics.
+
+## Weighted f1r3node Variants
+
+The weighted functions are added beside the paper-native functions:
+
+- `weighted_approving_creators(...)`
+- `weighted_ratifies(...)`
+- `weighted_super_ratifies(...)`
+- `is_weighted_supermajority(...)`
+
+`weighted_approving_creators(...)` does not define approval itself. It delegates
+to the existing paper-native `approves(...)` predicate. Any details about
+observed conflicts, incomparability, and equivocation remain owned by
+`approves(...)`.
+
+The weighted path changes only support accounting. Instead of counting distinct
+creators equally, it sums bonded stake from the active validator bond map:
+
+- unknown creators contribute no support
+- zero-weight creators contribute no support
+- each creator contributes at most once
+- the denominator is the total active stake in the supplied bond map
+
+## Weighted Threshold
+
+`is_weighted_supermajority(...)` uses a strict integer two-thirds check:
+
+```text
+support_weight * 3 > total_weight * 2
+```
+
+This avoids floating-point rounding and preserves strictness at the exact
+boundary. For total stake 10:
+
+- support 6 fails because `6 * 3 == 10 * 2`
+- support 7 passes because `7 * 3 > 10 * 2`
+
+Checked arithmetic is used for accumulation and multiplication. Overflow fails
+closed by returning `false`.
+
+## Closure and Witness Sets
+
+`weighted_ratifies(...)` follows the paper-native ratification shape: it inspects
+the ratifier block's inclusive causal closure, then applies weighted support to
+the blocks in that closure that approve the target.
+
+`weighted_super_ratifies(...)` receives the witness block set from its caller.
+That set should come from the relevant round, wave, or f1r3node adapter context.
+The weighted ratification module does not select leaders, finality windows,
+waves, pruning bounds, networking state, or ordering policy.
+
+## Memoization Scope
+
+Weighted super-ratification may ask repeated ratification questions over the
+same blocklace snapshot. The implementation uses a private per-call memo for
+weighted ratification results.
+
+The memo is intentionally local. It must not be reused globally across DAG
+updates, bond map changes, validator epoch changes, or threshold policy changes.
+
+## Out of Scope
+
+This issue does not implement leader finality, compatibility finality detection,
+ordering, pruning, networking, or adapter policy. Those concerns belong in a
+separate issue and PR.

--- a/docs/cordial-miners/09-ratification-math.md
+++ b/docs/cordial-miners/09-ratification-math.md
@@ -56,8 +56,9 @@ boundary. For total stake 10:
 - support 6 fails because `6 * 3 == 10 * 2`
 - support 7 passes because `7 * 3 > 10 * 2`
 
-Checked arithmetic is used for accumulation and multiplication. Overflow fails
-closed by returning `false`.
+The implementation converts `u64` bond weights to `u128` for accumulation and
+cross-multiplication. Checked arithmetic is still used, so overflow fails closed
+by returning `false`.
 
 ## Closure and Witness Sets
 


### PR DESCRIPTION
## Summary

This PR reopens the weighted ratification work from a clean branch based on `consensus`, so the diff contains only the scoped weighted ratification changes.

It adds f1r3node-compatible weighted variants beside the paper-native Cordial Miners functions:

- `weighted_approving_creators(...)`
- `weighted_ratifies(...)`
- `weighted_super_ratifies(...)`
- `is_weighted_supermajority(...)`

## Scope

The paper-native functions remain unchanged:

- `approves(...)`
- `ratifies(...)`
- `super_ratifies(...)`
- `is_supermajority(...)`

Weighted support reuses `approves(...)`, counts each bonded creator at most once, ignores unknown or zero-weight validators, and uses strict integer two-thirds checks with checked arithmetic.

## Implementation Notes

- `approval.rs` adds `weighted_approving_creators(...)`.
- `cordiality.rs` adds weighted ratification and weighted super-ratification.
- Weighted super-ratification uses a private per-call memo to avoid repeated weighted ratification recomputation.
- `docs/cordial-miners/09-ratification-math.md` documents the implementation plan, weighted threshold behavior, memo scope, and finality boundaries.
- Tests cover inclusive closure, duplicate creators, unknown and zero-weight validators, missing target or ratifier blocks, empty witness sets, strict 6/10 vs 7/10 boundaries, conflict safety, and paper-native regression calls.

## Validation

- `cargo fmt -p cordial-miners-core --check`
- `cargo fmt -p cordial-f1r3node-adapter --check`
- `cargo fmt -p cordial-f1r3space-adapter --check`
- `cargo test -p cordial-miners-core --test test_weighted_ratification`
- `cargo test -p cordial-miners-core`
- `cargo clippy -p cordial-miners-core -p cordial-f1r3node-adapter -p cordial-f1r3space-adapter --all-targets --all-features --no-deps -- -D warnings`
- `cargo build --verbose`
- `cargo test --verbose`
