### PR TITLE
 Ordered finalized output into the f1r3node adapter using the weighted `tau` path from the core consensus crate

### DIFF
--- a/crates/cordial-f1r3node-adapter/src/casper_adapter.rs
+++ b/crates/cordial-f1r3node-adapter/src/casper_adapter.rs
@@ -371,6 +371,19 @@ where
             &self.shard_id,
         )?)
     }
+
+    /// Return the current weighted ordered finalized output as block hashes.
+    ///
+    /// This is a convenience adapter-facing view over the snapshot's
+    /// `ordered_finalized_blocks` field, allowing callers to retrieve the
+    /// finalized ordered sequence without manually rebuilding and unpacking
+    /// a full snapshot.
+    pub async fn ordered_finalized_blocks(&self) -> Result<Vec<BlockHash>, CasperError> {
+        Ok(self
+            .build_current_snapshot()
+            .await?
+            .ordered_finalized_blocks)
+    }
 }
 
 #[async_trait]

--- a/crates/cordial-f1r3node-adapter/src/snapshot.rs
+++ b/crates/cordial-f1r3node-adapter/src/snapshot.rs
@@ -25,6 +25,7 @@
 //! | `dag.height_map`      | Indexed by each block's `CordialBlockPayload.state.block_number` |
 //! | `dag.block_number_map`| Same source, inverse lookup                           |
 //! | `last_finalized_block` | `latest_finalized_block_id(blocklace, bonds)`        |
+//! | `ordered_finalized_blocks` | `weighted_tau(blocklace, bonds)` as block hashes |
 //! | `lca`                  | `fork_choice(blocklace, bonds).lca`                  |
 //! | `tips`                 | `fork_choice(blocklace, bonds).tips`                 |
 //! | `parents`              | Translated from tips via `block_to_message`           |
@@ -60,7 +61,7 @@ use std::collections::{HashMap, HashSet};
 
 use cordial_miners_core::blocklace::Blocklace;
 use cordial_miners_core::consensus::{
-    collect_validator_tips, fork_choice, latest_weighted_final_leader,
+    collect_validator_tips, fork_choice, latest_weighted_final_leader, weighted_tau,
 };
 use cordial_miners_core::execution::{CordialBlockPayload, compute_deploys_in_scope};
 use cordial_miners_core::types::{BlockIdentity, NodeId};
