### PR TITLE
Implement missing-predecessor buffering and replay helpers for dissemination

### DIFF
--- a/crates/cordial-miners-core/src/consensus/dissemination.rs
+++ b/crates/cordial-miners-core/src/consensus/dissemination.rs
@@ -18,8 +18,10 @@
 
 use std::collections::{HashMap, HashSet};
 
+use crate::Block;
 use crate::blocklace::Blocklace;
 use crate::consensus::fork_choice::collect_validator_tips;
+use crate::crypto::CryptoVerifier;
 use crate::types::{BlockIdentity, NodeId};
 
 /// Collect the set of visible validator tips from the local blocklace.
@@ -181,4 +183,80 @@ pub fn weighted_required_acknowledgements(bonds: &HashMap<NodeId, u64>) -> u64 {
         return 0;
     }
     ((2 * total_stake) / 3 + 1) as u64
+}
+
+/// A buffer for blocks that arrive out of order (before their predecessors).
+///
+/// This provides the dependency-resolution side of dissemination: blocks with missing
+/// parents should be buffered and retried once dependencies arrive.
+#[derive(Default, Debug, Clone)]
+pub struct PendingBlockBuffer {
+    /// Blocks that are buffered, indexed by their identity.
+    pub buffered_blocks: HashMap<BlockIdentity, Block>,
+}
+
+impl PendingBlockBuffer {
+    /// Create a new empty pending block buffer.
+    pub fn new() -> Self {
+        Self {
+            buffered_blocks: HashMap::new(),
+        }
+    }
+
+    /// Add a block to the buffer that might be missing predecessors.
+    pub fn buffer_block_with_missing_predecessors(&mut self, block: Block) {
+        self.buffered_blocks.insert(block.identity.clone(), block);
+    }
+
+    /// Retry inserting buffered blocks into the given blocklace.
+    ///
+    /// Loops through buffered blocks and attempts to insert them if their
+    /// predecessors are now available. Continues as long as progress is made
+    /// (e.g., a block is inserted which then satisfies another block's dependencies).
+    ///
+    /// Successfully inserted blocks, or blocks that are definitively rejected
+    /// (e.g., due to invalid signatures), are removed from the buffer.
+    pub fn retry_buffered_blocks<V: CryptoVerifier>(
+        &mut self,
+        blocklace: &mut Blocklace,
+        verifier: &V,
+    ) {
+        let mut progress = true;
+        while progress {
+            progress = false;
+            let mut resolved = Vec::new();
+
+            for (id, block) in self.buffered_blocks.iter() {
+                // Check if all predecessors are in the blocklace
+                let ready = block
+                    .content
+                    .predecessors
+                    .iter()
+                    .all(|p| blocklace.content(p).is_some());
+
+                if ready {
+                    // Try to insert
+                    match blocklace.insert(block.clone(), verifier) {
+                        Ok(_) => {
+                            resolved.push(id.clone());
+                            progress = true;
+                        }
+                        Err(_) => {
+                            // Block is definitively invalid (bad signature, equivocation, etc).
+                            // Remove it so we do not retry a permanently broken block.
+                            // NOTE: closure violations cannot happen here because we verified
+                            // all predecessors exist above. If they did occur it would be a bug.
+                            // Full coverage of rejection cases requires a non-mock verifier
+                            // and is tested at the integration layer.
+                            resolved.push(id.clone());
+                        }
+                    }
+                }
+            }
+
+            for id in resolved {
+                self.buffered_blocks.remove(&id);
+            }
+        }
+    }
 }

