### PR TITLE
Add weighted finality

### DIFF
--- a/crates/cordial-miners-core/src/consensus/finality.rs
+++ b/crates/cordial-miners-core/src/consensus/finality.rs
@@ -1,8 +1,9 @@
+use std::collections::HashMap;
 use std::collections::HashSet;
 
 use crate::block::Block;
 use crate::blocklace::Blocklace;
-use crate::consensus::cordiality::super_ratifies;
+use crate::consensus::cordiality::{super_ratifies, weighted_super_ratifies};
 use crate::consensus::round::{blocks_at_depth, depth};
 use crate::consensus::wave::{last_round_of_wave, leader_blocks_of_wave, wave_of_round};
 use crate::types::{BlockIdentity, NodeId};
@@ -150,6 +151,130 @@ where
     for wave in (0..=latest_wave).rev() {
         if let Some(leader) =
             final_leader_for_wave(blocklace, wave, wavelength, n, f, leader_selection)
+        {
+            return Some(leader);
+        }
+    }
+
+    None
+}
+
+/// Check whether a leader block has achieved weighted finality within its wave.
+///
+/// This is the stake-weighted parallel to `is_final_leader`. It uses
+/// `weighted_super_ratifies` instead of `super_ratifies`, meaning the
+/// supermajority threshold is measured over bonded stake rather than
+/// distinct creator count.
+///
+/// Use `is_final_leader` for paper-native unweighted verification.
+/// Use `is_weighted_final_leader` for PoS stake-based consensus.
+///
+/// Returns `false` if:
+/// - the candidate block is not in the blocklace
+/// - the candidate is not one of the actual leader blocks for its wave
+/// - the wave boundaries cannot be computed
+/// - weighted super-ratification is not achieved
+pub fn is_weighted_final_leader<F>(
+    blocklace: &Blocklace,
+    candidate: &BlockIdentity,
+    wavelength: u64,
+    bonds: &HashMap<NodeId, u64>,
+    leader_selection: F,
+) -> bool
+where
+    F: Fn(u64) -> Option<NodeId>,
+{
+    let candidate_block = match blocklace.get(candidate) {
+        Some(block) => block,
+        None => return false,
+    };
+
+    let candidate_round = match depth(blocklace, candidate) {
+        Some(d) => d,
+        None => return false,
+    };
+
+    let wave = match wave_of_round(candidate_round, wavelength) {
+        Some(w) => w,
+        None => return false,
+    };
+
+    // Candidate must be one of the actual leader blocks for its wave
+    let leader_blocks = leader_blocks_of_wave(blocklace, wave, wavelength, &leader_selection);
+    if !leader_blocks
+        .iter()
+        .any(|leader_block| leader_block.identity == *candidate)
+    {
+        return false;
+    }
+
+    let last_round = match last_round_of_wave(wave, wavelength) {
+        Some(r) => r,
+        None => return false,
+    };
+
+    // PERF/PAPER NOTE:
+    // Same optimization as is_final_leader — blocks before candidate_round
+    // cannot observe the candidate and therefore cannot ratify it.
+    // Collecting from candidate_round..=last_round is mathematically
+    // equivalent to B(r + w - 1) per Definition 24.
+    let witness_blocks: HashSet<Block> = (candidate_round..=last_round)
+        .flat_map(|round| blocks_at_depth(blocklace, round))
+        .collect();
+
+    weighted_super_ratifies(blocklace, &witness_blocks, &candidate_block, bonds)
+}
+
+/// Return the weighted final leader block for a wave, if one exists.
+///
+/// Resolves the unique leader block for the wave then checks whether
+/// that block is weighted-final under bonded stake.
+pub fn weighted_final_leader_for_wave<F>(
+    blocklace: &Blocklace,
+    wave: u64,
+    wavelength: u64,
+    bonds: &HashMap<NodeId, u64>,
+    leader_selection: F,
+) -> Option<BlockIdentity>
+where
+    F: Fn(u64) -> Option<NodeId> + Copy,
+{
+    let leader = leader_block_for_wave(blocklace, wave, wavelength, leader_selection)?;
+    if is_weighted_final_leader(blocklace, &leader, wavelength, bonds, leader_selection) {
+        Some(leader)
+    } else {
+        None
+    }
+}
+
+/// Return the latest weighted final leader currently known in the blocklace.
+///
+/// Scans backward from the highest known wave, returning the newest wave
+/// whose unique leader block achieves weighted finality.
+pub fn latest_weighted_final_leader<F>(
+    blocklace: &Blocklace,
+    wavelength: u64,
+    bonds: &HashMap<NodeId, u64>,
+    leader_selection: F,
+) -> Option<BlockIdentity>
+where
+    F: Fn(u64) -> Option<NodeId> + Copy,
+{
+    if wavelength == 0 || blocklace.dom().is_empty() {
+        return None;
+    }
+
+    let max_round = blocklace
+        .dom()
+        .iter()
+        .filter_map(|id| depth(blocklace, id))
+        .max()?;
+
+    let latest_wave = wave_of_round(max_round, wavelength)?;
+
+    for wave in (0..=latest_wave).rev() {
+        if let Some(leader) =
+            weighted_final_leader_for_wave(blocklace, wave, wavelength, bonds, leader_selection)
         {
             return Some(leader);
         }

--- a/crates/cordial-miners-core/src/consensus/mod.rs
+++ b/crates/cordial-miners-core/src/consensus/mod.rs
@@ -14,7 +14,8 @@ pub use cordiality::{
     super_ratifies, weighted_ratifies, weighted_super_ratifies,
 };
 pub use finality::{
-    final_leader_for_wave, is_final_leader, latest_final_leader, leader_block_for_wave,
+    final_leader_for_wave, is_final_leader, is_weighted_final_leader, latest_final_leader,
+    latest_weighted_final_leader, leader_block_for_wave, weighted_final_leader_for_wave,
 };
 pub use fork_choice::{ForkChoice, collect_validator_tips, fork_choice, is_cordial};
 pub use round::{

--- a/crates/cordial-miners-core/tests/test_finality.rs
+++ b/crates/cordial-miners-core/tests/test_finality.rs
@@ -450,13 +450,15 @@ fn weighted_false_but_unweighted_true_when_low_stake_ratifiers() {
     // Unweighted: v2+v3+v4 = 3 distinct creators > (4+1)/2 = 2.5 → TRUE
     let b = unequal_bonds(&[(1, 4), (2, 4), (3, 4), (4, 4), (5, 900)]);
 
-    let unweighted_result =
-        is_final_leader(&bl, &leader.identity, wavelength, n, f, leader_node1);
+    let unweighted_result = is_final_leader(&bl, &leader.identity, wavelength, n, f, leader_node1);
     let weighted_result =
         is_weighted_final_leader(&bl, &leader.identity, wavelength, &b, leader_node1);
 
     assert!(unweighted_result, "unweighted should be final");
-    assert!(!weighted_result, "weighted should NOT be final — low stake ratifiers");
+    assert!(
+        !weighted_result,
+        "weighted should NOT be final — low stake ratifiers"
+    );
 }
 
 /// Weighted and unweighted agree when ratifying validators

--- a/crates/cordial-miners-core/tests/test_finality.rs
+++ b/crates/cordial-miners-core/tests/test_finality.rs
@@ -1,9 +1,11 @@
 use cordial_miners_core::blocklace::Blocklace;
 use cordial_miners_core::consensus::{
-    final_leader_for_wave, is_final_leader, latest_final_leader, leader_block_for_wave,
+    final_leader_for_wave, is_final_leader, is_weighted_final_leader, latest_final_leader,
+    latest_weighted_final_leader, leader_block_for_wave, weighted_final_leader_for_wave,
 };
 use cordial_miners_core::crypto::CryptoVerifier;
 use cordial_miners_core::{Block, BlockContent, BlockIdentity, NodeId};
+use std::collections::HashMap;
 use std::collections::HashSet;
 
 struct MockVerifier;
@@ -74,6 +76,16 @@ fn no_leader(_wave: u64) -> Option<NodeId> {
     None
 }
 
+fn equal_bonds(ids: &[u8], stake: u64) -> HashMap<NodeId, u64> {
+    ids.iter().map(|id| (node(*id), stake)).collect()
+}
+
+fn unequal_bonds(entries: &[(u8, u64)]) -> HashMap<NodeId, u64> {
+    entries
+        .iter()
+        .map(|(id, stake)| (node(*id), *stake))
+        .collect()
+}
 // ── leader_block_for_wave tests ──
 
 /// leader_block_for_wave returns the correct block when
@@ -351,4 +363,271 @@ fn latest_final_leader_returns_most_recent_final_wave() {
         latest_final_leader(&bl, wavelength, n, f, leader_node1),
         Some(w1_leader.identity)
     );
+}
+
+#[test]
+fn weighted_final_leader_true_when_stake_supermajority() {
+    let mut bl = Blocklace::new();
+    let wavelength = 3u64;
+
+    // Wave 0: rounds 0, 1, 2
+    let v1 = node(1);
+    let v2 = node(2);
+    let v3 = node(3);
+    let v4 = node(4);
+
+    // Round 0: leader block by node 1
+    let leader = genesis(&v1, 1);
+    insert(&mut bl, &leader);
+
+    // Round 1: v2, v3, v4 all observe leader
+    let b2r1 = child(&v2, 2, &[&leader]);
+    let b3r1 = child(&v3, 3, &[&leader]);
+    let b4r1 = child(&v4, 4, &[&leader]);
+    insert(&mut bl, &b2r1);
+    insert(&mut bl, &b3r1);
+    insert(&mut bl, &b4r1);
+
+    // Round 2: v2, v3, v4 observe all of round 1
+    let b2r2 = child(&v2, 5, &[&b2r1, &b3r1, &b4r1]);
+    let b3r2 = child(&v3, 6, &[&b2r1, &b3r1, &b4r1]);
+    let b4r2 = child(&v4, 7, &[&b2r1, &b3r1, &b4r1]);
+    insert(&mut bl, &b2r2);
+    insert(&mut bl, &b3r2);
+    insert(&mut bl, &b4r2);
+
+    // Equal stake — all four validators hold 100 each
+    // Ratifying validators: v1+v2+v3+v4 = 400 > 2/3 * 400
+    let b = equal_bonds(&[1, 2, 3, 4], 100);
+
+    let result = is_weighted_final_leader(&bl, &leader.identity, wavelength, &b, leader_node1);
+    assert!(result);
+}
+
+/// Weighted final leader returns false when ratifying validators
+/// hold less than 2/3 of total bonded stake even if unweighted
+/// supermajority is met.
+///
+/// This is the key divergence test between weighted and unweighted.
+#[test]
+fn weighted_false_but_unweighted_true_when_low_stake_ratifiers() {
+    let mut bl = Blocklace::new();
+    let wavelength = 3u64;
+    let n = 4;
+    let f = 1;
+
+    let v1 = node(1);
+    let v2 = node(2);
+    let v3 = node(3);
+    let v4 = node(4);
+
+    // Round 0: leader block by node 1
+    let leader = genesis(&v1, 1);
+    insert(&mut bl, &leader);
+
+    // Round 1: v2, v3, v4 observe leader — v1 absent
+    let b2r1 = child(&v2, 2, &[&leader]);
+    let b3r1 = child(&v3, 3, &[&leader]);
+    let b4r1 = child(&v4, 4, &[&leader]);
+    insert(&mut bl, &b2r1);
+    insert(&mut bl, &b3r1);
+    insert(&mut bl, &b4r1);
+
+    // Round 2: v2, v3, v4 observe all of round 1 — v1 absent
+    let b2r2 = child(&v2, 5, &[&b2r1, &b3r1, &b4r1]);
+    let b3r2 = child(&v3, 6, &[&b2r1, &b3r1, &b4r1]);
+    let b4r2 = child(&v4, 7, &[&b2r1, &b3r1, &b4r1]);
+    insert(&mut bl, &b2r2);
+    insert(&mut bl, &b3r2);
+    insert(&mut bl, &b4r2);
+
+    // v5 is a high-stake bonded validator who never participates
+    // v1, v2, v3, v4 each have low stake
+    // Total = 4 + 4 + 4 + 4 + 900 = 916
+    // Ratifying creators = v1+v2+v3+v4 at most = 16 out of 916
+    // 16 * 3 = 48 NOT > 916 * 2 = 1832 → weighted FALSE
+    //
+    // Unweighted: v2+v3+v4 = 3 distinct creators > (4+1)/2 = 2.5 → TRUE
+    let b = unequal_bonds(&[(1, 4), (2, 4), (3, 4), (4, 4), (5, 900)]);
+
+    let unweighted_result =
+        is_final_leader(&bl, &leader.identity, wavelength, n, f, leader_node1);
+    let weighted_result =
+        is_weighted_final_leader(&bl, &leader.identity, wavelength, &b, leader_node1);
+
+    assert!(unweighted_result, "unweighted should be final");
+    assert!(!weighted_result, "weighted should NOT be final — low stake ratifiers");
+}
+
+/// Weighted and unweighted agree when ratifying validators
+/// hold more than 2/3 of stake.
+#[test]
+fn weighted_and_unweighted_agree_when_high_stake_ratifiers() {
+    let mut bl = Blocklace::new();
+    let wavelength = 3u64;
+    let n = 4;
+    let f = 1;
+
+    let v1 = node(1);
+    let v2 = node(2);
+    let v3 = node(3);
+    let v4 = node(4);
+
+    let leader = genesis(&v1, 1);
+    insert(&mut bl, &leader);
+
+    let b2r1 = child(&v2, 2, &[&leader]);
+    let b3r1 = child(&v3, 3, &[&leader]);
+    let b4r1 = child(&v4, 4, &[&leader]);
+    insert(&mut bl, &b2r1);
+    insert(&mut bl, &b3r1);
+    insert(&mut bl, &b4r1);
+
+    let b2r2 = child(&v2, 5, &[&b2r1, &b3r1, &b4r1]);
+    let b3r2 = child(&v3, 6, &[&b2r1, &b3r1, &b4r1]);
+    let b4r2 = child(&v4, 7, &[&b2r1, &b3r1, &b4r1]);
+    insert(&mut bl, &b2r2);
+    insert(&mut bl, &b3r2);
+    insert(&mut bl, &b4r2);
+
+    // Equal stake — ratifying validators hold 3/4 = 75% > 2/3
+    let b = equal_bonds(&[1, 2, 3, 4], 100);
+
+    let unweighted_result = is_final_leader(&bl, &leader.identity, wavelength, n, f, leader_node1);
+    let weighted_result =
+        is_weighted_final_leader(&bl, &leader.identity, wavelength, &b, leader_node1);
+
+    assert!(unweighted_result, "unweighted should be final");
+    assert!(weighted_result, "weighted should also be final");
+}
+
+/// is_weighted_final_leader returns false for a non-leader block.
+#[test]
+fn weighted_final_leader_false_for_non_leader_block() {
+    let mut bl = Blocklace::new();
+    let v2 = node(2);
+    let non_leader = genesis(&v2, 1);
+    insert(&mut bl, &non_leader);
+
+    let b = equal_bonds(&[1, 2, 3, 4], 100);
+    let result = is_weighted_final_leader(&bl, &non_leader.identity, 3, &b, leader_node1);
+    assert!(!result);
+}
+
+/// is_weighted_final_leader returns false when block
+/// is not in the blocklace.
+#[test]
+fn weighted_final_leader_false_for_unknown_block() {
+    let bl = Blocklace::new();
+    let fake_id = make_id(&node(1), 99);
+    let b = equal_bonds(&[1, 2, 3, 4], 100);
+    assert!(!is_weighted_final_leader(
+        &bl,
+        &fake_id,
+        3,
+        &b,
+        leader_node1
+    ));
+}
+
+// ── weighted_final_leader_for_wave tests ──
+
+/// weighted_final_leader_for_wave returns Some when
+/// weighted finality is achieved.
+#[test]
+fn weighted_final_leader_for_wave_returns_some_when_final() {
+    let mut bl = Blocklace::new();
+    let wavelength = 3u64;
+
+    let v1 = node(1);
+    let v2 = node(2);
+    let v3 = node(3);
+    let v4 = node(4);
+
+    let leader = genesis(&v1, 1);
+    insert(&mut bl, &leader);
+
+    let b2r1 = child(&v2, 2, &[&leader]);
+    let b3r1 = child(&v3, 3, &[&leader]);
+    let b4r1 = child(&v4, 4, &[&leader]);
+    insert(&mut bl, &b2r1);
+    insert(&mut bl, &b3r1);
+    insert(&mut bl, &b4r1);
+
+    let b2r2 = child(&v2, 5, &[&b2r1, &b3r1, &b4r1]);
+    let b3r2 = child(&v3, 6, &[&b2r1, &b3r1, &b4r1]);
+    let b4r2 = child(&v4, 7, &[&b2r1, &b3r1, &b4r1]);
+    insert(&mut bl, &b2r2);
+    insert(&mut bl, &b3r2);
+    insert(&mut bl, &b4r2);
+
+    let b = equal_bonds(&[1, 2, 3, 4], 100);
+    let result = weighted_final_leader_for_wave(&bl, 0, wavelength, &b, leader_node1);
+    assert_eq!(result, Some(leader.identity));
+}
+
+/// weighted_final_leader_for_wave returns None when
+/// weighted finality is not achieved.
+#[test]
+fn weighted_final_leader_for_wave_returns_none_when_not_final() {
+    let mut bl = Blocklace::new();
+    let v1 = node(1);
+    let leader = genesis(&v1, 1);
+    insert(&mut bl, &leader);
+
+    // No ratifying blocks — cannot be final
+    let b = equal_bonds(&[1, 2, 3, 4], 100);
+    let result = weighted_final_leader_for_wave(&bl, 0, 3, &b, leader_node1);
+    assert!(result.is_none());
+}
+
+// ── latest_weighted_final_leader tests ──
+
+/// latest_weighted_final_leader returns None on empty blocklace.
+#[test]
+fn latest_weighted_final_leader_none_on_empty_blocklace() {
+    let bl = Blocklace::new();
+    let b = equal_bonds(&[1, 2, 3, 4], 100);
+    assert!(latest_weighted_final_leader(&bl, 3, &b, leader_node1).is_none());
+}
+
+/// latest_weighted_final_leader returns the most recent
+/// wave whose leader is weighted-final.
+#[test]
+fn latest_weighted_final_leader_returns_highest_final_wave() {
+    let mut bl = Blocklace::new();
+    let wavelength = 3u64;
+
+    let v1 = node(1);
+    let v2 = node(2);
+    let v3 = node(3);
+    let v4 = node(4);
+
+    // Wave 0: rounds 0, 1, 2 — fully ratified
+    let leader_w0 = genesis(&v1, 1);
+    insert(&mut bl, &leader_w0);
+
+    let b2r1 = child(&v2, 2, &[&leader_w0]);
+    let b3r1 = child(&v3, 3, &[&leader_w0]);
+    let b4r1 = child(&v4, 4, &[&leader_w0]);
+    insert(&mut bl, &b2r1);
+    insert(&mut bl, &b3r1);
+    insert(&mut bl, &b4r1);
+
+    let b2r2 = child(&v2, 5, &[&b2r1, &b3r1, &b4r1]);
+    let b3r2 = child(&v3, 6, &[&b2r1, &b3r1, &b4r1]);
+    let b4r2 = child(&v4, 7, &[&b2r1, &b3r1, &b4r1]);
+    insert(&mut bl, &b2r2);
+    insert(&mut bl, &b3r2);
+    insert(&mut bl, &b4r2);
+
+    // Wave 1: round 3 — leader block only, not yet ratified
+    let leader_w1 = child(&v1, 8, &[&b2r2, &b3r2, &b4r2]);
+    insert(&mut bl, &leader_w1);
+
+    let b = equal_bonds(&[1, 2, 3, 4], 100);
+    let result = latest_weighted_final_leader(&bl, wavelength, &b, leader_node1);
+
+    // Wave 0 leader is final, wave 1 leader is not
+    assert_eq!(result, Some(leader_w0.identity));
 }


### PR DESCRIPTION
## Summary

Adds a weighted finality path to `crates/cordial-miners-core/src/consensus/finality.rs` that runs in parallel with the existing paper-native unweighted path. The weighted path uses `weighted_super_ratifies` from `cordiality.rs` to measure supermajority over bonded stake rather than distinct creator count, enabling PoS stake-based consensus without modifying the existing unweighted API.

## What Was Implemented

- `is_weighted_final_leader(blocklace, candidate, wavelength, bonds, leader_selection)` — checks whether a leader block achieved weighted super-ratification within its wave boundaries using bonded stake thresholds instead of creator cardinality

- `weighted_final_leader_for_wave(blocklace, wave, wavelength, bonds, leader_selection)` — resolves the unique leader block for a wave and checks whether it is weighted-final, returning `None` if not achieved

- `latest_weighted_final_leader(blocklace, wavelength, bonds, leader_selection)` — scans backward from the highest known wave and returns the most recent wave whose leader achieves weighted finality

## How Weighted Differs From Unweighted

| | Unweighted | Weighted |
|---|---|---|
| Function | `is_final_leader` | `is_weighted_final_leader` |
| Supermajority check | `super_ratifies(..., n, f)` | `weighted_super_ratifies(..., bonds)` |
| Threshold | Distinct creator count `> (n+f)/2` | Stake sum `> 2/3 total bonds` |
| Parameters | `n: usize, f: usize` | `bonds: &HashMap<NodeId, u64>` |
| Everything else | Identical | Identical |

The two paths can produce different results when high-stake validators are absent from the wave — unweighted may pass on creator count alone while weighted correctly fails because the ratifying validators do not hold enough economic stake.

## Dependencies on Existing Modules

### `consensus/cordiality.rs`
- `weighted_super_ratifies(blocklace, blocks, target, bonds)` — the stake-weighted two-level super-ratification check

### `consensus/finality.rs` (existing)
- `leader_block_for_wave` — reused directly, leader selection is the same regardless of weighting
- `is_final_leader` — unweighted baseline kept intact and untouched

### `consensus/wave.rs`
- `leader_blocks_of_wave` — leader block resolution
- `last_round_of_wave` — wave boundary computation
- `wave_of_round` — wave lookup for candidate block

### `consensus/round.rs`
- `blocks_at_depth` — witness block collection
- `depth` — candidate round computation


## What Was Intentionally Left Out

- The unweighted path is completely unchanged — `is_final_leader`, `final_leader_for_wave`, and `latest_final_leader` are untouched
- Leader selection strategy remains caller-provided via closure
- tau ordering — follows after finality is complete

## Crates Modified

- `crates/cordial-miners-core` only — `src/consensus/finality.rs`, `src/consensus/mod.rs`, and `tests/test_finality.rs`
- No changes to `cordial-f1r3node-adapter` or `cordial-f1r3space-adapter`
- Layering rules preserved — builds on `weighted_super_ratifies` from `consensus/cordiality.rs` without reimplementing anything

## Test Plan

- Ran `cargo test -p cordial-miners-core --test test_finality` —  all 19 tests pass
- Ran `cargo clippy -p cordial-miners-core --all-targets
  --all-features --no-deps -- -D warnings` — no warnings
- New tests cover:
  - Weighted finality passes when ratifiers hold > 2/3 stake
  - Weighted finality fails when ratifiers hold < 2/3 stake even though unweighted passes — the key divergence case
  - Both paths agree when stake is evenly distributed
  - Returns false for non-leader block
  - Returns false for unknown block
  - Wave-level query returns correct result
  - Latest scan returns highest weighted-final wave
  - Empty blocklace returns None

## Related Issues

- Closes #63 