### PR TITLE
Implement core dissemination and local proposal construction

### DIFF
--- a/crates/cordial-miners-core/src/consensus/dissemination.rs
+++ b/crates/cordial-miners-core/src/consensus/dissemination.rs
@@ -225,21 +225,31 @@ pub enum ProposalError {
 /// visible honest validator tips to satisfy `required_acknowledgements(...)`.
 /// The predecessor set itself comes from `select_predecessors(...)`, which may
 /// include additional known equivocation branches needed for cordiality.
+///
+/// As a special bootstrap case, an empty blocklace yields an empty predecessor
+/// set so the first block can be proposed before any tips exist.
 pub fn build_block_candidate(
     blocklace: &Blocklace,
     bonds: &HashMap<NodeId, u64>,
     payload: Vec<u8>,
 ) -> Result<BlockContent, ProposalError> {
-    let observed = validator_visible_tips(blocklace, bonds).len();
-    let required = required_acknowledgements(bonds);
-
-    if observed < required {
-        return Err(ProposalError::InsufficientAcknowledgements { observed, required });
+    if blocklace.dom().is_empty() {
+        return Ok(BlockContent {
+            payload,
+            predecessors: HashSet::new(),
+        });
     }
 
     let predecessors = select_predecessors(blocklace, bonds);
     if predecessors.is_empty() {
         return Err(ProposalError::NoPredecessorsAvailable);
+    }
+
+    let observed = validator_visible_tips(blocklace, bonds).len();
+    let required = required_acknowledgements(bonds);
+
+    if observed < required {
+        return Err(ProposalError::InsufficientAcknowledgements { observed, required });
     }
 
     Ok(BlockContent {

--- a/crates/cordial-miners-core/src/consensus/dissemination.rs
+++ b/crates/cordial-miners-core/src/consensus/dissemination.rs
@@ -23,7 +23,7 @@ use crate::blocklace::Blocklace;
 use crate::consensus::cordiality::all_equivocations;
 use crate::consensus::fork_choice::collect_validator_tips;
 use crate::consensus::validation::{InvalidBlock, ValidationConfig, validated_insert};
-use crate::types::{BlockIdentity, NodeId};
+use crate::types::{BlockContent, BlockIdentity, NodeId};
 
 /// Collect the set of visible validator tips from the local blocklace.
 ///
@@ -202,6 +202,50 @@ pub fn weighted_required_acknowledgements(bonds: &HashMap<NodeId, u64>) -> u64 {
         return 0;
     }
     ((2 * total_stake) / 3 + 1) as u64
+}
+
+/// Reasons local proposal construction can fail.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProposalError {
+    /// The local view does not contain enough visible honest validator tips to
+    /// satisfy the cordial acknowledgement threshold.
+    InsufficientAcknowledgements { observed: usize, required: usize },
+
+    /// No predecessors could be selected from the current local view.
+    NoPredecessorsAvailable,
+}
+
+/// Build a deterministic block-content candidate from the current local view.
+///
+/// This helper does not decide *when* a node should propose; it only answers
+/// *what* payload and predecessor set should be used once an external scheduler
+/// requests a proposal.
+///
+/// Proposal construction succeeds only when the local view contains enough
+/// visible honest validator tips to satisfy `required_acknowledgements(...)`.
+/// The predecessor set itself comes from `select_predecessors(...)`, which may
+/// include additional known equivocation branches needed for cordiality.
+pub fn build_block_candidate(
+    blocklace: &Blocklace,
+    bonds: &HashMap<NodeId, u64>,
+    payload: Vec<u8>,
+) -> Result<BlockContent, ProposalError> {
+    let observed = validator_visible_tips(blocklace, bonds).len();
+    let required = required_acknowledgements(bonds);
+
+    if observed < required {
+        return Err(ProposalError::InsufficientAcknowledgements { observed, required });
+    }
+
+    let predecessors = select_predecessors(blocklace, bonds);
+    if predecessors.is_empty() {
+        return Err(ProposalError::NoPredecessorsAvailable);
+    }
+
+    Ok(BlockContent {
+        payload,
+        predecessors,
+    })
 }
 
 /// A buffer for blocks that arrive out of order (before their predecessors).

--- a/crates/cordial-miners-core/src/consensus/mod.rs
+++ b/crates/cordial-miners-core/src/consensus/mod.rs
@@ -16,8 +16,9 @@ pub use cordiality::{
     super_ratifies, weighted_ratifies, weighted_super_ratifies,
 };
 pub use dissemination::{
-    PendingBlockBuffer, required_acknowledgements, select_predecessors, select_predecessors_sorted,
-    validator_visible_tips, weighted_required_acknowledgements,
+    PendingBlockBuffer, ProposalError, build_block_candidate, required_acknowledgements,
+    select_predecessors, select_predecessors_sorted, validator_visible_tips,
+    weighted_required_acknowledgements,
 };
 pub use finality::{
     final_leader_for_wave, is_final_leader, is_weighted_final_leader, latest_final_leader,

--- a/crates/cordial-miners-core/tests/test_dissemination.rs
+++ b/crates/cordial-miners-core/tests/test_dissemination.rs
@@ -106,7 +106,10 @@ fn build_block_candidate_fails_when_no_predecessors_are_available() {
 
     let result = build_block_candidate(&blocklace, &bonds, vec![5, 6]);
 
-    assert!(matches!(result, Err(ProposalError::NoPredecessorsAvailable)));
+    assert!(matches!(
+        result,
+        Err(ProposalError::NoPredecessorsAvailable)
+    ));
 }
 
 #[test]
@@ -150,7 +153,10 @@ fn build_block_candidate_returns_payload_and_selected_predecessors() {
         .expect("sufficient local view should build a candidate");
 
     assert_eq!(candidate.payload, payload);
-    assert_eq!(candidate.predecessors, select_predecessors(&blocklace, &bonds));
+    assert_eq!(
+        candidate.predecessors,
+        select_predecessors(&blocklace, &bonds)
+    );
 }
 
 #[test]
@@ -167,7 +173,10 @@ fn build_block_candidate_extends_single_chain_with_latest_tip() {
     let candidate = build_block_candidate(&blocklace, &bonds, vec![8])
         .expect("single chain with visible tip should produce a candidate");
 
-    assert_eq!(candidate.predecessors, HashSet::from([block2.identity.clone()]));
+    assert_eq!(
+        candidate.predecessors,
+        HashSet::from([block2.identity.clone()])
+    );
 }
 
 #[test]

--- a/crates/cordial-miners-core/tests/test_dissemination.rs
+++ b/crates/cordial-miners-core/tests/test_dissemination.rs
@@ -80,16 +80,33 @@ fn dissemination_test_config() -> ValidationConfig {
 }
 
 #[test]
-fn build_block_candidate_fails_when_no_predecessors_are_available() {
+fn build_block_candidate_allows_bootstrap_on_empty_blocklace() {
     let blocklace = Blocklace::new();
-    let bonds = HashMap::new();
+    let mut bonds = HashMap::new();
+    bonds.insert(node(1), 100);
 
-    let result = build_block_candidate(&blocklace, &bonds, vec![1, 2, 3]);
+    let payload = vec![1, 2, 3];
+    let result = build_block_candidate(&blocklace, &bonds, payload.clone())
+        .expect("empty blocklace should allow the first block");
 
-    assert!(matches!(
-        result,
-        Err(ProposalError::NoPredecessorsAvailable)
-    ));
+    assert_eq!(result.payload, payload);
+    assert!(result.predecessors.is_empty());
+}
+
+#[test]
+fn build_block_candidate_fails_when_no_predecessors_are_available() {
+    let mut blocklace = Blocklace::new();
+    let mut bonds = HashMap::new();
+
+    let e1 = create_mock_block(1, 1, HashSet::new());
+    let e2 = create_mock_block(1, 2, HashSet::new());
+    insert(&mut blocklace, &e1);
+    insert(&mut blocklace, &e2);
+    bonds.insert(node(1), 100);
+
+    let result = build_block_candidate(&blocklace, &bonds, vec![5, 6]);
+
+    assert!(matches!(result, Err(ProposalError::NoPredecessorsAvailable)));
 }
 
 #[test]
@@ -134,6 +151,55 @@ fn build_block_candidate_returns_payload_and_selected_predecessors() {
 
     assert_eq!(candidate.payload, payload);
     assert_eq!(candidate.predecessors, select_predecessors(&blocklace, &bonds));
+}
+
+#[test]
+fn build_block_candidate_extends_single_chain_with_latest_tip() {
+    let mut blocklace = Blocklace::new();
+    let mut bonds = HashMap::new();
+    bonds.insert(node(1), 100);
+
+    let genesis = create_mock_block(1, 1, HashSet::new());
+    let block2 = create_mock_block(1, 2, HashSet::from([genesis.identity.clone()]));
+    insert(&mut blocklace, &genesis);
+    insert(&mut blocklace, &block2);
+
+    let candidate = build_block_candidate(&blocklace, &bonds, vec![8])
+        .expect("single chain with visible tip should produce a candidate");
+
+    assert_eq!(candidate.predecessors, HashSet::from([block2.identity.clone()]));
+}
+
+#[test]
+fn build_block_candidate_includes_missing_equivocation_branches() {
+    let mut blocklace = Blocklace::new();
+    let mut bonds = HashMap::new();
+
+    let e1 = create_mock_block(1, 1, HashSet::new());
+    let e2 = create_mock_block(1, 2, HashSet::new());
+    insert(&mut blocklace, &e1);
+    insert(&mut blocklace, &e2);
+
+    let honest_tip = create_mock_block(2, 3, HashSet::from([e1.identity.clone()]));
+    let tip3 = create_mock_block(3, 4, HashSet::new());
+    let tip4 = create_mock_block(4, 5, HashSet::new());
+    insert(&mut blocklace, &honest_tip);
+    insert(&mut blocklace, &tip3);
+    insert(&mut blocklace, &tip4);
+
+    bonds.insert(node(1), 100);
+    bonds.insert(node(2), 100);
+    bonds.insert(node(3), 100);
+    bonds.insert(node(4), 100);
+
+    let candidate = build_block_candidate(&blocklace, &bonds, vec![9, 9])
+        .expect("honest tip should allow a candidate");
+
+    assert!(candidate.predecessors.contains(&honest_tip.identity));
+    assert!(candidate.predecessors.contains(&tip3.identity));
+    assert!(candidate.predecessors.contains(&tip4.identity));
+    assert!(candidate.predecessors.contains(&e2.identity));
+    assert!(!candidate.predecessors.contains(&e1.identity));
 }
 
 #[test]

--- a/crates/cordial-miners-core/tests/test_dissemination.rs
+++ b/crates/cordial-miners-core/tests/test_dissemination.rs
@@ -1,8 +1,9 @@
 use cordial_miners_core::Block;
 use cordial_miners_core::blocklace::Blocklace;
 use cordial_miners_core::consensus::{
-    PendingBlockBuffer, ValidationConfig, required_acknowledgements, select_predecessors,
-    select_predecessors_sorted, validator_visible_tips, weighted_required_acknowledgements,
+    PendingBlockBuffer, ProposalError, ValidationConfig, build_block_candidate,
+    required_acknowledgements, select_predecessors, select_predecessors_sorted,
+    validator_visible_tips, weighted_required_acknowledgements,
 };
 use cordial_miners_core::crypto::CryptoVerifier;
 use cordial_miners_core::types::{BlockContent, BlockIdentity, NodeId};
@@ -76,6 +77,90 @@ fn dissemination_test_config() -> ValidationConfig {
         check_content_hash: false,
         ..ValidationConfig::default()
     }
+}
+
+#[test]
+fn build_block_candidate_fails_when_no_predecessors_are_available() {
+    let blocklace = Blocklace::new();
+    let bonds = HashMap::new();
+
+    let result = build_block_candidate(&blocklace, &bonds, vec![1, 2, 3]);
+
+    assert!(matches!(
+        result,
+        Err(ProposalError::NoPredecessorsAvailable)
+    ));
+}
+
+#[test]
+fn build_block_candidate_fails_when_visible_tips_are_below_threshold() {
+    let mut blocklace = Blocklace::new();
+    let mut bonds = HashMap::new();
+
+    for i in 1..=4u8 {
+        bonds.insert(node(i), 100);
+    }
+
+    let tip1 = create_mock_block(1, 1, HashSet::new());
+    let tip2 = create_mock_block(2, 2, HashSet::new());
+    insert(&mut blocklace, &tip1);
+    insert(&mut blocklace, &tip2);
+
+    let result = build_block_candidate(&blocklace, &bonds, vec![9]);
+
+    assert!(matches!(
+        result,
+        Err(ProposalError::InsufficientAcknowledgements {
+            observed: 2,
+            required: 3,
+        })
+    ));
+}
+
+#[test]
+fn build_block_candidate_returns_payload_and_selected_predecessors() {
+    let mut blocklace = Blocklace::new();
+    let mut bonds = HashMap::new();
+
+    for i in 1..=4u8 {
+        let block = create_mock_block(i, i, HashSet::new());
+        insert(&mut blocklace, &block);
+        bonds.insert(node(i), 100);
+    }
+
+    let payload = vec![4, 2];
+    let candidate = build_block_candidate(&blocklace, &bonds, payload.clone())
+        .expect("sufficient local view should build a candidate");
+
+    assert_eq!(candidate.payload, payload);
+    assert_eq!(candidate.predecessors, select_predecessors(&blocklace, &bonds));
+}
+
+#[test]
+fn build_block_candidate_is_deterministic_for_same_local_view() {
+    let mut blocklace = Blocklace::new();
+    let mut bonds = HashMap::new();
+
+    let genesis = create_mock_block(1, 1, HashSet::new());
+    let block2 = create_mock_block(2, 2, HashSet::from([genesis.identity.clone()]));
+    let block3 = create_mock_block(3, 3, HashSet::from([genesis.identity.clone()]));
+
+    insert(&mut blocklace, &genesis);
+    insert(&mut blocklace, &block2);
+    insert(&mut blocklace, &block3);
+
+    bonds.insert(node(1), 100);
+    bonds.insert(node(2), 100);
+    bonds.insert(node(3), 100);
+
+    let payload = vec![7];
+    let candidate1 = build_block_candidate(&blocklace, &bonds, payload.clone())
+        .expect("first proposal should succeed");
+    let candidate2 =
+        build_block_candidate(&blocklace, &bonds, payload).expect("second proposal should succeed");
+
+    assert_eq!(candidate1.payload, candidate2.payload);
+    assert_eq!(candidate1.predecessors, candidate2.predecessors);
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

This PR completes the first dissemination proposal-construction layer for Cordial Miners.

It adds:

- deterministic predecessor selection from the local blocklace view
- buffering and replay for out-of-order blocks with missing predecessors
- replay through the full consensus validation path
- local block candidate construction for new proposals

## What changed

Updated:

- `crates/cordial-miners-core/src/consensus/dissemination.rs`
- `crates/cordial-miners-core/tests/test_dissemination.rs`

Added / completed:

- predecessor selection helpers
- deterministic sorted predecessor selection
- equivocation-aware predecessor construction
- `PendingBlockBuffer`
- validated buffered replay
- explicit retryable validation-error handling
- `ProposalError`
- `build_block_candidate(...)`

## Why this matters

These changes establish the first core dissemination foundation for:

- choosing protocol-valid predecessors for outgoing blocks
- safely absorbing incoming blocks under out-of-order delivery
- constructing a new block candidate from the current local view once an external scheduler asks the node to propose

## Tests

Coverage includes:

- empty and degraded local views
- single-chain and multi-tip predecessor selection
- known equivocation handling
- deterministic predecessor ordering
- missing-predecessor buffering and replay
- rejection of invalid buffered blocks
- bootstrap proposal construction
- threshold-gated proposal construction
- deterministic local proposal construction

## Verification

```bash
cargo test -p cordial-miners-core --test test_dissemination -- --nocapture
cargo clippy -p cordial-miners-core --test test_dissemination -- -D warnings