@@ -132,6 +133,7 @@ pub struct OnChainCasperState {
 pub struct CasperSnapshot {
     pub dag: DagRepresentation,
     pub last_finalized_block: Vec<u8>,
+    pub ordered_finalized_blocks: Vec<Vec<u8>>,
     pub lca: Vec<u8>,
     pub tips: Vec<Vec<u8>>,
     pub parents: Vec<BlockMessage>,
@@ -323,6 +325,7 @@ pub fn build_snapshot(
     Ok(CasperSnapshot {
         dag,
         last_finalized_block: dag_lfb(&blocklace_lfb_from(blocklace, bonds)),
+        ordered_finalized_blocks: ordered_finalized_block_hashes(blocklace, bonds),
         lca: lca_bytes,
         tips: tips_vec,
         parents,
@@ -370,6 +373,29 @@ pub(crate) fn latest_finalized_block_id(
         let idx = usize::try_from(wave).ok()? % leaders.len();
         Some(leaders[idx].clone())
     })
+}
+
+pub(crate) fn ordered_finalized_block_hashes(
+    blocklace: &Blocklace,
+    bonds: &HashMap<NodeId, u64>,
+) -> Vec<Vec<u8>> {
+    let leaders = ordered_validators(bonds);
+
+    if leaders.is_empty() {
+        return Vec::new();
+    }
+
+    weighted_tau(blocklace, ES_WAVELENGTH, bonds, |wave| {
+        let idx = usize::try_from(wave).ok()? % leaders.len();
+        Some(leaders[idx].clone())
+    })
+    .map(|ordered| {
+        ordered
+            .into_iter()
+            .map(|id| id.content_hash.to_vec())
+            .collect()
+    })
+    .unwrap_or_default()
 }
 
 fn ordered_validators(bonds: &HashMap<NodeId, u64>) -> Vec<NodeId> {

--- a/crates/cordial-f1r3node-adapter/tests/test_casper_adapter.rs
+++ b/crates/cordial-f1r3node-adapter/tests/test_casper_adapter.rs
@@ -295,6 +295,21 @@ async fn get_snapshot_succeeds_on_empty_blocklace() {
     assert_eq!(snap.on_chain_state.bonds_map[&vec![1u8]], 100);
 }
 
+#[tokio::test]
+async fn ordered_finalized_blocks_is_empty_when_nothing_is_weighted_final() {
+    let adapter = CordialCasperAdapter::new_with_verifier(
+        bonds(&[(1, 100)]),
+        default_shard_conf(),
+        "root",
+        DeployPoolConfig::default(),
+        None,
+        MockVerifier,
+    );
+
+    let ordered = adapter.ordered_finalized_blocks().await.unwrap();
+    assert!(ordered.is_empty());
+}
+
 // ── validate ─────────────────────────────────────────────────────────────
 
 #[tokio::test]
@@ -478,6 +493,24 @@ async fn last_finalized_returns_genesis_once_supermajority_supports_it() {
     // f1r3node-style Blake2b block hash).
     assert_eq!(lfb_msg.block_hash, g_hash);
     assert_eq!(lfb_msg.sender, vec![1]);
+}
+
+#[tokio::test]
+async fn ordered_finalized_blocks_returns_weighted_tau_output() {
+    let adapter = CordialCasperAdapter::new_with_verifier(
+        bonds(&[(1, 100)]),
+        default_shard_conf(),
+        "root",
+        DeployPoolConfig::default(),
+        None,
+        MockVerifier,
+    );
+    let g = make_block(node(1), simple_payload(0), HashSet::new(), 1);
+    let g_hash = g.identity.content_hash.to_vec();
+    insert_through_adapter(&adapter, g).await;
+
+    let ordered = adapter.ordered_finalized_blocks().await.unwrap();
+    assert_eq!(ordered, vec![g_hash]);
 }
 
 // ── normalized_initial_fault ─────────────────────────────────────────────

--- a/crates/cordial-f1r3node-adapter/tests/test_snapshot.rs
+++ b/crates/cordial-f1r3node-adapter/tests/test_snapshot.rs
@@ -96,6 +96,7 @@ fn empty_blocklace_produces_empty_snapshot() {
     assert!(snap.dag.height_map.is_empty());
     assert!(snap.dag.last_finalized_block_hash.is_empty());
     assert!(snap.last_finalized_block.is_empty());
+    assert!(snap.ordered_finalized_blocks.is_empty());
     assert!(snap.lca.is_empty());
     assert!(snap.tips.is_empty());
     assert!(snap.parents.is_empty());
@@ -305,6 +306,16 @@ fn last_finalized_block_matches_finality_detector() {
         snap.last_finalized_block,
         snap.dag.last_finalized_block_hash
     );
+    assert!(!snap.ordered_finalized_blocks.is_empty());
+    assert!(
+        snap.ordered_finalized_blocks
+            .contains(&snap.last_finalized_block)
+    );
+    assert!(
+        snap.ordered_finalized_blocks
+            .iter()
+            .all(|hash| snap.dag.dag_set.contains(hash))
+    );
 
     // The LFB must be a real block in the lace
     assert!(snap.dag.dag_set.contains(&snap.last_finalized_block));
@@ -334,6 +345,7 @@ fn no_finality_when_single_validator_has_no_supermajority() {
 
     assert!(snap.dag.last_finalized_block_hash.is_empty());
     assert!(snap.last_finalized_block.is_empty());
+    assert!(snap.ordered_finalized_blocks.is_empty());
     assert!(snap.dag.finalized_blocks_set.is_empty());
 }
 

--- a/crates/cordial-miners-core/src/consensus/ordering.rs
+++ b/crates/cordial-miners-core/src/consensus/ordering.rs
@@ -16,7 +16,7 @@ use crate::types::{BlockIdentity, NodeId};
 
 #[derive(Debug, Clone, Default)]
 pub struct OrderingCache {
-    generation: usize,
+    dom_size_generation: usize,
     approved_blocks_by_leader: HashMap<BlockIdentity, HashSet<Block>>,
     sorted_approved_by_leader: HashMap<BlockIdentity, Result<Vec<BlockIdentity>, OrderingError>>,
     previous_final_by_leader: HashMap<PreviousLeaderCacheKey, Option<BlockIdentity>>,
@@ -32,6 +32,7 @@ struct PreviousLeaderCacheKey {
     wavelength: u64,
     n: usize,
     f: usize,
+    leader_selection_id: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -39,6 +40,7 @@ struct WeightedPreviousLeaderCacheKey {
     current_leader: BlockIdentity,
     wavelength: u64,
     bonds_fingerprint: u64,
+    leader_selection_id: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -47,6 +49,7 @@ struct TauOutputCacheKey {
     wavelength: u64,
     n: usize,
     f: usize,
+    leader_selection_id: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -54,6 +57,7 @@ struct WeightedTauOutputCacheKey {
     latest_leader: BlockIdentity,
     wavelength: u64,
     bonds_fingerprint: u64,
+    leader_selection_id: u64,
 }
 
 struct TauState {
@@ -68,6 +72,7 @@ where
     wavelength: u64,
     n: usize,
     f: usize,
+    leader_selection_id: u64,
     leader_selection: F,
 }
 
@@ -77,6 +82,7 @@ where
 {
     wavelength: u64,
     bonds: &'a HashMap<NodeId, u64>,
+    leader_selection_id: u64,
     leader_selection: F,
 }
 
@@ -158,9 +164,9 @@ pub fn xsort(blocks: &HashSet<Block>) -> Result<Vec<BlockIdentity>, OrderingErro
 }
 
 fn sync_cache_generation(blocklace: &Blocklace, cache: &mut OrderingCache) {
-    let generation = blocklace.dom().len();
-    if cache.generation != generation {
-        cache.generation = generation;
+    let dom_size_generation = blocklace.dom().len();
+    if cache.dom_size_generation != dom_size_generation {
+        cache.dom_size_generation = dom_size_generation;
         cache.approved_blocks_by_leader.clear();
         cache.sorted_approved_by_leader.clear();
         cache.previous_final_by_leader.clear();
@@ -222,10 +228,7 @@ fn sorted_approved_fragment(
 fn previous_final_leader_cached<F>(
     blocklace: &Blocklace,
     current_leader: &BlockIdentity,
-    wavelength: u64,
-    n: usize,
-    f: usize,
-    leader_selection: F,
+    config: &TauConfig<F>,
     cache: &mut OrderingCache,
 ) -> Option<BlockIdentity>
 where
@@ -235,17 +238,24 @@ where
 
     let key = PreviousLeaderCacheKey {
         current_leader: current_leader.clone(),
-        wavelength,
-        n,
-        f,
+        wavelength: config.wavelength,
+        n: config.n,
+        f: config.f,
+        leader_selection_id: config.leader_selection_id,
     };
 
     if let Some(previous) = cache.previous_final_by_leader.get(&key) {
         return previous.clone();
     }
 
-    let previous =
-        previous_final_leader(blocklace, current_leader, wavelength, n, f, leader_selection);
+    let previous = previous_final_leader(
+        blocklace,
+        current_leader,
+        config.wavelength,
+        config.n,
+        config.f,
+        config.leader_selection,
+    );
     cache.previous_final_by_leader.insert(key, previous.clone());
     previous
 }
@@ -253,9 +263,7 @@ where
 fn weighted_previous_final_leader_cached<F>(
     blocklace: &Blocklace,
     current_leader: &BlockIdentity,
-    wavelength: u64,
-    bonds: &HashMap<NodeId, u64>,
-    leader_selection: F,
+    config: &WeightedTauConfig<'_, F>,
     cache: &mut OrderingCache,
 ) -> Option<BlockIdentity>
 where
@@ -265,16 +273,22 @@ where
 
     let key = WeightedPreviousLeaderCacheKey {
         current_leader: current_leader.clone(),
-        wavelength,
-        bonds_fingerprint: bonds_fingerprint(bonds),
+        wavelength: config.wavelength,
+        bonds_fingerprint: bonds_fingerprint(config.bonds),
+        leader_selection_id: config.leader_selection_id,
     };
 
     if let Some(previous) = cache.weighted_previous_final_by_leader.get(&key) {
         return previous.clone();
     }
 
-    let previous =
-        weighted_previous_final_leader(blocklace, current_leader, wavelength, bonds, leader_selection);
+    let previous = weighted_previous_final_leader(
+        blocklace,
+        current_leader,
+        config.wavelength,
+        config.bonds,
+        config.leader_selection,
+    );
     cache
         .weighted_previous_final_by_leader
         .insert(key, previous.clone());
@@ -390,6 +404,7 @@ where
         wavelength,
         n,
         f,
+        leader_selection_id: 0,
         leader_selection,
     };
     let mut state = TauState {
@@ -410,6 +425,7 @@ pub fn tau_with_cache<F>(
     wavelength: u64,
     n: usize,
     f: usize,
+    leader_selection_id: u64,
     leader_selection: F,
     cache: &mut OrderingCache,
 ) -> Result<Vec<BlockIdentity>, OrderingError>
@@ -428,6 +444,7 @@ where
         wavelength,
         n,
         f,
+        leader_selection_id,
     };
     if let Some(ordered) = cache.tau_output_by_latest_leader.get(&key) {
         return ordered.clone();
@@ -437,14 +454,20 @@ where
         wavelength,
         n,
         f,
+        leader_selection_id,
         leader_selection,
     };
     let mut state = TauState {
         emitted: BTreeSet::new(),
         ordered: Vec::new(),
     };
-    let ordered = match tau_from_leader_cached(blocklace, &latest_leader, &config, cache, &mut state)
-    {
+    let ordered = match tau_from_leader_cached(
+        blocklace,
+        &latest_leader,
+        &config,
+        cache,
+        &mut state,
+    ) {
         Ok(()) => Ok(state.ordered),
         Err(err) => Err(err),
     };
@@ -478,6 +501,7 @@ where
     let config = WeightedTauConfig {
         wavelength,
         bonds,
+        leader_selection_id: 0,
         leader_selection,
     };
     let mut state = TauState {
@@ -497,6 +521,7 @@ pub fn weighted_tau_with_cache<F>(
     blocklace: &Blocklace,
     wavelength: u64,
     bonds: &HashMap<NodeId, u64>,
+    leader_selection_id: u64,
     leader_selection: F,
     cache: &mut OrderingCache,
 ) -> Result<Vec<BlockIdentity>, OrderingError>
@@ -515,6 +540,7 @@ where
         latest_leader: latest_leader.clone(),
         wavelength,
         bonds_fingerprint: bonds_fingerprint(bonds),
+        leader_selection_id,
     };
     if let Some(ordered) = cache.weighted_tau_output_by_latest_leader.get(&key) {
         return ordered.clone();
@@ -523,18 +549,23 @@ where
     let config = WeightedTauConfig {
         wavelength,
         bonds,
+        leader_selection_id,
         leader_selection,
     };
     let mut state = TauState {
         emitted: BTreeSet::new(),
         ordered: Vec::new(),
     };
-    let ordered =
-        match weighted_tau_from_leader_cached(blocklace, &latest_leader, &config, cache, &mut state)
-        {
-            Ok(()) => Ok(state.ordered),
-            Err(err) => Err(err),
-        };
+    let ordered = match weighted_tau_from_leader_cached(
+        blocklace,
+        &latest_leader,
+        &config,
+        cache,
+        &mut state,
+    ) {
+        Ok(()) => Ok(state.ordered),
+        Err(err) => Err(err),
+    };
     cache
         .weighted_tau_output_by_latest_leader
         .insert(key, ordered.clone());
@@ -585,15 +616,7 @@ fn tau_from_leader_cached<F>(
 where
     F: Fn(u64) -> Option<NodeId> + Copy,
 {
-    if let Some(previous) = previous_final_leader_cached(
-        blocklace,
-        leader,
-        config.wavelength,
-        config.n,
-        config.f,
-        config.leader_selection,
-        cache,
-    ) {
+    if let Some(previous) = previous_final_leader_cached(blocklace, leader, config, cache) {
         tau_from_leader_cached(blocklace, &previous, config, cache, state)?;
     }
 
@@ -649,14 +672,8 @@ fn weighted_tau_from_leader_cached<'a, F>(
 where
     F: Fn(u64) -> Option<NodeId> + Copy,
 {
-    if let Some(previous) = weighted_previous_final_leader_cached(
-        blocklace,
-        leader,
-        config.wavelength,
-        config.bonds,
-        config.leader_selection,
-        cache,
-    ) {
+    if let Some(previous) = weighted_previous_final_leader_cached(blocklace, leader, config, cache)
+    {
         weighted_tau_from_leader_cached(blocklace, &previous, config, cache, state)?;
     }
 

--- a/crates/cordial-miners-core/tests/test_ordering.rs
+++ b/crates/cordial-miners-core/tests/test_ordering.rs
@@ -56,6 +56,10 @@ fn leader_node1(_wave: u64) -> Option<NodeId> {
     Some(node(1))
 }
 
+fn leader_node2(_wave: u64) -> Option<NodeId> {
+    Some(node(2))
+}
+
 fn bonds(entries: &[(u8, u64)]) -> HashMap<NodeId, u64> {
     entries
         .iter()
@@ -833,7 +837,8 @@ fn tau_with_cache_matches_uncached_tau() {
 
     let mut cache = OrderingCache::default();
     let uncached = tau(&blocklace, wavelength, n, f, leader_node1).unwrap();
-    let cached = tau_with_cache(&blocklace, wavelength, n, f, leader_node1, &mut cache).unwrap();
+    let cached =
+        tau_with_cache(&blocklace, wavelength, n, f, 1, leader_node1, &mut cache).unwrap();
 
     assert_eq!(cached, uncached);
 }
@@ -886,7 +891,7 @@ fn weighted_tau_with_cache_matches_uncached_weighted_tau() {
 
     let mut cache = OrderingCache::default();
     let uncached = weighted_tau(&blocklace, 3, &weights, leader_node1).unwrap();
-    let cached = weighted_tau_with_cache(&blocklace, 3, &weights, leader_node1, &mut cache)
+    let cached = weighted_tau_with_cache(&blocklace, 3, &weights, 1, leader_node1, &mut cache)
         .unwrap();
 
     assert_eq!(cached, uncached);
@@ -942,9 +947,11 @@ fn weighted_tau_with_cache_distinguishes_bond_sets() {
     let mut cache = OrderingCache::default();
 
     let low_majority_cached =
-        weighted_tau_with_cache(&blocklace, 3, &low_majority, leader_node1, &mut cache).unwrap();
+        weighted_tau_with_cache(&blocklace, 3, &low_majority, 1, leader_node1, &mut cache)
+            .unwrap();
     let even_split_cached =
-        weighted_tau_with_cache(&blocklace, 3, &even_split, leader_node1, &mut cache).unwrap();
+        weighted_tau_with_cache(&blocklace, 3, &even_split, 1, leader_node1, &mut cache)
+            .unwrap();
 
     let low_majority_uncached = weighted_tau(&blocklace, 3, &low_majority, leader_node1).unwrap();
     let even_split_uncached = weighted_tau(&blocklace, 3, &even_split, leader_node1).unwrap();
@@ -1004,7 +1011,8 @@ fn tau_with_cache_invalidates_when_blocklace_grows() {
     insert(&mut blocklace, &w0_r2_v4);
 
     let mut cache = OrderingCache::default();
-    let first = tau_with_cache(&blocklace, wavelength, n, f, leader_node1, &mut cache).unwrap();
+    let first =
+        tau_with_cache(&blocklace, wavelength, n, f, 1, leader_node1, &mut cache).unwrap();
 
     let wave1_leader = block(
         1,
@@ -1055,7 +1063,8 @@ fn tau_with_cache_invalidates_when_blocklace_grows() {
     insert(&mut blocklace, &w1_r2_v3);
     insert(&mut blocklace, &w1_r2_v4);
 
-    let second = tau_with_cache(&blocklace, wavelength, n, f, leader_node1, &mut cache).unwrap();
+    let second =
+        tau_with_cache(&blocklace, wavelength, n, f, 1, leader_node1, &mut cache).unwrap();
 
     assert!(second.starts_with(&first));
     assert!(second.len() >= first.len());
@@ -1110,12 +1119,75 @@ fn tau_with_cache_reuses_full_output_for_same_latest_leader() {
     insert(&mut blocklace, &round2_v4);
 
     let mut cache = OrderingCache::default();
-    let first = tau_with_cache(&blocklace, wavelength, n, f, leader_node1, &mut cache).unwrap();
-    let second = tau_with_cache(&blocklace, wavelength, n, f, leader_node1, &mut cache).unwrap();
+    let first =
+        tau_with_cache(&blocklace, wavelength, n, f, 1, leader_node1, &mut cache).unwrap();
+    let second =
+        tau_with_cache(&blocklace, wavelength, n, f, 1, leader_node1, &mut cache).unwrap();
     let uncached = tau(&blocklace, wavelength, n, f, leader_node1).unwrap();
 
     assert_eq!(first, second);
     assert_eq!(second, uncached);
+}
+
+#[test]
+fn tau_with_cache_distinguishes_leader_selection_identity() {
+    let mut blocklace = Blocklace::new();
+    let wavelength = 3u64;
+    let n = 4usize;
+    let f = 1usize;
+
+    let wave0_leader = block(1, 1, HashSet::new());
+    insert(&mut blocklace, &wave0_leader);
+
+    let w0_r1_v2 = block(2, 2, HashSet::from([wave0_leader.identity.clone()]));
+    let w0_r1_v3 = block(3, 3, HashSet::from([wave0_leader.identity.clone()]));
+    let w0_r1_v4 = block(4, 4, HashSet::from([wave0_leader.identity.clone()]));
+    insert(&mut blocklace, &w0_r1_v2);
+    insert(&mut blocklace, &w0_r1_v3);
+    insert(&mut blocklace, &w0_r1_v4);
+
+    let w0_r2_v2 = block(
+        2,
+        5,
+        HashSet::from([
+            w0_r1_v2.identity.clone(),
+            w0_r1_v3.identity.clone(),
+            w0_r1_v4.identity.clone(),
+        ]),
+    );
+    let w0_r2_v3 = block(
+        3,
+        6,
+        HashSet::from([
+            w0_r1_v2.identity.clone(),
+            w0_r1_v3.identity.clone(),
+            w0_r1_v4.identity.clone(),
+        ]),
+    );
+    let w0_r2_v4 = block(
+        4,
+        7,
+        HashSet::from([
+            w0_r1_v2.identity.clone(),
+            w0_r1_v3.identity.clone(),
+            w0_r1_v4.identity.clone(),
+        ]),
+    );
+    insert(&mut blocklace, &w0_r2_v2);
+    insert(&mut blocklace, &w0_r2_v3);
+    insert(&mut blocklace, &w0_r2_v4);
+
+    let mut cache = OrderingCache::default();
+    let first = tau_with_cache(&blocklace, wavelength, n, f, 1, leader_node1, &mut cache).unwrap();
+    let second =
+        tau_with_cache(&blocklace, wavelength, n, f, 2, leader_node2, &mut cache).unwrap();
+
+    let uncached_first = tau(&blocklace, wavelength, n, f, leader_node1).unwrap();
+    let uncached_second = tau(&blocklace, wavelength, n, f, leader_node2).unwrap();
+
+    assert_eq!(first, uncached_first);
+    assert_eq!(second, uncached_second);
+    assert_ne!(first, second);
 }
 
 #[test]
@@ -1165,7 +1237,8 @@ fn weighted_tau_with_cache_updates_when_latest_weighted_leader_changes() {
     insert(&mut blocklace, &w0_r2_v4);
 
     let mut cache = OrderingCache::default();
-    let first = weighted_tau_with_cache(&blocklace, 3, &weights, leader_node1, &mut cache).unwrap();
+    let first =
+        weighted_tau_with_cache(&blocklace, 3, &weights, 1, leader_node1, &mut cache).unwrap();
 
     let wave1_leader = block(
         1,
@@ -1216,7 +1289,8 @@ fn weighted_tau_with_cache_updates_when_latest_weighted_leader_changes() {
     insert(&mut blocklace, &w1_r2_v3);
     insert(&mut blocklace, &w1_r2_v4);
 
-    let second = weighted_tau_with_cache(&blocklace, 3, &weights, leader_node1, &mut cache).unwrap();
+    let second =
+        weighted_tau_with_cache(&blocklace, 3, &weights, 1, leader_node1, &mut cache).unwrap();
     let uncached = weighted_tau(&blocklace, 3, &weights, leader_node1).unwrap();
 
     assert!(second.starts_with(&first));

--- a/docs/cordial-miners/11-tau-ordering.md
+++ b/docs/cordial-miners/11-tau-ordering.md
@@ -88,9 +88,10 @@ It currently caches:
 - full `weighted_tau` output prefixes keyed by the current latest weighted final leader
 
 Cache entries are invalidated automatically when the blocklace size changes.
-When reusing a cache across calls, the caller should keep the leader-selection
-rule stable; the current cache keys assume a consistent leader-selection
-function across repeated use.
+When reusing a cache across calls, the caller must pass a stable
+`leader_selection_id` describing the leader-selection policy in use.
+Cache keys include that identifier so results from different selector
+policies are not reused accidentally.
 
 ## `tau(...)`
 
@@ -132,7 +133,8 @@ The module also provides:
 - `weighted_tau_with_cache(...)`
 
 These reuse an `OrderingCache` across repeated ordering calls while preserving
-the same output as the uncached paths.
+the same output as the uncached paths. Callers are responsible for providing a
+stable `leader_selection_id` for repeated uses of the same selector policy.
 
 ## Current Behavior
 


### PR DESCRIPTION
closes issue  #74 also fixes [comment](https://github.com/iCog-Labs-Dev/cordial-f1r3node/pull/75#discussion_r3271068161) 

## Summary

This PR integrates ordered finalized output into the f1r3node adapter using the weighted `tau` path from the core consensus crate.

The main change is adapter-facing: consumers can now access the weighted ordered finalized sequence both through snapshots and through a direct adapter helper.

As part of this integration, the core ordering cache was also tightened so repeated `tau` / `weighted_tau` calls remain correct and efficient.

## What changed

### f1r3node adapter integration

Updated:

- `crates/cordial-f1r3node-adapter/src/snapshot.rs`
- `crates/cordial-f1r3node-adapter/src/casper_adapter.rs`

Added:

- `CasperSnapshot.ordered_finalized_blocks`
- snapshot-side computation of ordered finalized output via `weighted_tau(...)`
- `ordered_finalized_blocks()` on `CordialCasperAdapter`

This makes the weighted ordered finalized sequence available to adapter consumers without requiring them to reconstruct it manually from core consensus state.

### Secondary: core ordering cache improvements

Updated:

- `crates/cordial-miners-core/src/consensus/ordering.rs`
- `docs/cordial-miners/11-tau-ordering.md`

The cache now supports:

- approved block set reuse
- sorted fragment reuse
- previous-leader traversal reuse
- full ordered output prefix reuse

It also includes an explicit `leader_selection_id` in cache keys so cached ordering results remain correct if the leader-selection policy changes.

## Tests

Updated:

- `crates/cordial-f1r3node-adapter/tests/test_snapshot.rs`
- `crates/cordial-f1r3node-adapter/tests/test_casper_adapter.rs`
- `crates/cordial-miners-core/tests/test_ordering.rs`

Coverage includes:

- ordered finalized output in snapshots
- direct adapter access to ordered finalized output
- empty ordered output when no weighted finality exists
- weighted ordered output once finality holds
- cache correctness across blocklace growth, bond-map changes, and leader-selection changes

## Verification

```bash
cargo test -p cordial-f1r3node-adapter --test test_snapshot -- --nocapture
cargo test -p cordial-f1r3node-adapter --test test_casper_adapter -- --nocapture
cargo check -p cordial-f1r3node-adapter
cargo test -p cordial-miners-core --test test_ordering -- --nocapture
cargo clippy -p cordial-miners-core --all-targets --all-features --no-deps -- -D warnings