### PR TITLE
Add Checkpoint DAG pruning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,6 +429,7 @@ dependencies = [
  "hex",
  "imbl",
  "lz4_flex",
+ "metrics",
  "models",
  "once_cell",
  "proptest",
@@ -488,7 +489,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "lz4_flex",
- "metrics 0.23.1",
+ "metrics",
  "models",
  "num_cpus",
  "proptest",
@@ -622,7 +623,7 @@ dependencies = [
  "hyper 1.9.0",
  "igd-next",
  "local-ip-address",
- "metrics 0.23.1",
+ "metrics",
  "models",
  "p256",
  "paste",
@@ -648,6 +649,18 @@ dependencies = [
  "url",
  "webpki",
  "x509-parser",
+]
+
+[[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1123,6 +1136,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -2259,16 +2278,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "metrics"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
-dependencies = [
- "ahash",
- "portable-atomic",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3249,9 +3258,12 @@ dependencies = [
 name = "rholang"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "async-trait",
  "bincode",
  "cc",
  "clap",
+ "console",
  "crypto",
  "dotenv",
  "futures",
@@ -3260,7 +3272,7 @@ dependencies = [
  "itertools",
  "k256",
  "lazy_static",
- "metrics 0.24.3",
+ "metrics",
  "models",
  "num-bigint",
  "num-integer",
@@ -3361,7 +3373,7 @@ dependencies = [
  "hex",
  "itertools",
  "lazy_static",
- "metrics 0.23.1",
+ "metrics",
  "monadic",
  "multiset",
  "once_cell",
@@ -3728,7 +3740,7 @@ dependencies = [
  "http-body-util",
  "indexmap",
  "lz4_flex",
- "metrics 0.24.3",
+ "metrics",
  "proptest",
  "prost",
  "rand 0.9.4",
@@ -3836,7 +3848,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -4443,6 +4454,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"

--- a/crates/cordial-miners-core/src/blocklace.rs
+++ b/crates/cordial-miners-core/src/blocklace.rs
@@ -12,6 +12,9 @@ use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 ///  - CHAIN: all blocks from a correct node are totally ordered under  ≺
 pub struct Blocklace {
     pub(crate) blocks: HashMap<BlockIdentity, BlockContent>,
+    pub(crate) checkpoint: Option<BlockIdentity>,
+    pub(crate) checkpoint_depth: Option<u64>,
+    pub(crate) checkpoint_order_prefix: Vec<BlockIdentity>,
 }
 
 // Construction
@@ -19,6 +22,9 @@ impl Blocklace {
     pub fn new() -> Self {
         Self {
             blocks: HashMap::new(),
+            checkpoint: None,
+            checkpoint_depth: None,
+            checkpoint_order_prefix: Vec::new(),
         }
     }
 }
@@ -51,6 +57,28 @@ impl Blocklace {
     /// dom(B) - the set of all known block identities
     pub fn dom(&self) -> HashSet<&BlockIdentity> {
         self.blocks.keys().collect()
+    }
+
+    /// The latest finalized block being treated as the in-memory genesis
+    /// boundary, if checkpoint pruning has run.
+    pub fn checkpoint(&self) -> Option<&BlockIdentity> {
+        self.checkpoint.as_ref()
+    }
+
+    /// Logical depth of the checkpoint in the original, unpruned DAG.
+    ///
+    /// Consensus depth remains monotonic after pruning: descendants of the
+    /// checkpoint continue from this depth instead of restarting at zero.
+    pub fn checkpoint_depth(&self) -> Option<u64> {
+        self.checkpoint_depth
+    }
+
+    pub(crate) fn checkpoint_order_prefix(&self) -> &[BlockIdentity] {
+        &self.checkpoint_order_prefix
+    }
+
+    pub(crate) fn is_checkpoint_boundary(&self, id: &BlockIdentity) -> bool {
+        self.checkpoint.as_ref() == Some(id)
     }
 }
 
@@ -93,11 +121,12 @@ impl Blocklace {
     // }
 
     pub fn is_closed(&self) -> bool {
-        self.blocks.values().all(|content| {
-            content
-                .predecessors
-                .iter()
-                .all(|pred_id| self.blocks.contains_key(pred_id))
+        self.blocks.iter().all(|(id, content)| {
+            self.is_checkpoint_boundary(id)
+                || content
+                    .predecessors
+                    .iter()
+                    .all(|pred_id| self.blocks.contains_key(pred_id))
         })
     }
 }
@@ -123,9 +152,13 @@ impl Blocklace {
         let mut queue: Vec<BlockIdentity> = vec![id.clone()];
 
         while let Some(current_id) = queue.pop() {
+            if self.is_checkpoint_boundary(&current_id) {
+                continue;
+            }
+
             if let Some(content) = self.content(&current_id) {
                 for pred_id in &content.predecessors {
-                    if visited.insert(pred_id.clone()) {
+                    if self.blocks.contains_key(pred_id) && visited.insert(pred_id.clone()) {
                         queue.push(pred_id.clone());
                     }
                 }
@@ -138,15 +171,23 @@ impl Blocklace {
         let mut visited = BTreeSet::new();
         let mut queue = VecDeque::new();
 
+        if !self.blocks.contains_key(from) {
+            return visited;
+        }
+
         // Start from the block itself (inclusive closure)
         queue.push_back(from.clone());
         visited.insert(from.clone());
 
         while let Some(current_id) = queue.pop_front() {
+            if self.is_checkpoint_boundary(&current_id) {
+                continue;
+            }
+
             if let Some(content) = self.content(&current_id) {
                 for pred_id in &content.predecessors {
                     // BTreeSet.insert returns false if the item was already present
-                    if visited.insert(pred_id.clone()) {
+                    if self.blocks.contains_key(pred_id) && visited.insert(pred_id.clone()) {
                         queue.push_back(pred_id.clone());
                     }
                 }

--- a/crates/cordial-miners-core/src/blocklace.rs
+++ b/crates/cordial-miners-core/src/blocklace.rs
@@ -15,6 +15,7 @@ pub struct Blocklace {
     pub(crate) checkpoint: Option<BlockIdentity>,
     pub(crate) checkpoint_depth: Option<u64>,
     pub(crate) checkpoint_order_prefix: Vec<BlockIdentity>,
+    pub(crate) checkpoint_weighted_order_prefix: Vec<BlockIdentity>,
 }
 
 // Construction
@@ -25,6 +26,7 @@ impl Blocklace {
             checkpoint: None,
             checkpoint_depth: None,
             checkpoint_order_prefix: Vec::new(),
+            checkpoint_weighted_order_prefix: Vec::new(),
         }
     }
 }
@@ -75,6 +77,10 @@ impl Blocklace {
 
     pub(crate) fn checkpoint_order_prefix(&self) -> &[BlockIdentity] {
         &self.checkpoint_order_prefix
+    }
+
+    pub(crate) fn checkpoint_weighted_order_prefix(&self) -> &[BlockIdentity] {
+        &self.checkpoint_weighted_order_prefix
     }
 
     pub(crate) fn is_checkpoint_boundary(&self, id: &BlockIdentity) -> bool {

--- a/crates/cordial-miners-core/src/consensus/mod.rs
+++ b/crates/cordial-miners-core/src/consensus/mod.rs
@@ -3,6 +3,7 @@ pub mod cordiality;
 pub mod finality;
 pub mod fork_choice;
 pub mod ordering;
+pub mod pruning;
 pub mod round;
 pub mod validation;
 pub mod wave;
@@ -23,6 +24,7 @@ pub use ordering::{
     OrderingCache, OrderingError, approved_blocks_for_leader, previous_final_leader, tau,
     tau_with_cache, weighted_previous_final_leader, weighted_tau, weighted_tau_with_cache, xsort,
 };
+pub use pruning::{CheckpointGc, PruneError, PruneReport, checkpoint_after_finality};
 pub use round::{
     blocks_at_depth, compute_all_depths, depth, depth_prefix, depth_suffix, is_round_cordial,
     latest_cordial_round, max_depth,

--- a/crates/cordial-miners-core/src/consensus/mod.rs
+++ b/crates/cordial-miners-core/src/consensus/mod.rs
@@ -24,7 +24,10 @@ pub use ordering::{
     OrderingCache, OrderingError, approved_blocks_for_leader, previous_final_leader, tau,
     tau_with_cache, weighted_previous_final_leader, weighted_tau, weighted_tau_with_cache, xsort,
 };
-pub use pruning::{CheckpointGc, PruneError, PruneReport, checkpoint_after_finality};
+pub use pruning::{
+    CheckpointGc, PruneError, PruneReport, checkpoint_after_finality,
+    checkpoint_after_weighted_finality,
+};
 pub use round::{
     blocks_at_depth, compute_all_depths, depth, depth_prefix, depth_suffix, is_round_cordial,
     latest_cordial_round, max_depth,

--- a/crates/cordial-miners-core/src/consensus/ordering.rs
+++ b/crates/cordial-miners-core/src/consensus/ordering.rs
@@ -578,6 +578,10 @@ fn tau_from_leader<F>(
 where
     F: Fn(u64) -> Option<NodeId> + Copy,
 {
+    if emit_checkpoint_prefix(blocklace, leader, state) {
+        return Ok(());
+    }
+
     if let Some(previous) = previous_final_leader(
         blocklace,
         leader,
@@ -587,6 +591,8 @@ where
         config.leader_selection,
     ) {
         tau_from_leader(blocklace, &previous, config, state)?;
+    } else if let Some(checkpoint) = checkpoint_predecessor(blocklace, leader) {
+        emit_checkpoint_prefix(blocklace, checkpoint, state);
     }
 
     let newly_approved: HashSet<Block> = approved_blocks_for_leader(blocklace, leader)
@@ -613,8 +619,14 @@ fn tau_from_leader_cached<F>(
 where
     F: Fn(u64) -> Option<NodeId> + Copy,
 {
+    if emit_checkpoint_prefix(blocklace, leader, state) {
+        return Ok(());
+    }
+
     if let Some(previous) = previous_final_leader_cached(blocklace, leader, config, cache) {
         tau_from_leader_cached(blocklace, &previous, config, cache, state)?;
+    } else if let Some(checkpoint) = checkpoint_predecessor(blocklace, leader) {
+        emit_checkpoint_prefix(blocklace, checkpoint, state);
     }
 
     for id in sorted_approved_fragment(blocklace, leader, cache)? {
@@ -635,6 +647,10 @@ fn weighted_tau_from_leader<'a, F>(
 where
     F: Fn(u64) -> Option<NodeId> + Copy,
 {
+    if emit_checkpoint_prefix(blocklace, leader, state) {
+        return Ok(());
+    }
+
     if let Some(previous) = weighted_previous_final_leader(
         blocklace,
         leader,
@@ -643,6 +659,8 @@ where
         config.leader_selection,
     ) {
         weighted_tau_from_leader(blocklace, &previous, config, state)?;
+    } else if let Some(checkpoint) = checkpoint_predecessor(blocklace, leader) {
+        emit_checkpoint_prefix(blocklace, checkpoint, state);
     }
 
     let newly_approved: HashSet<Block> = approved_blocks_for_leader(blocklace, leader)
@@ -669,9 +687,15 @@ fn weighted_tau_from_leader_cached<'a, F>(
 where
     F: Fn(u64) -> Option<NodeId> + Copy,
 {
+    if emit_checkpoint_prefix(blocklace, leader, state) {
+        return Ok(());
+    }
+
     if let Some(previous) = weighted_previous_final_leader_cached(blocklace, leader, config, cache)
     {
         weighted_tau_from_leader_cached(blocklace, &previous, config, cache, state)?;
+    } else if let Some(checkpoint) = checkpoint_predecessor(blocklace, leader) {
+        emit_checkpoint_prefix(blocklace, checkpoint, state);
     }
 
     for id in sorted_approved_fragment(blocklace, leader, cache)? {
@@ -681,4 +705,34 @@ where
     }
 
     Ok(())
+}
+
+fn emit_checkpoint_prefix(
+    blocklace: &Blocklace,
+    leader: &BlockIdentity,
+    state: &mut TauState,
+) -> bool {
+    if blocklace.checkpoint() != Some(leader) || blocklace.checkpoint_order_prefix().is_empty() {
+        return false;
+    }
+
+    for id in blocklace.checkpoint_order_prefix() {
+        if state.emitted.insert(id.clone()) {
+            state.ordered.push(id.clone());
+        }
+    }
+
+    true
+}
+
+fn checkpoint_predecessor<'a>(
+    blocklace: &'a Blocklace,
+    leader: &BlockIdentity,
+) -> Option<&'a BlockIdentity> {
+    let checkpoint = blocklace.checkpoint()?;
+    if checkpoint == leader || !blocklace.precedes(checkpoint, leader) {
+        return None;
+    }
+
+    Some(checkpoint)
 }

--- a/crates/cordial-miners-core/src/consensus/ordering.rs
+++ b/crates/cordial-miners-core/src/consensus/ordering.rs
@@ -647,7 +647,7 @@ fn weighted_tau_from_leader<'a, F>(
 where
     F: Fn(u64) -> Option<NodeId> + Copy,
 {
-    if emit_checkpoint_prefix(blocklace, leader, state) {
+    if emit_weighted_checkpoint_prefix(blocklace, leader, state) {
         return Ok(());
     }
 
@@ -660,7 +660,7 @@ where
     ) {
         weighted_tau_from_leader(blocklace, &previous, config, state)?;
     } else if let Some(checkpoint) = checkpoint_predecessor(blocklace, leader) {
-        emit_checkpoint_prefix(blocklace, checkpoint, state);
+        emit_weighted_checkpoint_prefix(blocklace, checkpoint, state);
     }
 
     let newly_approved: HashSet<Block> = approved_blocks_for_leader(blocklace, leader)
@@ -687,7 +687,7 @@ fn weighted_tau_from_leader_cached<'a, F>(
 where
     F: Fn(u64) -> Option<NodeId> + Copy,
 {
-    if emit_checkpoint_prefix(blocklace, leader, state) {
+    if emit_weighted_checkpoint_prefix(blocklace, leader, state) {
         return Ok(());
     }
 
@@ -695,7 +695,7 @@ where
     {
         weighted_tau_from_leader_cached(blocklace, &previous, config, cache, state)?;
     } else if let Some(checkpoint) = checkpoint_predecessor(blocklace, leader) {
-        emit_checkpoint_prefix(blocklace, checkpoint, state);
+        emit_weighted_checkpoint_prefix(blocklace, checkpoint, state);
     }
 
     for id in sorted_approved_fragment(blocklace, leader, cache)? {
@@ -717,6 +717,26 @@ fn emit_checkpoint_prefix(
     }
 
     for id in blocklace.checkpoint_order_prefix() {
+        if state.emitted.insert(id.clone()) {
+            state.ordered.push(id.clone());
+        }
+    }
+
+    true
+}
+
+fn emit_weighted_checkpoint_prefix(
+    blocklace: &Blocklace,
+    leader: &BlockIdentity,
+    state: &mut TauState,
+) -> bool {
+    if blocklace.checkpoint() != Some(leader)
+        || blocklace.checkpoint_weighted_order_prefix().is_empty()
+    {
+        return false;
+    }
+
+    for id in blocklace.checkpoint_weighted_order_prefix() {
         if state.emitted.insert(id.clone()) {
             state.ordered.push(id.clone());
         }

--- a/crates/cordial-miners-core/src/consensus/pruning.rs
+++ b/crates/cordial-miners-core/src/consensus/pruning.rs
@@ -4,11 +4,11 @@
 //! materialized, the consensus engine can treat that leader as the new in-memory
 //! genesis and delete older orphaned block contents.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 
 use crate::blocklace::Blocklace;
-use crate::consensus::finality::latest_final_leader;
-use crate::consensus::ordering::{tau, xsort};
+use crate::consensus::finality::{latest_final_leader, latest_weighted_final_leader};
+use crate::consensus::ordering::{tau, weighted_tau, xsort};
 use crate::consensus::round::depth;
 use crate::types::{BlockIdentity, NodeId};
 
@@ -29,6 +29,7 @@ pub struct PruneReport<Id> {
     pub removed: BTreeSet<Id>,
     pub retained_blocks: usize,
     pub tau_prefix_len: usize,
+    pub weighted_tau_prefix_len: usize,
 }
 
 /// Reasons checkpoint pruning can be rejected.
@@ -57,7 +58,7 @@ impl CheckpointGc<BlockIdentity> for Blocklace {
         checkpoint: &BlockIdentity,
     ) -> Result<PruneReport<BlockIdentity>, PruneError<BlockIdentity>> {
         let checkpoint_order_prefix = checkpoint_order_prefix(self, checkpoint);
-        self.prune_below_checkpoint_with_prefix(checkpoint, checkpoint_order_prefix)
+        self.prune_below_checkpoint_with_prefix(checkpoint, checkpoint_order_prefix, Vec::new())
     }
 }
 
@@ -66,6 +67,7 @@ impl Blocklace {
         &mut self,
         checkpoint: &BlockIdentity,
         checkpoint_order_prefix: Vec<BlockIdentity>,
+        checkpoint_weighted_order_prefix: Vec<BlockIdentity>,
     ) -> Result<PruneReport<BlockIdentity>, PruneError<BlockIdentity>> {
         if !self.blocks.contains_key(checkpoint) {
             return Err(PruneError::UnknownCheckpoint {
@@ -86,6 +88,7 @@ impl Blocklace {
                     removed: BTreeSet::new(),
                     retained_blocks: self.blocks.len(),
                     tau_prefix_len: self.checkpoint_order_prefix.len(),
+                    weighted_tau_prefix_len: self.checkpoint_weighted_order_prefix.len(),
                 });
             }
 
@@ -123,6 +126,7 @@ impl Blocklace {
         self.checkpoint = Some(checkpoint.clone());
         self.checkpoint_depth = Some(checkpoint_depth);
         self.checkpoint_order_prefix = checkpoint_order_prefix;
+        self.checkpoint_weighted_order_prefix = checkpoint_weighted_order_prefix;
 
         Ok(PruneReport {
             checkpoint: checkpoint.clone(),
@@ -130,6 +134,7 @@ impl Blocklace {
             removed: candidates,
             retained_blocks: self.blocks.len(),
             tau_prefix_len: self.checkpoint_order_prefix.len(),
+            weighted_tau_prefix_len: self.checkpoint_weighted_order_prefix.len(),
         })
     }
 }
@@ -158,7 +163,44 @@ where
         .unwrap_or_else(|_| checkpoint_order_prefix(blocklace, &final_leader));
 
     blocklace
-        .prune_below_checkpoint_with_prefix(&final_leader, checkpoint_order_prefix)
+        .prune_below_checkpoint_with_prefix(&final_leader, checkpoint_order_prefix, Vec::new())
+        .map(Some)
+}
+
+/// Advance the checkpoint to the latest stake-weighted final leader, if one exists.
+///
+/// This is the f1r3node-oriented counterpart to [`checkpoint_after_finality`].
+/// It stores the weighted tau prefix separately so `weighted_tau(...)` does not
+/// replay a paper-native tau prefix after pruning.
+pub fn checkpoint_after_weighted_finality<F>(
+    blocklace: &mut Blocklace,
+    wavelength: u64,
+    bonds: &HashMap<NodeId, u64>,
+    leader_selection: F,
+) -> Result<Option<PruneReport<BlockIdentity>>, PruneError<BlockIdentity>>
+where
+    F: Fn(u64) -> Option<NodeId> + Copy,
+{
+    let Some(final_leader) =
+        latest_weighted_final_leader(blocklace, wavelength, bonds, leader_selection)
+    else {
+        return Ok(None);
+    };
+
+    if blocklace.checkpoint() == Some(&final_leader) {
+        return Ok(None);
+    }
+
+    let checkpoint_weighted_order_prefix =
+        weighted_tau(blocklace, wavelength, bonds, leader_selection)
+            .unwrap_or_else(|_| checkpoint_order_prefix(blocklace, &final_leader));
+
+    blocklace
+        .prune_below_checkpoint_with_prefix(
+            &final_leader,
+            Vec::new(),
+            checkpoint_weighted_order_prefix,
+        )
         .map(Some)
 }
 

--- a/crates/cordial-miners-core/src/consensus/pruning.rs
+++ b/crates/cordial-miners-core/src/consensus/pruning.rs
@@ -1,0 +1,200 @@
+//! Checkpoint-based garbage collection for the in-memory blocklace.
+//!
+//! Once a leader has finalized and the corresponding tau prefix has been
+//! materialized, the consensus engine can treat that leader as the new in-memory
+//! genesis and delete older orphaned block contents.
+
+use std::collections::BTreeSet;
+
+use crate::blocklace::Blocklace;
+use crate::consensus::finality::latest_final_leader;
+use crate::consensus::ordering::{tau, xsort};
+use crate::consensus::round::depth;
+use crate::types::{BlockIdentity, NodeId};
+
+/// Trait for DAG stores that can expose and advance a finalized checkpoint.
+pub trait CheckpointGc<Id> {
+    fn current_checkpoint(&self) -> Option<&Id>;
+    fn prune_below_checkpoint(
+        &mut self,
+        checkpoint: &Id,
+    ) -> Result<PruneReport<Id>, PruneError<Id>>;
+}
+
+/// Summary of a checkpoint prune operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PruneReport<Id> {
+    pub checkpoint: Id,
+    pub checkpoint_depth: u64,
+    pub removed: BTreeSet<Id>,
+    pub retained_blocks: usize,
+    pub tau_prefix_len: usize,
+}
+
+/// Reasons checkpoint pruning can be rejected.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PruneError<Id> {
+    UnknownCheckpoint { checkpoint: Id },
+    CheckpointRegression { current: Id, requested: Id },
+    DisconnectedCheckpoint { current: Id, requested: Id },
+}
+
+impl CheckpointGc<BlockIdentity> for Blocklace {
+    fn current_checkpoint(&self) -> Option<&BlockIdentity> {
+        self.checkpoint()
+    }
+
+    fn prune_below_checkpoint(
+        &mut self,
+        checkpoint: &BlockIdentity,
+    ) -> Result<PruneReport<BlockIdentity>, PruneError<BlockIdentity>> {
+        let checkpoint_order_prefix = checkpoint_order_prefix(self, checkpoint);
+        self.prune_below_checkpoint_with_prefix(checkpoint, checkpoint_order_prefix)
+    }
+}
+
+impl Blocklace {
+    fn prune_below_checkpoint_with_prefix(
+        &mut self,
+        checkpoint: &BlockIdentity,
+        checkpoint_order_prefix: Vec<BlockIdentity>,
+    ) -> Result<PruneReport<BlockIdentity>, PruneError<BlockIdentity>> {
+        if !self.blocks.contains_key(checkpoint) {
+            return Err(PruneError::UnknownCheckpoint {
+                checkpoint: checkpoint.clone(),
+            });
+        }
+
+        let checkpoint_depth =
+            depth(self, checkpoint).ok_or_else(|| PruneError::UnknownCheckpoint {
+                checkpoint: checkpoint.clone(),
+            })?;
+
+        if let Some(current) = self.checkpoint.clone() {
+            if current == *checkpoint {
+                return Ok(PruneReport {
+                    checkpoint: checkpoint.clone(),
+                    checkpoint_depth,
+                    removed: BTreeSet::new(),
+                    retained_blocks: self.blocks.len(),
+                    tau_prefix_len: self.checkpoint_order_prefix.len(),
+                });
+            }
+
+            if let Some(current_depth) = self.checkpoint_depth {
+                if checkpoint_depth < current_depth {
+                    return Err(PruneError::CheckpointRegression {
+                        current,
+                        requested: checkpoint.clone(),
+                    });
+                }
+            }
+
+            if !self.preceedes_or_equals(&current, checkpoint) {
+                return Err(PruneError::DisconnectedCheckpoint {
+                    current,
+                    requested: checkpoint.clone(),
+                });
+            }
+        }
+
+        let mut candidates: BTreeSet<BlockIdentity> =
+            self.observe(checkpoint).into_iter().collect();
+        candidates.remove(checkpoint);
+
+        let protected = protected_candidate_closure(self, checkpoint, &candidates);
+        for id in &protected {
+            candidates.remove(id);
+        }
+
+        for id in &candidates {
+            self.blocks.remove(id);
+        }
+
+        self.checkpoint = Some(checkpoint.clone());
+        self.checkpoint_depth = Some(checkpoint_depth);
+        self.checkpoint_order_prefix = checkpoint_order_prefix;
+
+        Ok(PruneReport {
+            checkpoint: checkpoint.clone(),
+            checkpoint_depth,
+            removed: candidates,
+            retained_blocks: self.blocks.len(),
+            tau_prefix_len: self.checkpoint_order_prefix.len(),
+        })
+    }
+}
+
+/// Advance the checkpoint to the latest known final leader, if one exists.
+pub fn checkpoint_after_finality<F>(
+    blocklace: &mut Blocklace,
+    wavelength: u64,
+    n: usize,
+    f: usize,
+    leader_selection: F,
+) -> Result<Option<PruneReport<BlockIdentity>>, PruneError<BlockIdentity>>
+where
+    F: Fn(u64) -> Option<NodeId> + Copy,
+{
+    let Some(final_leader) = latest_final_leader(blocklace, wavelength, n, f, leader_selection)
+    else {
+        return Ok(None);
+    };
+
+    if blocklace.checkpoint() == Some(&final_leader) {
+        return Ok(None);
+    }
+
+    let checkpoint_order_prefix = tau(blocklace, wavelength, n, f, leader_selection)
+        .unwrap_or_else(|_| checkpoint_order_prefix(blocklace, &final_leader));
+
+    blocklace
+        .prune_below_checkpoint_with_prefix(&final_leader, checkpoint_order_prefix)
+        .map(Some)
+}
+
+fn checkpoint_order_prefix(
+    blocklace: &Blocklace,
+    checkpoint: &BlockIdentity,
+) -> Vec<BlockIdentity> {
+    let observed_ids: std::collections::HashSet<BlockIdentity> =
+        blocklace.observe(checkpoint).into_iter().collect();
+    let observed_blocks = blocklace.get_set(&observed_ids);
+
+    xsort(&observed_blocks).unwrap_or_else(|_| blocklace.observe(checkpoint).into_iter().collect())
+}
+
+fn protected_candidate_closure(
+    blocklace: &Blocklace,
+    checkpoint: &BlockIdentity,
+    candidates: &BTreeSet<BlockIdentity>,
+) -> BTreeSet<BlockIdentity> {
+    let mut protected = BTreeSet::new();
+    let mut stack = Vec::new();
+
+    for (id, content) in &blocklace.blocks {
+        if candidates.contains(id) || id == checkpoint {
+            continue;
+        }
+
+        for pred_id in &content.predecessors {
+            if candidates.contains(pred_id) && protected.insert(pred_id.clone()) {
+                stack.push(pred_id.clone());
+            }
+        }
+    }
+
+    while let Some(id) = stack.pop() {
+        let Some(content) = blocklace.content(&id) else {
+            continue;
+        };
+
+        for pred_id in &content.predecessors {
+            if candidates.contains(pred_id) && protected.insert(pred_id.clone()) {
+                stack.push(pred_id.clone());
+            }
+        }
+    }
+
+    protected
+}

--- a/crates/cordial-miners-core/src/consensus/pruning.rs
+++ b/crates/cordial-miners-core/src/consensus/pruning.rs
@@ -34,9 +34,17 @@ pub struct PruneReport<Id> {
 /// Reasons checkpoint pruning can be rejected.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PruneError<Id> {
-    UnknownCheckpoint { checkpoint: Id },
-    CheckpointRegression { current: Id, requested: Id },
-    DisconnectedCheckpoint { current: Id, requested: Id },
+    UnknownCheckpoint {
+        checkpoint: Box<Id>,
+    },
+    CheckpointRegression {
+        current: Box<Id>,
+        requested: Box<Id>,
+    },
+    DisconnectedCheckpoint {
+        current: Box<Id>,
+        requested: Box<Id>,
+    },
 }
 
 impl CheckpointGc<BlockIdentity> for Blocklace {
@@ -61,13 +69,13 @@ impl Blocklace {
     ) -> Result<PruneReport<BlockIdentity>, PruneError<BlockIdentity>> {
         if !self.blocks.contains_key(checkpoint) {
             return Err(PruneError::UnknownCheckpoint {
-                checkpoint: checkpoint.clone(),
+                checkpoint: Box::new(checkpoint.clone()),
             });
         }
 
         let checkpoint_depth =
             depth(self, checkpoint).ok_or_else(|| PruneError::UnknownCheckpoint {
-                checkpoint: checkpoint.clone(),
+                checkpoint: Box::new(checkpoint.clone()),
             })?;
 
         if let Some(current) = self.checkpoint.clone() {
@@ -81,19 +89,20 @@ impl Blocklace {
                 });
             }
 
-            if let Some(current_depth) = self.checkpoint_depth {
-                if checkpoint_depth < current_depth {
-                    return Err(PruneError::CheckpointRegression {
-                        current,
-                        requested: checkpoint.clone(),
-                    });
-                }
+            if self
+                .checkpoint_depth
+                .is_some_and(|current_depth| checkpoint_depth < current_depth)
+            {
+                return Err(PruneError::CheckpointRegression {
+                    current: Box::new(current.clone()),
+                    requested: Box::new(checkpoint.clone()),
+                });
             }
 
             if !self.preceedes_or_equals(&current, checkpoint) {
                 return Err(PruneError::DisconnectedCheckpoint {
-                    current,
-                    requested: checkpoint.clone(),
+                    current: Box::new(current),
+                    requested: Box::new(checkpoint.clone()),
                 });
             }
         }

--- a/crates/cordial-miners-core/src/consensus/round.rs
+++ b/crates/cordial-miners-core/src/consensus/round.rs
@@ -40,6 +40,12 @@ fn depth_recursive(
         return Some(d);
     }
 
+    if blocklace.checkpoint() == Some(block_id) {
+        let depth = blocklace.checkpoint_depth().unwrap_or(0);
+        cache.insert(block_id.clone(), depth);
+        return Some(depth);
+    }
+
     let content = blocklace.content(block_id)?;
 
     if content.predecessors.is_empty() {

--- a/crates/cordial-miners-core/tests/test_checkpoint_pruning.rs
+++ b/crates/cordial-miners-core/tests/test_checkpoint_pruning.rs
@@ -1,0 +1,196 @@
+use std::collections::HashSet;
+
+use cordial_miners_core::blocklace::Blocklace;
+use cordial_miners_core::consensus::{CheckpointGc, checkpoint_after_finality, tau};
+use cordial_miners_core::crypto::CryptoVerifier;
+use cordial_miners_core::{Block, BlockContent, BlockIdentity, NodeId};
+
+struct MockVerifier;
+
+impl CryptoVerifier for MockVerifier {
+    type Error = String;
+
+    fn verify_block(
+        &self,
+        _content: &BlockContent,
+        _sig: &[u8],
+        _creator: &NodeId,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+fn node(id: u8) -> NodeId {
+    NodeId(vec![id])
+}
+
+fn make_id(creator: &NodeId, tag: u64) -> BlockIdentity {
+    let mut hash = [0u8; 32];
+    hash[0..8].copy_from_slice(&tag.to_le_bytes());
+    hash[8] = creator.0[0];
+
+    BlockIdentity {
+        content_hash: hash,
+        creator: creator.clone(),
+        signature: tag.to_le_bytes().to_vec(),
+    }
+}
+
+fn genesis(creator: &NodeId, tag: u64) -> Block {
+    Block {
+        identity: make_id(creator, tag),
+        content: BlockContent {
+            payload: tag.to_le_bytes().to_vec(),
+            predecessors: HashSet::new(),
+        },
+    }
+}
+
+fn child(creator: &NodeId, tag: u64, parents: &[&Block]) -> Block {
+    Block {
+        identity: make_id(creator, tag),
+        content: BlockContent {
+            payload: tag.to_le_bytes().to_vec(),
+            predecessors: parents.iter().map(|block| block.identity.clone()).collect(),
+        },
+    }
+}
+
+fn insert(blocklace: &mut Blocklace, block: &Block) {
+    blocklace
+        .insert(block.clone(), &MockVerifier)
+        .expect("test block should insert");
+}
+
+fn leader_node1(_wave: u64) -> Option<NodeId> {
+    Some(node(1))
+}
+
+#[test]
+fn checkpoint_prune_removes_old_blocks_and_observe_stops_at_boundary() {
+    let mut blocklace = Blocklace::new();
+
+    let genesis = genesis(&node(1), 1);
+    let parent = child(&node(2), 2, &[&genesis]);
+    let checkpoint = child(&node(1), 3, &[&parent]);
+    let tip = child(&node(2), 4, &[&checkpoint]);
+
+    for block in [&genesis, &parent, &checkpoint, &tip] {
+        insert(&mut blocklace, block);
+    }
+
+    assert!(blocklace.observe(&tip.identity).contains(&genesis.identity));
+
+    let report = blocklace
+        .prune_below_checkpoint(&checkpoint.identity)
+        .expect("checkpoint should prune");
+
+    assert!(report.removed.contains(&genesis.identity));
+    assert!(report.removed.contains(&parent.identity));
+    assert_eq!(blocklace.current_checkpoint(), Some(&checkpoint.identity));
+    assert!(blocklace.get(&genesis.identity).is_none());
+    assert!(blocklace.get(&parent.identity).is_none());
+    assert!(blocklace.get(&checkpoint.identity).is_some());
+    assert!(blocklace.get(&tip.identity).is_some());
+    assert!(blocklace.is_closed());
+
+    let observed = blocklace.observe(&tip.identity);
+    assert!(observed.contains(&tip.identity));
+    assert!(observed.contains(&checkpoint.identity));
+    assert!(!observed.contains(&parent.identity));
+    assert!(!observed.contains(&genesis.identity));
+    assert!(blocklace.observe(&genesis.identity).is_empty());
+}
+
+#[test]
+fn checkpoint_after_finality_prunes_latest_final_leader_history() {
+    let mut blocklace = Blocklace::new();
+    let wavelength = 3;
+    let n = 4;
+    let f = 1;
+
+    let v1 = node(1);
+    let v2 = node(2);
+    let v3 = node(3);
+    let v4 = node(4);
+
+    let w0_leader = genesis(&v1, 1);
+    insert(&mut blocklace, &w0_leader);
+
+    let w0_r1_v2 = child(&v2, 2, &[&w0_leader]);
+    let w0_r1_v3 = child(&v3, 3, &[&w0_leader]);
+    let w0_r1_v4 = child(&v4, 4, &[&w0_leader]);
+    for block in [&w0_r1_v2, &w0_r1_v3, &w0_r1_v4] {
+        insert(&mut blocklace, block);
+    }
+
+    let w0_r2_v2 = child(&v2, 5, &[&w0_r1_v2, &w0_r1_v3, &w0_r1_v4]);
+    let w0_r2_v3 = child(&v3, 6, &[&w0_r1_v2, &w0_r1_v3, &w0_r1_v4]);
+    let w0_r2_v4 = child(&v4, 7, &[&w0_r1_v2, &w0_r1_v3, &w0_r1_v4]);
+    for block in [&w0_r2_v2, &w0_r2_v3, &w0_r2_v4] {
+        insert(&mut blocklace, block);
+    }
+
+    let w1_leader = child(&v1, 8, &[&w0_r2_v2, &w0_r2_v3, &w0_r2_v4]);
+    insert(&mut blocklace, &w1_leader);
+
+    let w1_r1_v2 = child(&v2, 9, &[&w1_leader]);
+    let w1_r1_v3 = child(&v3, 10, &[&w1_leader]);
+    let w1_r1_v4 = child(&v4, 11, &[&w1_leader]);
+    for block in [&w1_r1_v2, &w1_r1_v3, &w1_r1_v4] {
+        insert(&mut blocklace, block);
+    }
+
+    let w1_r2_v2 = child(&v2, 12, &[&w1_r1_v2, &w1_r1_v3, &w1_r1_v4]);
+    let w1_r2_v3 = child(&v3, 13, &[&w1_r1_v2, &w1_r1_v3, &w1_r1_v4]);
+    let w1_r2_v4 = child(&v4, 14, &[&w1_r1_v2, &w1_r1_v3, &w1_r1_v4]);
+    for block in [&w1_r2_v2, &w1_r2_v3, &w1_r2_v4] {
+        insert(&mut blocklace, block);
+    }
+
+    let before = tau(&blocklace, wavelength, n, f, leader_node1).expect("tau should order");
+    let report = checkpoint_after_finality(&mut blocklace, wavelength, n, f, leader_node1)
+        .expect("finality checkpoint should not error")
+        .expect("latest final leader should prune");
+    let after = tau(&blocklace, wavelength, n, f, leader_node1).expect("tau should order");
+
+    assert_eq!(report.checkpoint, w1_leader.identity);
+    assert!(report.removed.contains(&w0_leader.identity));
+    assert!(blocklace.get(&w0_leader.identity).is_none());
+    assert_eq!(after, before);
+}
+
+#[test]
+fn frequent_checkpoint_pruning_keeps_block_memory_bounded() {
+    let mut blocklace = Blocklace::new();
+    let prune_interval = 100usize;
+    let total_blocks = 10_000usize;
+
+    let mut previous = genesis(&node(1), 1);
+    let first_id = previous.identity.clone();
+    insert(&mut blocklace, &previous);
+
+    let mut max_retained = blocklace.dom().len();
+
+    for index in 2..=total_blocks {
+        let creator = node(((index % 4) + 1) as u8);
+        let next = child(&creator, index as u64, &[&previous]);
+        insert(&mut blocklace, &next);
+        previous = next;
+
+        if index % prune_interval == 0 {
+            let report = blocklace
+                .prune_below_checkpoint(&previous.identity)
+                .expect("checkpoint should prune");
+            assert!(report.retained_blocks <= prune_interval);
+            assert!(blocklace.is_closed());
+        }
+
+        max_retained = max_retained.max(blocklace.dom().len());
+    }
+
+    assert!(max_retained <= prune_interval);
+    assert!(blocklace.dom().len() <= prune_interval);
+    assert!(blocklace.get(&first_id).is_none());
+    assert_eq!(blocklace.current_checkpoint(), Some(&previous.identity));
+}

--- a/crates/cordial-miners-core/tests/test_checkpoint_pruning.rs
+++ b/crates/cordial-miners-core/tests/test_checkpoint_pruning.rs
@@ -1,7 +1,9 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use cordial_miners_core::blocklace::Blocklace;
-use cordial_miners_core::consensus::{CheckpointGc, checkpoint_after_finality, tau};
+use cordial_miners_core::consensus::{
+    CheckpointGc, checkpoint_after_finality, checkpoint_after_weighted_finality, tau, weighted_tau,
+};
 use cordial_miners_core::crypto::CryptoVerifier;
 use cordial_miners_core::{Block, BlockContent, BlockIdentity, NodeId};
 
@@ -64,6 +66,69 @@ fn insert(blocklace: &mut Blocklace, block: &Block) {
 
 fn leader_node1(_wave: u64) -> Option<NodeId> {
     Some(node(1))
+}
+
+fn bonds(entries: &[(u8, u64)]) -> HashMap<NodeId, u64> {
+    entries
+        .iter()
+        .map(|(id, stake)| (node(*id), *stake))
+        .collect()
+}
+
+struct WeightedCheckpointGraph {
+    w0_leader: Block,
+    w1_leader: Block,
+    w1_tip: Block,
+}
+
+fn insert_weighted_two_wave_checkpoint_graph(blocklace: &mut Blocklace) -> WeightedCheckpointGraph {
+    let v1 = node(1);
+    let v2 = node(2);
+    let v3 = node(3);
+    let v4 = node(4);
+    let v5 = node(5);
+
+    let w0_leader = genesis(&v1, 1);
+    insert(blocklace, &w0_leader);
+
+    let w0_r1_v2 = child(&v2, 2, &[&w0_leader]);
+    let w0_r1_v3 = child(&v3, 3, &[&w0_leader]);
+    let w0_r1_v4 = child(&v4, 4, &[&w0_leader]);
+    for block in [&w0_r1_v2, &w0_r1_v3, &w0_r1_v4] {
+        insert(blocklace, block);
+    }
+
+    let w0_r2_v2 = child(&v2, 5, &[&w0_r1_v2, &w0_r1_v3, &w0_r1_v4]);
+    let w0_r2_v3 = child(&v3, 6, &[&w0_r1_v2, &w0_r1_v3, &w0_r1_v4]);
+    let w0_r2_v4 = child(&v4, 7, &[&w0_r1_v2, &w0_r1_v3, &w0_r1_v4]);
+    for block in [&w0_r2_v2, &w0_r2_v3, &w0_r2_v4] {
+        insert(blocklace, block);
+    }
+
+    let w1_leader = child(&v1, 8, &[&w0_r2_v2, &w0_r2_v3, &w0_r2_v4]);
+    insert(blocklace, &w1_leader);
+
+    let w1_r1_v2 = child(&v2, 9, &[&w1_leader]);
+    let w1_r1_v3 = child(&v3, 10, &[&w1_leader]);
+    let w1_r1_v4 = child(&v4, 11, &[&w1_leader]);
+    let w1_r1_v5 = child(&v5, 12, &[&w1_leader]);
+    for block in [&w1_r1_v2, &w1_r1_v3, &w1_r1_v4, &w1_r1_v5] {
+        insert(blocklace, block);
+    }
+
+    let w1_r2_v2 = child(&v2, 13, &[&w1_r1_v2, &w1_r1_v3, &w1_r1_v4, &w1_r1_v5]);
+    let w1_r2_v3 = child(&v3, 14, &[&w1_r1_v2, &w1_r1_v3, &w1_r1_v4, &w1_r1_v5]);
+    let w1_r2_v4 = child(&v4, 15, &[&w1_r1_v2, &w1_r1_v3, &w1_r1_v4, &w1_r1_v5]);
+    let w1_tip = child(&v5, 16, &[&w1_r1_v2, &w1_r1_v3, &w1_r1_v4, &w1_r1_v5]);
+    for block in [&w1_r2_v2, &w1_r2_v3, &w1_r2_v4, &w1_tip] {
+        insert(blocklace, block);
+    }
+
+    WeightedCheckpointGraph {
+        w0_leader,
+        w1_leader,
+        w1_tip,
+    }
 }
 
 #[test]
@@ -158,6 +223,60 @@ fn checkpoint_after_finality_prunes_latest_final_leader_history() {
     assert!(report.removed.contains(&w0_leader.identity));
     assert!(blocklace.get(&w0_leader.identity).is_none());
     assert_eq!(after, before);
+}
+
+#[test]
+fn weighted_checkpoint_prune_preserves_weighted_tau_prefix() {
+    let mut blocklace = Blocklace::new();
+    let wavelength = 3;
+    let weights = bonds(&[(1, 1), (2, 1), (3, 1), (4, 1), (5, 100)]);
+    let graph = insert_weighted_two_wave_checkpoint_graph(&mut blocklace);
+
+    let before =
+        weighted_tau(&blocklace, wavelength, &weights, leader_node1).expect("weighted tau");
+    let report =
+        checkpoint_after_weighted_finality(&mut blocklace, wavelength, &weights, leader_node1)
+            .expect("weighted finality checkpoint should not error")
+            .expect("latest weighted final leader should prune");
+    let after = weighted_tau(&blocklace, wavelength, &weights, leader_node1).expect("weighted tau");
+
+    assert_eq!(report.checkpoint, graph.w1_leader.identity);
+    assert_eq!(report.tau_prefix_len, 0);
+    assert_eq!(report.weighted_tau_prefix_len, before.len());
+    assert!(report.removed.contains(&graph.w0_leader.identity));
+    assert!(blocklace.get(&graph.w0_leader.identity).is_none());
+    assert_eq!(after, before);
+
+    let observed = blocklace.observe(&graph.w1_tip.identity);
+    assert!(observed.contains(&graph.w1_leader.identity));
+    assert!(!observed.contains(&graph.w0_leader.identity));
+}
+
+#[test]
+fn weighted_tau_does_not_replay_unweighted_checkpoint_prefix() {
+    let mut blocklace = Blocklace::new();
+    let wavelength = 3;
+    let n = 4;
+    let f = 1;
+    let weights = bonds(&[(1, 1), (2, 1), (3, 1), (4, 1), (5, 100)]);
+    let graph = insert_weighted_two_wave_checkpoint_graph(&mut blocklace);
+
+    let unweighted_before =
+        tau(&blocklace, wavelength, n, f, leader_node1).expect("tau should order");
+    let weighted_before =
+        weighted_tau(&blocklace, wavelength, &weights, leader_node1).expect("weighted tau");
+    assert!(!weighted_before.is_empty());
+
+    let report = blocklace
+        .prune_below_checkpoint(&graph.w1_leader.identity)
+        .expect("manual checkpoint should prune");
+    assert_eq!(report.tau_prefix_len, unweighted_before.len());
+    assert_eq!(report.weighted_tau_prefix_len, 0);
+
+    let weighted_after =
+        weighted_tau(&blocklace, wavelength, &weights, leader_node1).expect("weighted tau");
+    assert_eq!(weighted_after, vec![graph.w1_leader.identity]);
+    assert_ne!(weighted_after, unweighted_before);
 }
 
 #[test]

--- a/docs/cordial-miners/12-checkpoint-pruning.md
+++ b/docs/cordial-miners/12-checkpoint-pruning.md
@@ -1,0 +1,74 @@
+# 12 - Checkpoint Pruning
+
+## Goal
+
+A production validator cannot keep every block from genesis in the in-memory
+blocklace. Once a leader block is finalized and the corresponding tau prefix is
+materialized, the finalized leader becomes a checkpoint boundary. The consensus
+engine can then treat that checkpoint as the new in-memory genesis and remove
+older DAG contents from the `HashMap`.
+
+## Trigger
+
+Checkpoint garbage collection is triggered after leader finality:
+
+1. `latest_final_leader(...)` finds the newest finalized leader.
+2. `tau(...)` materializes the deterministic finalized output prefix for that
+   leader.
+3. `prune_below_checkpoint(...)` advances the checkpoint and deletes old blocks
+   below it.
+
+The convenience API is `checkpoint_after_finality(...)`. It returns `None` when
+there is no finalized leader or when the latest final leader is already the
+current checkpoint.
+
+## Boundary Semantics
+
+The checkpoint is retained in memory. Its predecessors may be removed.
+
+Traversal treats the checkpoint as a boundary:
+
+- `observe(checkpoint)` returns the checkpoint itself and stops.
+- `observe(descendant)` can walk down to the checkpoint but not below it.
+- Logical depth does not reset. The checkpoint stores its original depth, so
+  descendants continue at the same round numbers they had before pruning.
+
+This keeps wave and finality calculations monotonic while preventing repeated
+walks back to genesis.
+
+## What Is Deleted
+
+The pruning candidate set is the checkpoint's observed closure minus the
+checkpoint itself. Those blocks are physically removed from the in-memory
+`HashMap` when they are orphaned by the new checkpoint boundary.
+
+If a retained non-checkpoint block still directly depends on one of those
+candidates, that candidate and its candidate ancestors are protected for this
+prune pass. This preserves the closure invariant for retained live blocks while
+still allowing normal finalized history to be collected.
+
+## Memory Boundary
+
+After regular finalization, retained block contents are bounded by:
+
+- the current checkpoint block
+- blocks created after that checkpoint
+- any protected side-history still directly referenced by retained live blocks
+- the stored tau output identities needed to prove finalized ordering stability
+
+The large payload and predecessor-set memory belongs to the block `HashMap`.
+That memory plateaus under frequent checkpointing because old finalized block
+contents are removed instead of remaining traversable forever.
+
+## Safety Invariants
+
+Checkpoint pruning must preserve:
+
+- finalized tau output stability before and after GC
+- checkpoint monotonicity, meaning the checkpoint cannot move backwards
+- branch continuity, meaning a new checkpoint must observe the current one
+- closure for retained non-checkpoint blocks
+- deterministic observation, with no pruned block returned from `observe`
+
+Pruning rejects unknown checkpoints, backwards checkpoints, and disconnected
+checkpoints instead of guessing.

--- a/docs/cordial-miners/12-checkpoint-pruning.md
+++ b/docs/cordial-miners/12-checkpoint-pruning.md
@@ -10,17 +10,20 @@ older DAG contents from the `HashMap`.
 
 ## Trigger
 
-Checkpoint garbage collection is triggered after leader finality:
+Checkpoint garbage collection is triggered after leader finality. There are two
+entry points because the paper-native and f1r3node integration paths finalize
+leaders with different predicates:
 
-1. `latest_final_leader(...)` finds the newest finalized leader.
-2. `tau(...)` materializes the deterministic finalized output prefix for that
-   leader.
-3. `prune_below_checkpoint(...)` advances the checkpoint and deletes old blocks
-   below it.
+1. `checkpoint_after_finality(...)` uses `latest_final_leader(...)` and stores
+   the unweighted `tau(...)` prefix.
+2. `checkpoint_after_weighted_finality(...)` uses
+   `latest_weighted_final_leader(...)` and stores the `weighted_tau(...)`
+   prefix.
+3. `prune_below_checkpoint(...)` advances an explicitly supplied checkpoint and
+   deletes old blocks below it.
 
-The convenience API is `checkpoint_after_finality(...)`. It returns `None` when
-there is no finalized leader or when the latest final leader is already the
-current checkpoint.
+Both finality helpers return `None` when there is no finalized leader for their
+mode or when the latest final leader is already the current checkpoint.
 
 ## Boundary Semantics
 
@@ -35,6 +38,20 @@ Traversal treats the checkpoint as a boundary:
 
 This keeps wave and finality calculations monotonic while preventing repeated
 walks back to genesis.
+
+## Ordering Prefixes
+
+The checkpoint keeps output identities for ordering stability, but it does not
+store a single shared prefix for all ordering modes.
+
+- `tau(...)` replays only the unweighted checkpoint prefix.
+- `weighted_tau(...)` replays only the weighted checkpoint prefix.
+
+This separation matters because a leader can be final under the paper-native
+validator-count threshold while the stake-weighted finality path has a different
+latest leader or a different ordered prefix. Replaying the unweighted prefix from
+`weighted_tau(...)` after GC would make the weighted consensus view inconsistent
+with the pre-prune blocklace.
 
 ## What Is Deleted
 
@@ -54,7 +71,8 @@ After regular finalization, retained block contents are bounded by:
 - the current checkpoint block
 - blocks created after that checkpoint
 - any protected side-history still directly referenced by retained live blocks
-- the stored tau output identities needed to prove finalized ordering stability
+- the stored tau or weighted-tau output identities needed to prove finalized
+  ordering stability for the pruning mode that advanced the checkpoint
 
 The large payload and predecessor-set memory belongs to the block `HashMap`.
 That memory plateaus under frequent checkpointing because old finalized block


### PR DESCRIPTION
# Checkpoint-Based DAG Garbage Collection

## Summary

Resolves Issue #21 by adding checkpoint-based DAG garbage collection for the Cordial Miners in-memory blocklace.

Long-running nodes previously retained and traversed the full DAG history back to genesis. This PR introduces checkpoint pruning so finalized history can be safely removed from memory while preserving consensus-visible ordering.

## Changes

- Added checkpoint state to `Blocklace`
  - checkpoint identity
  - checkpoint depth
  - stored finalized `tau(...)` prefix

- Updated DAG traversal and `observe(...)` to stop at the checkpoint boundary.

- Preserved logical depth continuity after pruning.

- Added `consensus/pruning.rs` with:
  - `CheckpointGc`
  - `current_checkpoint`
  - `prune_below_checkpoint`
  - `checkpoint_after_finality`
  - `PruneReport`
  - `PruneError`

- Integrated pruning with ordering logic:
  - finalized `tau(...)` output is stored before pruning
  - `tau(...)` and `weighted_tau(...)` replay the stored prefix after pruning

- Added checkpoint pruning documentation.

## Tests

Added tests covering:

- pruning behavior
- checkpoint traversal boundaries
- `tau(...)` stability before/after pruning
- stress testing with 10,000 blocks and repeated pruning

## Verification

```bash
cargo test -p cordial-miners-core --test test_checkpoint_pruning
cargo test -p cordial-miners-core --test test_ordering
cargo test --workspace
```