--- a/crates/cordial-miners-core/src/consensus/mod.rs
+++ b/crates/cordial-miners-core/src/consensus/mod.rs
@@ -15,7 +15,7 @@ pub use cordiality::{
     super_ratifies, weighted_ratifies, weighted_super_ratifies,
 };
 pub use dissemination::{
-    required_acknowledgements, select_predecessors, select_predecessors_sorted,
+    PendingBlockBuffer, required_acknowledgements, select_predecessors, select_predecessors_sorted,
     validator_visible_tips, weighted_required_acknowledgements,
 };
 pub use finality::{

--- a/crates/cordial-miners-core/tests/test_dissemination.rs
+++ b/crates/cordial-miners-core/tests/test_dissemination.rs
@@ -1,7 +1,7 @@
 use cordial_miners_core::Block;
 use cordial_miners_core::blocklace::Blocklace;
 use cordial_miners_core::consensus::{
-    required_acknowledgements, select_predecessors, select_predecessors_sorted,
+    PendingBlockBuffer, required_acknowledgements, select_predecessors, select_predecessors_sorted,
     validator_visible_tips, weighted_required_acknowledgements,
 };
 use cordial_miners_core::crypto::CryptoVerifier;
@@ -618,4 +618,134 @@ fn weighted_required_acknowledgements_large_numbers() {
     bonds.insert(node(1), 1_000_000);
 
     assert_eq!(weighted_required_acknowledgements(&bonds), 666_667);
+}
+
+// PENDING BLOCK BUFFER TESTS
+#[test]
+fn pending_buffer_resolves_single_missing_predecessor() {
+    let mut blocklace = Blocklace::new();
+    let verifier = MockVerifier;
+    let mut buffer = PendingBlockBuffer::new();
+
+    let genesis = create_mock_block(1, 1, HashSet::new());
+    let block2 = create_mock_block(1, 2, HashSet::from([genesis.identity.clone()]));
+
+    // block2 arrives before genesis
+    buffer.buffer_block_with_missing_predecessors(block2.clone());
+
+    // retry shouldn't insert block2 yet
+    buffer.retry_buffered_blocks(&mut blocklace, &verifier);
+    assert_eq!(buffer.buffered_blocks.len(), 1);
+    assert!(blocklace.content(&block2.identity).is_none());
+
+    // genesis arrives
+    insert(&mut blocklace, &genesis);
+
+    // retry should now insert block2
+    buffer.retry_buffered_blocks(&mut blocklace, &verifier);
+    assert!(buffer.buffered_blocks.is_empty());
+    assert!(blocklace.content(&block2.identity).is_some());
+}
+
+#[test]
+fn pending_buffer_resolves_chained_missing_predecessors() {
+    let mut blocklace = Blocklace::new();
+    let verifier = MockVerifier;
+    let mut buffer = PendingBlockBuffer::new();
+
+    let genesis = create_mock_block(1, 1, HashSet::new());
+    let block2 = create_mock_block(1, 2, HashSet::from([genesis.identity.clone()]));
+    let block3 = create_mock_block(1, 3, HashSet::from([block2.identity.clone()]));
+
+    // block3 and block2 arrive before genesis out of order
+    buffer.buffer_block_with_missing_predecessors(block3.clone());
+    buffer.buffer_block_with_missing_predecessors(block2.clone());
+
+    buffer.retry_buffered_blocks(&mut blocklace, &verifier);
+    assert_eq!(buffer.buffered_blocks.len(), 2);
+
+    // genesis arrives
+    insert(&mut blocklace, &genesis);
+
+    // retry should insert both recursively
+    buffer.retry_buffered_blocks(&mut blocklace, &verifier);
+    assert!(buffer.buffered_blocks.is_empty());
+    assert!(blocklace.content(&block2.identity).is_some());
+    assert!(blocklace.content(&block3.identity).is_some());
+}
+
+#[test]
+fn pending_buffer_handles_out_of_order_arrival() {
+    let mut blocklace = Blocklace::new();
+    let verifier = MockVerifier;
+    let mut buffer = PendingBlockBuffer::new();
+
+    let genesis = create_mock_block(1, 1, HashSet::new());
+    let block2a = create_mock_block(1, 2, HashSet::from([genesis.identity.clone()]));
+    let block2b = create_mock_block(2, 2, HashSet::from([genesis.identity.clone()]));
+    let block3 = create_mock_block(
+        3,
+        3,
+        HashSet::from([block2a.identity.clone(), block2b.identity.clone()]),
+    );
+
+    // block 3 arrives early
+    buffer.buffer_block_with_missing_predecessors(block3.clone());
+
+    // genesis and one predecessor arrive
+    insert(&mut blocklace, &genesis);
+    insert(&mut blocklace, &block2a);
+    buffer.retry_buffered_blocks(&mut blocklace, &verifier);
+
+    // block 3 should still be unresolved due to missing block2b
+    assert_eq!(buffer.buffered_blocks.len(), 1);
+
+    // block2b arrives
+    insert(&mut blocklace, &block2b);
+    buffer.retry_buffered_blocks(&mut blocklace, &verifier);
+
+    assert!(buffer.buffered_blocks.is_empty());
+    assert!(blocklace.content(&block3.identity).is_some());
+}
+
+#[test]
+fn pending_buffer_no_duplicate_insertion_on_repeated_retry() {
+    let mut blocklace = Blocklace::new();
+    let verifier = MockVerifier;
+    let mut buffer = PendingBlockBuffer::new();
+
+    let genesis = create_mock_block(1, 1, HashSet::new());
+    let block2 = create_mock_block(1, 2, HashSet::from([genesis.identity.clone()]));
+
+    buffer.buffer_block_with_missing_predecessors(block2.clone());
+
+    insert(&mut blocklace, &genesis);
+
+    buffer.retry_buffered_blocks(&mut blocklace, &verifier);
+    assert!(buffer.buffered_blocks.is_empty());
+
+    // retry again, should be a no-op
+    buffer.retry_buffered_blocks(&mut blocklace, &verifier);
+    assert!(blocklace.content(&block2.identity).is_some());
+}
+
+#[test]
+fn pending_buffer_removes_block_already_in_blocklace() {
+    let mut blocklace = Blocklace::new();
+    let verifier = MockVerifier;
+    let mut buffer = PendingBlockBuffer::new();
+
+    let genesis = create_mock_block(1, 1, HashSet::new());
+    let block2 = create_mock_block(1, 2, HashSet::from([genesis.identity.clone()]));
+
+    // block2 buffered while genesis is missing
+    buffer.buffer_block_with_missing_predecessors(block2.clone());
+
+    // Both arrive directly — buffer not yet retried
+    insert(&mut blocklace, &genesis);
+    insert(&mut blocklace, &block2);
+
+    // retry should still clear the buffer cleanly
+    buffer.retry_buffered_blocks(&mut blocklace, &verifier);
+    assert!(buffer.buffered_blocks.is_empty());
 }


### PR DESCRIPTION
## Summary

Adds dependency-resolution helpers for out-of-order block arrival in
`crates/cordial-miners-core/src/consensus/dissemination.rs`. This
supports the paper's asynchronous dissemination assumptions where blocks
may propagate over an unreliable network and arrive before their
predecessors are known locally.

## Why This Is Needed

The Cordial Miners paper (arXiv:2205.09174) assumes blocks propagate
asynchronously and may arrive out of order. The blocklace enforces the
closure axiom on insertion — a block cannot be inserted until all its
predecessors exist. Without a buffer, blocks that arrive early would be
silently dropped, breaking knowledge propagation and eventual finality.

## What Was Implemented

### `PendingBlockBuffer`
A buffer for blocks that arrive before their predecessors, indexed by
`BlockIdentity` for O(1) lookup and natural deduplication. If the same
block arrives via two paths it is stored once, not twice.

### `buffer_block_with_missing_predecessors(block)`
Accepts any block into the buffer without validation. Validation is
deferred to retry time when predecessors may be available.

### `retry_buffered_blocks(blocklace, verifier)`
Attempts to insert buffered blocks whose predecessors are now present
in the blocklace. Uses a `while progress` loop to handle chained
dependencies — a single retry pass can resolve a full chain of
buffered blocks in the correct order. Successfully inserted blocks and
permanently invalid blocks are both removed from the buffer so they
are never retried.

## Dependencies on Existing Modules

### `blocklace`
- `blocklace.insert(block, verifier)` — closure-enforcing insertion
- `blocklace.content(id)` — predecessor existence check

### `crypto`
- `CryptoVerifier` trait — passed through to `blocklace.insert`

## Error Handling Note

Permanently invalid blocks (bad signature, equivocation) are removed
from the buffer after the first failed insertion attempt so they are
not retried indefinitely. Closure violations cannot occur at retry time
because predecessor existence is verified before each insertion attempt.
Full rejection coverage requires a non-mock verifier and is tested at
the integration layer.

## What Was Intentionally Left Out

- Eviction policy (max buffer size, TTL) — out of scope for this issue
- Metrics or logging — out of scope for this issue
- Network-layer integration — this is a pure in-memory helper

## Crates Modified

- `crates/cordial-miners-core` only — `src/consensus/dissemination.rs`,
  `src/consensus/mod.rs`, and `tests/test_dissemination.rs`
- No changes to `cordial-f1r3node-adapter` or
  `cordial-f1r3space-adapter`
- Layering rules preserved — no imports from adapter or node crates

## Test Plan

- Ran `cargo test -p cordial-miners-core --test test_dissemination`
  — all tests pass
- Ran `cargo clippy -p cordial-miners-core --all-targets --all-features
  --no-deps -- -D warnings` — no warnings
- Tests cover all acceptance criteria:
  - Single missing predecessor buffered and resolved on retry
  - Chained missing predecessors resolved in correct order
  - Out-of-order arrival with partial predecessor availability
  - No duplicate insertion on repeated retry calls
  - Buffer clears cleanly when block already in blocklace

## Related Issues

- Follows dissemination predecessor selection PR
- Part of the broader dissemination layer before networking integration
- Closes #82 