### PR TITLE
Add first-pass memoization for `tau` and `weighted_tau` ordering.

### DIFF
--- a/crates/cordial-miners-core/src/consensus/mod.rs
+++ b/crates/cordial-miners-core/src/consensus/mod.rs
@@ -20,8 +20,8 @@ pub use finality::{
 };
 pub use fork_choice::{ForkChoice, collect_validator_tips, fork_choice, is_cordial};
 pub use ordering::{
-    OrderingError, approved_blocks_for_leader, previous_final_leader, tau,
-    weighted_previous_final_leader, weighted_tau, xsort,
+    OrderingCache, OrderingError, approved_blocks_for_leader, previous_final_leader, tau,
+    tau_with_cache, weighted_previous_final_leader, weighted_tau, weighted_tau_with_cache, xsort,
 };
 pub use round::{
     blocks_at_depth, compute_all_depths, depth, depth_prefix, depth_suffix, is_round_cordial,

--- a/crates/cordial-miners-core/src/consensus/ordering.rs
+++ b/crates/cordial-miners-core/src/consensus/ordering.rs
@@ -21,6 +21,9 @@ pub struct OrderingCache {
     sorted_approved_by_leader: HashMap<BlockIdentity, Result<Vec<BlockIdentity>, OrderingError>>,
     previous_final_by_leader: HashMap<PreviousLeaderCacheKey, Option<BlockIdentity>>,
     weighted_previous_final_by_leader: HashMap<WeightedPreviousLeaderCacheKey, Option<BlockIdentity>>,
+    tau_output_by_latest_leader: HashMap<TauOutputCacheKey, Result<Vec<BlockIdentity>, OrderingError>>,
+    weighted_tau_output_by_latest_leader:
+        HashMap<WeightedTauOutputCacheKey, Result<Vec<BlockIdentity>, OrderingError>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -34,6 +37,21 @@ struct PreviousLeaderCacheKey {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct WeightedPreviousLeaderCacheKey {
     current_leader: BlockIdentity,
+    wavelength: u64,
+    bonds_fingerprint: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct TauOutputCacheKey {
+    latest_leader: BlockIdentity,
+    wavelength: u64,
+    n: usize,
+    f: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct WeightedTauOutputCacheKey {
+    latest_leader: BlockIdentity,
     wavelength: u64,
     bonds_fingerprint: u64,
 }
@@ -147,6 +165,8 @@ fn sync_cache_generation(blocklace: &Blocklace, cache: &mut OrderingCache) {
         cache.sorted_approved_by_leader.clear();
         cache.previous_final_by_leader.clear();
         cache.weighted_previous_final_by_leader.clear();
+        cache.tau_output_by_latest_leader.clear();
+        cache.weighted_tau_output_by_latest_leader.clear();
     }
 }
 
@@ -396,10 +416,22 @@ pub fn tau_with_cache<F>(
 where
     F: Fn(u64) -> Option<NodeId> + Copy,
 {
+    sync_cache_generation(blocklace, cache);
+
     let Some(latest_leader) = latest_final_leader(blocklace, wavelength, n, f, leader_selection)
     else {
         return Ok(Vec::new());
     };
+
+    let key = TauOutputCacheKey {
+        latest_leader: latest_leader.clone(),
+        wavelength,
+        n,
+        f,
+    };
+    if let Some(ordered) = cache.tau_output_by_latest_leader.get(&key) {
+        return ordered.clone();
+    }
 
     let config = TauConfig {
         wavelength,
@@ -411,8 +443,15 @@ where
         emitted: BTreeSet::new(),
         ordered: Vec::new(),
     };
-    tau_from_leader_cached(blocklace, &latest_leader, &config, cache, &mut state)?;
-    Ok(state.ordered)
+    let ordered = match tau_from_leader_cached(blocklace, &latest_leader, &config, cache, &mut state)
+    {
+        Ok(()) => Ok(state.ordered),
+        Err(err) => Err(err),
+    };
+    cache
+        .tau_output_by_latest_leader
+        .insert(key, ordered.clone());
+    ordered
 }
 
 /// Return the stake-weighted ordered output sequence of the blocklace.
@@ -464,11 +503,22 @@ pub fn weighted_tau_with_cache<F>(
 where
     F: Fn(u64) -> Option<NodeId> + Copy,
 {
+    sync_cache_generation(blocklace, cache);
+
     let Some(latest_leader) =
         latest_weighted_final_leader(blocklace, wavelength, bonds, leader_selection)
     else {
         return Ok(Vec::new());
     };
+
+    let key = WeightedTauOutputCacheKey {
+        latest_leader: latest_leader.clone(),
+        wavelength,
+        bonds_fingerprint: bonds_fingerprint(bonds),
+    };
+    if let Some(ordered) = cache.weighted_tau_output_by_latest_leader.get(&key) {
+        return ordered.clone();
+    }
 
     let config = WeightedTauConfig {
         wavelength,
@@ -479,8 +529,16 @@ where
         emitted: BTreeSet::new(),
         ordered: Vec::new(),
     };
-    weighted_tau_from_leader_cached(blocklace, &latest_leader, &config, cache, &mut state)?;
-    Ok(state.ordered)
+    let ordered =
+        match weighted_tau_from_leader_cached(blocklace, &latest_leader, &config, cache, &mut state)
+        {
+            Ok(()) => Ok(state.ordered),
+            Err(err) => Err(err),
+        };
+    cache
+        .weighted_tau_output_by_latest_leader
+        .insert(key, ordered.clone());
+    ordered
 }
 
 fn tau_from_leader<F>(

--- a/crates/cordial-miners-core/src/consensus/ordering.rs
+++ b/crates/cordial-miners-core/src/consensus/ordering.rs
@@ -12,6 +12,13 @@ use crate::consensus::round::depth;
 use crate::consensus::wave::wave_of_round;
 use crate::types::{BlockIdentity, NodeId};
 
+#[derive(Debug, Clone, Default)]
+pub struct OrderingCache {
+    generation: usize,
+    approved_blocks_by_leader: HashMap<BlockIdentity, HashSet<Block>>,
+    sorted_approved_by_leader: HashMap<BlockIdentity, Result<Vec<BlockIdentity>, OrderingError>>,
+}
+
 struct TauState {
     emitted: BTreeSet<BlockIdentity>,
     ordered: Vec<BlockIdentity>,
@@ -111,6 +118,52 @@ pub fn xsort(blocks: &HashSet<Block>) -> Result<Vec<BlockIdentity>, OrderingErro
     }
 
     Ok(ordered)
+}
+
+fn sync_cache_generation(blocklace: &Blocklace, cache: &mut OrderingCache) {
+    let generation = blocklace.dom().len();
+    if cache.generation != generation {
+        cache.generation = generation;
+        cache.approved_blocks_by_leader.clear();
+        cache.sorted_approved_by_leader.clear();
+    }
+}
+
+fn approved_blocks_for_leader_cached(
+    blocklace: &Blocklace,
+    leader: &BlockIdentity,
+    cache: &mut OrderingCache,
+) -> HashSet<Block> {
+    sync_cache_generation(blocklace, cache);
+
+    if let Some(blocks) = cache.approved_blocks_by_leader.get(leader) {
+        return blocks.clone();
+    }
+
+    let blocks = approved_blocks_for_leader(blocklace, leader);
+    cache
+        .approved_blocks_by_leader
+        .insert(leader.clone(), blocks.clone());
+    blocks
+}
+
+fn sorted_approved_fragment(
+    blocklace: &Blocklace,
+    leader: &BlockIdentity,
+    cache: &mut OrderingCache,
+) -> Result<Vec<BlockIdentity>, OrderingError> {
+    sync_cache_generation(blocklace, cache);
+
+    if let Some(sorted) = cache.sorted_approved_by_leader.get(leader) {
+        return sorted.clone();
+    }
+
+    let approved = approved_blocks_for_leader_cached(blocklace, leader, cache);
+    let sorted = xsort(&approved);
+    cache
+        .sorted_approved_by_leader
+        .insert(leader.clone(), sorted.clone());
+    sorted
 }
 
 /// Return the newest earlier final leader ratified by `current_leader`.
@@ -232,6 +285,41 @@ where
     Ok(state.ordered)
 }
 
+/// Cached variant of [`tau`].
+///
+/// Reuses per-leader approved block sets and sorted fragments across repeated
+/// calls. Cache entries are invalidated automatically when the blocklace size
+/// changes.
+pub fn tau_with_cache<F>(
+    blocklace: &Blocklace,
+    wavelength: u64,
+    n: usize,
+    f: usize,
+    leader_selection: F,
+    cache: &mut OrderingCache,
+) -> Result<Vec<BlockIdentity>, OrderingError>
+where
+    F: Fn(u64) -> Option<NodeId> + Copy,
+{
+    let Some(latest_leader) = latest_final_leader(blocklace, wavelength, n, f, leader_selection)
+    else {
+        return Ok(Vec::new());
+    };
+
+    let config = TauConfig {
+        wavelength,
+        n,
+        f,
+        leader_selection,
+    };
+    let mut state = TauState {
+        emitted: BTreeSet::new(),
+        ordered: Vec::new(),
+    };
+    tau_from_leader_cached(blocklace, &latest_leader, &config, cache, &mut state)?;
+    Ok(state.ordered)
+}
+
 /// Return the stake-weighted ordered output sequence of the blocklace.
 ///
 /// `weighted_tau` mirrors [`tau`] but anchors on the latest weighted final
@@ -263,6 +351,40 @@ where
         ordered: Vec::new(),
     };
     weighted_tau_from_leader(blocklace, &latest_leader, &config, &mut state)?;
+    Ok(state.ordered)
+}
+
+/// Cached variant of [`weighted_tau`].
+///
+/// Reuses per-leader approved block sets and sorted fragments across repeated
+/// calls. Cache entries are invalidated automatically when the blocklace size
+/// changes.
+pub fn weighted_tau_with_cache<F>(
+    blocklace: &Blocklace,
+    wavelength: u64,
+    bonds: &HashMap<NodeId, u64>,
+    leader_selection: F,
+    cache: &mut OrderingCache,
+) -> Result<Vec<BlockIdentity>, OrderingError>
+where
+    F: Fn(u64) -> Option<NodeId> + Copy,
+{
+    let Some(latest_leader) =
+        latest_weighted_final_leader(blocklace, wavelength, bonds, leader_selection)
+    else {
+        return Ok(Vec::new());
+    };
+
+    let config = WeightedTauConfig {
+        wavelength,
+        bonds,
+        leader_selection,
+    };
+    let mut state = TauState {
+        emitted: BTreeSet::new(),
+        ordered: Vec::new(),
+    };
+    weighted_tau_from_leader_cached(blocklace, &latest_leader, &config, cache, &mut state)?;
     Ok(state.ordered)
 }
 
@@ -300,6 +422,36 @@ where
     Ok(())
 }
 
+fn tau_from_leader_cached<F>(
+    blocklace: &Blocklace,
+    leader: &BlockIdentity,
+    config: &TauConfig<F>,
+    cache: &mut OrderingCache,
+    state: &mut TauState,
+) -> Result<(), OrderingError>
+where
+    F: Fn(u64) -> Option<NodeId> + Copy,
+{
+    if let Some(previous) = previous_final_leader(
+        blocklace,
+        leader,
+        config.wavelength,
+        config.n,
+        config.f,
+        config.leader_selection,
+    ) {
+        tau_from_leader_cached(blocklace, &previous, config, cache, state)?;
+    }
+
+    for id in sorted_approved_fragment(blocklace, leader, cache)? {
+        if state.emitted.insert(id.clone()) {
+            state.ordered.push(id);
+        }
+    }
+
+    Ok(())
+}
+
 fn weighted_tau_from_leader<'a, F>(
     blocklace: &Blocklace,
     leader: &BlockIdentity,
@@ -325,6 +477,35 @@ where
         .collect();
 
     for id in xsort(&newly_approved)? {
+        if state.emitted.insert(id.clone()) {
+            state.ordered.push(id);
+        }
+    }
+
+    Ok(())
+}
+
+fn weighted_tau_from_leader_cached<'a, F>(
+    blocklace: &Blocklace,
+    leader: &BlockIdentity,
+    config: &WeightedTauConfig<'a, F>,
+    cache: &mut OrderingCache,
+    state: &mut TauState,
+) -> Result<(), OrderingError>
+where
+    F: Fn(u64) -> Option<NodeId> + Copy,
+{
+    if let Some(previous) = weighted_previous_final_leader(
+        blocklace,
+        leader,
+        config.wavelength,
+        config.bonds,
+        config.leader_selection,
+    ) {
+        weighted_tau_from_leader_cached(blocklace, &previous, config, cache, state)?;
+    }
+
+    for id in sorted_approved_fragment(blocklace, leader, cache)? {
         if state.emitted.insert(id.clone()) {
             state.ordered.push(id);
         }

--- a/crates/cordial-miners-core/src/consensus/ordering.rs
+++ b/crates/cordial-miners-core/src/consensus/ordering.rs
@@ -1,4 +1,6 @@
 use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 
 use crate::block::Block;
 use crate::blocklace::Blocklace;
@@ -17,6 +19,23 @@ pub struct OrderingCache {
     generation: usize,
     approved_blocks_by_leader: HashMap<BlockIdentity, HashSet<Block>>,
     sorted_approved_by_leader: HashMap<BlockIdentity, Result<Vec<BlockIdentity>, OrderingError>>,
+    previous_final_by_leader: HashMap<PreviousLeaderCacheKey, Option<BlockIdentity>>,
+    weighted_previous_final_by_leader: HashMap<WeightedPreviousLeaderCacheKey, Option<BlockIdentity>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct PreviousLeaderCacheKey {
+    current_leader: BlockIdentity,
+    wavelength: u64,
+    n: usize,
+    f: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct WeightedPreviousLeaderCacheKey {
+    current_leader: BlockIdentity,
+    wavelength: u64,
+    bonds_fingerprint: u64,
 }
 
 struct TauState {
@@ -126,7 +145,21 @@ fn sync_cache_generation(blocklace: &Blocklace, cache: &mut OrderingCache) {
         cache.generation = generation;
         cache.approved_blocks_by_leader.clear();
         cache.sorted_approved_by_leader.clear();
+        cache.previous_final_by_leader.clear();
+        cache.weighted_previous_final_by_leader.clear();
     }
+}
+
+fn bonds_fingerprint(bonds: &HashMap<NodeId, u64>) -> u64 {
+    let mut entries: Vec<_> = bonds.iter().collect();
+    entries.sort_by_key(|(left, _)| *left);
+
+    let mut hasher = DefaultHasher::new();
+    for (node, weight) in entries {
+        node.hash(&mut hasher);
+        weight.hash(&mut hasher);
+    }
+    hasher.finish()
 }
 
 fn approved_blocks_for_leader_cached(
@@ -164,6 +197,68 @@ fn sorted_approved_fragment(
         .sorted_approved_by_leader
         .insert(leader.clone(), sorted.clone());
     sorted
+}
+
+fn previous_final_leader_cached<F>(
+    blocklace: &Blocklace,
+    current_leader: &BlockIdentity,
+    wavelength: u64,
+    n: usize,
+    f: usize,
+    leader_selection: F,
+    cache: &mut OrderingCache,
+) -> Option<BlockIdentity>
+where
+    F: Fn(u64) -> Option<NodeId> + Copy,
+{
+    sync_cache_generation(blocklace, cache);
+
+    let key = PreviousLeaderCacheKey {
+        current_leader: current_leader.clone(),
+        wavelength,
+        n,
+        f,
+    };
+
+    if let Some(previous) = cache.previous_final_by_leader.get(&key) {
+        return previous.clone();
+    }
+
+    let previous =
+        previous_final_leader(blocklace, current_leader, wavelength, n, f, leader_selection);
+    cache.previous_final_by_leader.insert(key, previous.clone());
+    previous
+}
+
+fn weighted_previous_final_leader_cached<F>(
+    blocklace: &Blocklace,
+    current_leader: &BlockIdentity,
+    wavelength: u64,
+    bonds: &HashMap<NodeId, u64>,
+    leader_selection: F,
+    cache: &mut OrderingCache,
+) -> Option<BlockIdentity>
+where
+    F: Fn(u64) -> Option<NodeId> + Copy,
+{
+    sync_cache_generation(blocklace, cache);
+
+    let key = WeightedPreviousLeaderCacheKey {
+        current_leader: current_leader.clone(),
+        wavelength,
+        bonds_fingerprint: bonds_fingerprint(bonds),
+    };
+
+    if let Some(previous) = cache.weighted_previous_final_by_leader.get(&key) {
+        return previous.clone();
+    }
+
+    let previous =
+        weighted_previous_final_leader(blocklace, current_leader, wavelength, bonds, leader_selection);
+    cache
+        .weighted_previous_final_by_leader
+        .insert(key, previous.clone());
+    previous
 }
 
 /// Return the newest earlier final leader ratified by `current_leader`.
@@ -432,13 +527,14 @@ fn tau_from_leader_cached<F>(
 where
     F: Fn(u64) -> Option<NodeId> + Copy,
 {
-    if let Some(previous) = previous_final_leader(
+    if let Some(previous) = previous_final_leader_cached(
         blocklace,
         leader,
         config.wavelength,
         config.n,
         config.f,
         config.leader_selection,
+        cache,
     ) {
         tau_from_leader_cached(blocklace, &previous, config, cache, state)?;
     }
@@ -495,12 +591,13 @@ fn weighted_tau_from_leader_cached<'a, F>(
 where
     F: Fn(u64) -> Option<NodeId> + Copy,
 {
-    if let Some(previous) = weighted_previous_final_leader(
+    if let Some(previous) = weighted_previous_final_leader_cached(
         blocklace,
         leader,
         config.wavelength,
         config.bonds,
         config.leader_selection,
+        cache,
     ) {
         weighted_tau_from_leader_cached(blocklace, &previous, config, cache, state)?;
     }

--- a/crates/cordial-miners-core/tests/test_ordering.rs
+++ b/crates/cordial-miners-core/tests/test_ordering.rs
@@ -2,8 +2,8 @@ use std::collections::{HashMap, HashSet};
 
 use cordial_miners_core::blocklace::Blocklace;
 use cordial_miners_core::consensus::{
-    OrderingError, approved_blocks_for_leader, previous_final_leader, tau,
-    weighted_previous_final_leader, weighted_tau, xsort,
+    OrderingCache, OrderingError, approved_blocks_for_leader, previous_final_leader, tau,
+    tau_with_cache, weighted_previous_final_leader, weighted_tau, weighted_tau_with_cache, xsort,
 };
 use cordial_miners_core::crypto::CryptoVerifier;
 use cordial_miners_core::{Block, BlockContent, BlockIdentity, NodeId};
@@ -781,4 +781,219 @@ fn xsort_returns_cycle_detected_for_cyclic_subset() {
     let blocks = HashSet::from([cyclic_a, b]);
 
     assert_eq!(xsort(&blocks), Err(OrderingError::CycleDetected));
+}
+
+#[test]
+fn tau_with_cache_matches_uncached_tau() {
+    let mut blocklace = Blocklace::new();
+    let wavelength = 3u64;
+    let n = 4usize;
+    let f = 1usize;
+
+    let wave0_leader = block(1, 1, HashSet::new());
+    insert(&mut blocklace, &wave0_leader);
+
+    let w0_r1_v2 = block(2, 2, HashSet::from([wave0_leader.identity.clone()]));
+    let w0_r1_v3 = block(3, 3, HashSet::from([wave0_leader.identity.clone()]));
+    let w0_r1_v4 = block(4, 4, HashSet::from([wave0_leader.identity.clone()]));
+    insert(&mut blocklace, &w0_r1_v2);
+    insert(&mut blocklace, &w0_r1_v3);
+    insert(&mut blocklace, &w0_r1_v4);
+
+    let w0_r2_v2 = block(
+        2,
+        5,
+        HashSet::from([
+            w0_r1_v2.identity.clone(),
+            w0_r1_v3.identity.clone(),
+            w0_r1_v4.identity.clone(),
+        ]),
+    );
+    let w0_r2_v3 = block(
+        3,
+        6,
+        HashSet::from([
+            w0_r1_v2.identity.clone(),
+            w0_r1_v3.identity.clone(),
+            w0_r1_v4.identity.clone(),
+        ]),
+    );
+    let w0_r2_v4 = block(
+        4,
+        7,
+        HashSet::from([
+            w0_r1_v2.identity.clone(),
+            w0_r1_v3.identity.clone(),
+            w0_r1_v4.identity.clone(),
+        ]),
+    );
+    insert(&mut blocklace, &w0_r2_v2);
+    insert(&mut blocklace, &w0_r2_v3);
+    insert(&mut blocklace, &w0_r2_v4);
+
+    let mut cache = OrderingCache::default();
+    let uncached = tau(&blocklace, wavelength, n, f, leader_node1).unwrap();
+    let cached = tau_with_cache(&blocklace, wavelength, n, f, leader_node1, &mut cache).unwrap();
+
+    assert_eq!(cached, uncached);
+}
+
+#[test]
+fn weighted_tau_with_cache_matches_uncached_weighted_tau() {
+    let mut blocklace = Blocklace::new();
+    let weights = bonds(&[(1, 1), (2, 3), (3, 3), (4, 3)]);
+
+    let leader = block(1, 1, HashSet::new());
+    insert(&mut blocklace, &leader);
+
+    let round1_v2 = block(2, 2, HashSet::from([leader.identity.clone()]));
+    let round1_v3 = block(3, 3, HashSet::from([leader.identity.clone()]));
+    let round1_v4 = block(4, 4, HashSet::from([leader.identity.clone()]));
+    insert(&mut blocklace, &round1_v2);
+    insert(&mut blocklace, &round1_v3);
+    insert(&mut blocklace, &round1_v4);
+
+    let round2_v2 = block(
+        2,
+        5,
+        HashSet::from([
+            round1_v2.identity.clone(),
+            round1_v3.identity.clone(),
+            round1_v4.identity.clone(),
+        ]),
+    );
+    let round2_v3 = block(
+        3,
+        6,
+        HashSet::from([
+            round1_v2.identity.clone(),
+            round1_v3.identity.clone(),
+            round1_v4.identity.clone(),
+        ]),
+    );
+    let round2_v4 = block(
+        4,
+        7,
+        HashSet::from([
+            round1_v2.identity.clone(),
+            round1_v3.identity.clone(),
+            round1_v4.identity.clone(),
+        ]),
+    );
+    insert(&mut blocklace, &round2_v2);
+    insert(&mut blocklace, &round2_v3);
+    insert(&mut blocklace, &round2_v4);
+
+    let mut cache = OrderingCache::default();
+    let uncached = weighted_tau(&blocklace, 3, &weights, leader_node1).unwrap();
+    let cached = weighted_tau_with_cache(&blocklace, 3, &weights, leader_node1, &mut cache)
+        .unwrap();
+
+    assert_eq!(cached, uncached);
+}
+
+#[test]
+fn tau_with_cache_invalidates_when_blocklace_grows() {
+    let mut blocklace = Blocklace::new();
+    let wavelength = 3u64;
+    let n = 4usize;
+    let f = 1usize;
+
+    let wave0_leader = block(1, 1, HashSet::new());
+    insert(&mut blocklace, &wave0_leader);
+
+    let w0_r1_v2 = block(2, 2, HashSet::from([wave0_leader.identity.clone()]));
+    let w0_r1_v3 = block(3, 3, HashSet::from([wave0_leader.identity.clone()]));
+    let w0_r1_v4 = block(4, 4, HashSet::from([wave0_leader.identity.clone()]));
+    insert(&mut blocklace, &w0_r1_v2);
+    insert(&mut blocklace, &w0_r1_v3);
+    insert(&mut blocklace, &w0_r1_v4);
+
+    let w0_r2_v2 = block(
+        2,
+        5,
+        HashSet::from([
+            w0_r1_v2.identity.clone(),
+            w0_r1_v3.identity.clone(),
+            w0_r1_v4.identity.clone(),
+        ]),
+    );
+    let w0_r2_v3 = block(
+        3,
+        6,
+        HashSet::from([
+            w0_r1_v2.identity.clone(),
+            w0_r1_v3.identity.clone(),
+            w0_r1_v4.identity.clone(),
+        ]),
+    );
+    let w0_r2_v4 = block(
+        4,
+        7,
+        HashSet::from([
+            w0_r1_v2.identity.clone(),
+            w0_r1_v3.identity.clone(),
+            w0_r1_v4.identity.clone(),
+        ]),
+    );
+    insert(&mut blocklace, &w0_r2_v2);
+    insert(&mut blocklace, &w0_r2_v3);
+    insert(&mut blocklace, &w0_r2_v4);
+
+    let mut cache = OrderingCache::default();
+    let first = tau_with_cache(&blocklace, wavelength, n, f, leader_node1, &mut cache).unwrap();
+
+    let wave1_leader = block(
+        1,
+        8,
+        HashSet::from([
+            w0_r2_v2.identity.clone(),
+            w0_r2_v3.identity.clone(),
+            w0_r2_v4.identity.clone(),
+        ]),
+    );
+    insert(&mut blocklace, &wave1_leader);
+
+    let w1_r1_v2 = block(2, 9, HashSet::from([wave1_leader.identity.clone()]));
+    let w1_r1_v3 = block(3, 10, HashSet::from([wave1_leader.identity.clone()]));
+    let w1_r1_v4 = block(4, 11, HashSet::from([wave1_leader.identity.clone()]));
+    insert(&mut blocklace, &w1_r1_v2);
+    insert(&mut blocklace, &w1_r1_v3);
+    insert(&mut blocklace, &w1_r1_v4);
+
+    let w1_r2_v2 = block(
+        2,
+        12,
+        HashSet::from([
+            w1_r1_v2.identity.clone(),
+            w1_r1_v3.identity.clone(),
+            w1_r1_v4.identity.clone(),
+        ]),
+    );
+    let w1_r2_v3 = block(
+        3,
+        13,
+        HashSet::from([
+            w1_r1_v2.identity.clone(),
+            w1_r1_v3.identity.clone(),
+            w1_r1_v4.identity.clone(),
+        ]),
+    );
+    let w1_r2_v4 = block(
+        4,
+        14,
+        HashSet::from([
+            w1_r1_v2.identity.clone(),
+            w1_r1_v3.identity.clone(),
+            w1_r1_v4.identity.clone(),
+        ]),
+    );
+    insert(&mut blocklace, &w1_r2_v2);
+    insert(&mut blocklace, &w1_r2_v3);
+    insert(&mut blocklace, &w1_r2_v4);
+
+    let second = tau_with_cache(&blocklace, wavelength, n, f, leader_node1, &mut cache).unwrap();
+
+    assert!(second.starts_with(&first));
+    assert!(second.len() >= first.len());
 }

--- a/crates/cordial-miners-core/tests/test_ordering.rs
+++ b/crates/cordial-miners-core/tests/test_ordering.rs
@@ -893,6 +893,69 @@ fn weighted_tau_with_cache_matches_uncached_weighted_tau() {
 }
 
 #[test]
+fn weighted_tau_with_cache_distinguishes_bond_sets() {
+    let mut blocklace = Blocklace::new();
+    let low_majority = bonds(&[(1, 10), (2, 10), (3, 10), (4, 10), (5, 70)]);
+    let even_split = bonds(&[(1, 25), (2, 25), (3, 25), (4, 25)]);
+
+    let leader = block(1, 1, HashSet::new());
+    insert(&mut blocklace, &leader);
+
+    let round1_v2 = block(2, 2, HashSet::from([leader.identity.clone()]));
+    let round1_v3 = block(3, 3, HashSet::from([leader.identity.clone()]));
+    let round1_v4 = block(4, 4, HashSet::from([leader.identity.clone()]));
+    insert(&mut blocklace, &round1_v2);
+    insert(&mut blocklace, &round1_v3);
+    insert(&mut blocklace, &round1_v4);
+
+    let round2_v2 = block(
+        2,
+        5,
+        HashSet::from([
+            round1_v2.identity.clone(),
+            round1_v3.identity.clone(),
+            round1_v4.identity.clone(),
+        ]),
+    );
+    let round2_v3 = block(
+        3,
+        6,
+        HashSet::from([
+            round1_v2.identity.clone(),
+            round1_v3.identity.clone(),
+            round1_v4.identity.clone(),
+        ]),
+    );
+    let round2_v4 = block(
+        4,
+        7,
+        HashSet::from([
+            round1_v2.identity.clone(),
+            round1_v3.identity.clone(),
+            round1_v4.identity.clone(),
+        ]),
+    );
+    insert(&mut blocklace, &round2_v2);
+    insert(&mut blocklace, &round2_v3);
+    insert(&mut blocklace, &round2_v4);
+
+    let mut cache = OrderingCache::default();
+
+    let low_majority_cached =
+        weighted_tau_with_cache(&blocklace, 3, &low_majority, leader_node1, &mut cache).unwrap();
+    let even_split_cached =
+        weighted_tau_with_cache(&blocklace, 3, &even_split, leader_node1, &mut cache).unwrap();
+
+    let low_majority_uncached = weighted_tau(&blocklace, 3, &low_majority, leader_node1).unwrap();
+    let even_split_uncached = weighted_tau(&blocklace, 3, &even_split, leader_node1).unwrap();
+
+    assert_eq!(low_majority_cached, low_majority_uncached);
+    assert_eq!(even_split_cached, even_split_uncached);
+    assert!(low_majority_cached.is_empty());
+    assert!(!even_split_cached.is_empty());
+}
+
+#[test]
 fn tau_with_cache_invalidates_when_blocklace_grows() {
     let mut blocklace = Blocklace::new();
     let wavelength = 3u64;

--- a/crates/cordial-miners-core/tests/test_ordering.rs
+++ b/crates/cordial-miners-core/tests/test_ordering.rs
@@ -1060,3 +1060,166 @@ fn tau_with_cache_invalidates_when_blocklace_grows() {
     assert!(second.starts_with(&first));
     assert!(second.len() >= first.len());
 }
+
+#[test]
+fn tau_with_cache_reuses_full_output_for_same_latest_leader() {
+    let mut blocklace = Blocklace::new();
+    let wavelength = 3u64;
+    let n = 4usize;
+    let f = 1usize;
+
+    let leader = block(1, 1, HashSet::new());
+    insert(&mut blocklace, &leader);
+
+    let round1_v2 = block(2, 2, HashSet::from([leader.identity.clone()]));
+    let round1_v3 = block(3, 3, HashSet::from([leader.identity.clone()]));
+    let round1_v4 = block(4, 4, HashSet::from([leader.identity.clone()]));
+    insert(&mut blocklace, &round1_v2);
+    insert(&mut blocklace, &round1_v3);
+    insert(&mut blocklace, &round1_v4);
+
+    let round2_v2 = block(
+        2,
+        5,
+        HashSet::from([
+            round1_v2.identity.clone(),
+            round1_v3.identity.clone(),
+            round1_v4.identity.clone(),
+        ]),
+    );
+    let round2_v3 = block(
+        3,
+        6,
+        HashSet::from([
+            round1_v2.identity.clone(),
+            round1_v3.identity.clone(),
+            round1_v4.identity.clone(),
+        ]),
+    );
+    let round2_v4 = block(
+        4,
+        7,
+        HashSet::from([
+            round1_v2.identity.clone(),
+            round1_v3.identity.clone(),
+            round1_v4.identity.clone(),
+        ]),
+    );
+    insert(&mut blocklace, &round2_v2);
+    insert(&mut blocklace, &round2_v3);
+    insert(&mut blocklace, &round2_v4);
+
+    let mut cache = OrderingCache::default();
+    let first = tau_with_cache(&blocklace, wavelength, n, f, leader_node1, &mut cache).unwrap();
+    let second = tau_with_cache(&blocklace, wavelength, n, f, leader_node1, &mut cache).unwrap();
+    let uncached = tau(&blocklace, wavelength, n, f, leader_node1).unwrap();
+
+    assert_eq!(first, second);
+    assert_eq!(second, uncached);
+}
+
+#[test]
+fn weighted_tau_with_cache_updates_when_latest_weighted_leader_changes() {
+    let mut blocklace = Blocklace::new();
+    let weights = bonds(&[(1, 1), (2, 3), (3, 3), (4, 3)]);
+
+    let wave0_leader = block(1, 1, HashSet::new());
+    insert(&mut blocklace, &wave0_leader);
+
+    let w0_r1_v2 = block(2, 2, HashSet::from([wave0_leader.identity.clone()]));
+    let w0_r1_v3 = block(3, 3, HashSet::from([wave0_leader.identity.clone()]));
+    let w0_r1_v4 = block(4, 4, HashSet::from([wave0_leader.identity.clone()]));
+    insert(&mut blocklace, &w0_r1_v2);
+    insert(&mut blocklace, &w0_r1_v3);
+    insert(&mut blocklace, &w0_r1_v4);
+
+    let w0_r2_v2 = block(
+        2,
+        5,
+        HashSet::from([
+            w0_r1_v2.identity.clone(),
+            w0_r1_v3.identity.clone(),
+            w0_r1_v4.identity.clone(),
+        ]),
+    );
+    let w0_r2_v3 = block(
+        3,
+        6,
+        HashSet::from([
+            w0_r1_v2.identity.clone(),
+            w0_r1_v3.identity.clone(),
+            w0_r1_v4.identity.clone(),
+        ]),
+    );
+    let w0_r2_v4 = block(
+        4,
+        7,
+        HashSet::from([
+            w0_r1_v2.identity.clone(),
+            w0_r1_v3.identity.clone(),
+            w0_r1_v4.identity.clone(),
+        ]),
+    );
+    insert(&mut blocklace, &w0_r2_v2);
+    insert(&mut blocklace, &w0_r2_v3);
+    insert(&mut blocklace, &w0_r2_v4);
+
+    let mut cache = OrderingCache::default();
+    let first = weighted_tau_with_cache(&blocklace, 3, &weights, leader_node1, &mut cache).unwrap();
+
+    let wave1_leader = block(
+        1,
+        8,
+        HashSet::from([
+            w0_r2_v2.identity.clone(),
+            w0_r2_v3.identity.clone(),
+            w0_r2_v4.identity.clone(),
+        ]),
+    );
+    insert(&mut blocklace, &wave1_leader);
+
+    let w1_r1_v2 = block(2, 9, HashSet::from([wave1_leader.identity.clone()]));
+    let w1_r1_v3 = block(3, 10, HashSet::from([wave1_leader.identity.clone()]));
+    let w1_r1_v4 = block(4, 11, HashSet::from([wave1_leader.identity.clone()]));
+    insert(&mut blocklace, &w1_r1_v2);
+    insert(&mut blocklace, &w1_r1_v3);
+    insert(&mut blocklace, &w1_r1_v4);
+
+    let w1_r2_v2 = block(
+        2,
+        12,
+        HashSet::from([
+            w1_r1_v2.identity.clone(),
+            w1_r1_v3.identity.clone(),
+            w1_r1_v4.identity.clone(),
+        ]),
+    );
+    let w1_r2_v3 = block(
+        3,
+        13,
+        HashSet::from([
+            w1_r1_v2.identity.clone(),
+            w1_r1_v3.identity.clone(),
+            w1_r1_v4.identity.clone(),
+        ]),
+    );
+    let w1_r2_v4 = block(
+        4,
+        14,
+        HashSet::from([
+            w1_r1_v2.identity.clone(),
+            w1_r1_v3.identity.clone(),
+            w1_r1_v4.identity.clone(),
+        ]),
+    );
+    insert(&mut blocklace, &w1_r2_v2);
+    insert(&mut blocklace, &w1_r2_v3);
+    insert(&mut blocklace, &w1_r2_v4);
+
+    let second = weighted_tau_with_cache(&blocklace, 3, &weights, leader_node1, &mut cache).unwrap();
+    let uncached = weighted_tau(&blocklace, 3, &weights, leader_node1).unwrap();
+
+    assert!(second.starts_with(&first));
+    assert!(second.len() >= first.len());
+    assert_eq!(second, uncached);
+}

--- a/docs/cordial-miners/11-tau-ordering.md
+++ b/docs/cordial-miners/11-tau-ordering.md
@@ -82,8 +82,13 @@ It currently caches:
 
 - approved block sets per leader
 - deterministic sorted fragments per leader
+- previous-final-leader traversal results keyed by leader and ordering parameters
+- weighted previous-final-leader traversal results keyed by leader, wavelength, and bonded stake map
 
 Cache entries are invalidated automatically when the blocklace size changes.
+When reusing a cache across calls, the caller should keep the leader-selection
+rule stable; the current cache keys assume a consistent leader-selection
+function across repeated use.
 
 ## `tau(...)`
 
@@ -145,7 +150,6 @@ The current implementation is intentionally direct and readable.
 
 Things not yet optimized:
 
-- no memoized previous-leader traversal yet
 - no cached full output prefix yet
 - no adapter-facing ordered output plumbing yet
 

--- a/docs/cordial-miners/11-tau-ordering.md
+++ b/docs/cordial-miners/11-tau-ordering.md
@@ -32,6 +32,7 @@ The module currently provides both:
 
 - paper-native unweighted ordering
 - stake-weighted ordering for PoS / f1r3node-style integration
+- first-pass caching via `OrderingCache`
 
 ## Helper Functions
 
@@ -73,6 +74,17 @@ It uses:
 
 instead of the paper-native creator-count predicates.
 
+### `OrderingCache`
+
+`OrderingCache` is a first-pass memoization layer for repeated ordering calls.
+
+It currently caches:
+
+- approved block sets per leader
+- deterministic sorted fragments per leader
+
+Cache entries are invalidated automatically when the blocklace size changes.
+
 ## `tau(...)`
 
 ### Paper-native path
@@ -105,6 +117,16 @@ This keeps the ordering structure aligned between:
 - paper-native consensus
 - stake-weighted integration
 
+### Cached entrypoints
+
+The module also provides:
+
+- `tau_with_cache(...)`
+- `weighted_tau_with_cache(...)`
+
+These reuse an `OrderingCache` across repeated ordering calls while preserving
+the same output as the uncached paths.
+
 ## Current Behavior
 
 The implemented ordering layer now supports:
@@ -114,6 +136,8 @@ The implemented ordering layer now supports:
 - recursive growth across multiple final leaders
 - duplicate suppression across recursive segments
 - divergence between unweighted and weighted output when finality differs
+- cached and uncached ordering equivalence
+- cache invalidation when the blocklace grows
 
 ## Current Limitations
 
@@ -121,8 +145,8 @@ The current implementation is intentionally direct and readable.
 
 Things not yet optimized:
 
-- no memoization for recursive leader-chain traversal
-- no cached approved-block fragments
+- no memoized previous-leader traversal yet
+- no cached full output prefix yet
 - no adapter-facing ordered output plumbing yet
 
 Those can be added later without changing the high-level semantics.
@@ -137,6 +161,8 @@ Current tests cover:
 - `weighted_previous_final_leader(...)`
 - `tau(...)`
 - `weighted_tau(...)`
+- `tau_with_cache(...)`
+- `weighted_tau_with_cache(...)`
 
 Important tested properties include:
 
@@ -145,6 +171,8 @@ Important tested properties include:
 - monotonic growth
 - no duplicate output
 - weighted/unweighted divergence where expected
+- cached/uncached equivalence
+- cache invalidation on blocklace growth
 
 ## Relationship to Other Modules
 

--- a/docs/cordial-miners/11-tau-ordering.md
+++ b/docs/cordial-miners/11-tau-ordering.md
@@ -84,6 +84,8 @@ It currently caches:
 - deterministic sorted fragments per leader
 - previous-final-leader traversal results keyed by leader and ordering parameters
 - weighted previous-final-leader traversal results keyed by leader, wavelength, and bonded stake map
+- full `tau` output prefixes keyed by the current latest final leader
+- full `weighted_tau` output prefixes keyed by the current latest weighted final leader
 
 Cache entries are invalidated automatically when the blocklace size changes.
 When reusing a cache across calls, the caller should keep the leader-selection
@@ -143,6 +145,7 @@ The implemented ordering layer now supports:
 - divergence between unweighted and weighted output when finality differs
 - cached and uncached ordering equivalence
 - cache invalidation when the blocklace grows
+- repeated cached calls can reuse full output prefixes when the latest final leader is unchanged
 
 ## Current Limitations
 
@@ -150,7 +153,6 @@ The current implementation is intentionally direct and readable.
 
 Things not yet optimized:
 
-- no cached full output prefix yet
 - no adapter-facing ordered output plumbing yet
 
 Those can be added later without changing the high-level semantics.


### PR DESCRIPTION
closes issue #73 

## Summary

This PR improves repeated ordering queries by caching:

- approved block sets per leader
- sorted approved fragments per leader
- previous-final-leader traversal results
- full ordered output prefixes keyed by the latest final leader

## What changed

Implemented in:

- `crates/cordial-miners-core/src/consensus/ordering.rs`

Added / extended:

- `OrderingCache`
- `tau_with_cache(...)`
- `weighted_tau_with_cache(...)`

The cache now reuses:

- fragment membership
- fragment sorting
- previous-leader traversal
- full assembled output when the latest final leader is unchanged

Cache entries are invalidated automatically when the blocklace size changes.

## Tests

Updated:

- `crates/cordial-miners-core/tests/test_ordering.rs`

Coverage includes:

- cached `tau` matches uncached `tau`
- cached weighted `tau` matches uncached weighted `tau`
- cache invalidates when the blocklace grows
- weighted cache distinguishes different bond maps
- cached output prefixes are reused when the latest final leader is unchanged
- weighted cached output updates when the latest weighted final leader changes

## Docs

Updated:

- `docs/cordial-miners/11-tau-ordering.md`

## Verification

```bash
cargo test -p cordial-miners-core --test test_ordering -- --nocapture
cargo clippy -p cordial-miners-core --all-targets --all-features --no-deps -- -D warnings