### PR TITLE
Simulate dissemination recovery, finality, and tau convergence

### DIFF
--- a/crates/cordial-miners-core/src/consensus/dissemination.rs
+++ b/crates/cordial-miners-core/src/consensus/dissemination.rs
@@ -215,29 +215,26 @@ pub enum ProposalError {
     NoPredecessorsAvailable,
 }
 
-/// Build a deterministic block-content candidate from the current local view.
+/// Select the predecessor set for the next locally proposed block.
 ///
 /// This helper does not decide *when* a node should propose; it only answers
-/// *what* payload and predecessor set should be used once an external scheduler
-/// requests a proposal.
-///
-/// Proposal construction succeeds only when the local view contains enough
-/// visible honest validator tips to satisfy `required_acknowledgements(...)`.
-/// The predecessor set itself comes from `select_predecessors(...)`, which may
-/// include additional known equivocation branches needed for cordiality.
+/// which predecessors should be referenced once an external scheduler requests
+/// a proposal.
 ///
 /// As a special bootstrap case, an empty blocklace yields an empty predecessor
 /// set so the first block can be proposed before any tips exist.
-pub fn build_block_candidate(
+///
+/// For non-empty views, predecessor selection succeeds only when the local
+/// blocklace contains enough visible honest validator tips to satisfy
+/// `required_acknowledgements(...)`. The returned set itself comes from
+/// `select_predecessors(...)`, which may include additional known equivocation
+/// branches needed for cordiality.
+pub fn next_block_predecessors(
     blocklace: &Blocklace,
     bonds: &HashMap<NodeId, u64>,
-    payload: Vec<u8>,
-) -> Result<BlockContent, ProposalError> {
+) -> Result<HashSet<BlockIdentity>, ProposalError> {
     if blocklace.dom().is_empty() {
-        return Ok(BlockContent {
-            payload,
-            predecessors: HashSet::new(),
-        });
+        return Ok(HashSet::new());
     }
 
     let predecessors = select_predecessors(blocklace, bonds);
@@ -251,6 +248,21 @@ pub fn build_block_candidate(
     if observed < required {
         return Err(ProposalError::InsufficientAcknowledgements { observed, required });
     }
+
+    Ok(predecessors)
+}
+
+/// Build a deterministic block-content candidate from the current local view.
+///
+/// This helper does not decide *when* a node should propose; it only answers
+/// *what* payload and predecessor set should be used once an external scheduler
+/// requests a proposal.
+pub fn build_block_candidate(
+    blocklace: &Blocklace,
+    bonds: &HashMap<NodeId, u64>,
+    payload: Vec<u8>,
+) -> Result<BlockContent, ProposalError> {
+    let predecessors = next_block_predecessors(blocklace, bonds)?;
 
     Ok(BlockContent {
         payload,

--- a/crates/cordial-miners-core/src/consensus/mod.rs
+++ b/crates/cordial-miners-core/src/consensus/mod.rs
@@ -16,9 +16,9 @@ pub use cordiality::{
     super_ratifies, weighted_ratifies, weighted_super_ratifies,
 };
 pub use dissemination::{
-    PendingBlockBuffer, ProposalError, build_block_candidate, required_acknowledgements,
-    select_predecessors, select_predecessors_sorted, validator_visible_tips,
-    weighted_required_acknowledgements,
+    PendingBlockBuffer, ProposalError, build_block_candidate, next_block_predecessors,
+    required_acknowledgements, select_predecessors, select_predecessors_sorted,
+    validator_visible_tips, weighted_required_acknowledgements,
 };
 pub use finality::{
     final_leader_for_wave, is_final_leader, is_weighted_final_leader, latest_final_leader,

--- a/crates/cordial-miners-core/src/lib.rs
+++ b/crates/cordial-miners-core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod dag;
 pub mod execution;
 pub mod finality;
 pub mod network;
+pub mod simulation;
 pub mod types;
 pub mod wave;
 

--- a/crates/cordial-miners-core/src/simulation/dissemination.rs
+++ b/crates/cordial-miners-core/src/simulation/dissemination.rs
@@ -1,0 +1,89 @@
+use std::collections::HashMap;
+
+use crate::Block;
+use crate::blocklace::Blocklace;
+use crate::consensus::{
+    InvalidBlock, PendingBlockBuffer, ValidationConfig, ValidationResult, validated_insert,
+};
+use crate::types::{BlockIdentity, NodeId};
+
+/// Outcome of delivering a block to a simulated node.
+#[derive(Debug, Clone, PartialEq)]
+pub enum DeliveryOutcome {
+    Inserted,
+    Buffered,
+    Rejected(Vec<InvalidBlock>),
+}
+
+/// Minimal node model for dissemination simulations.
+///
+/// This keeps only the local state needed for early dissemination tests:
+/// - a local blocklace view
+/// - a pending buffer for out-of-order blocks
+/// - validation inputs used when receiving or retrying blocks
+pub struct SimNode {
+    pub id: NodeId,
+    pub blocklace: Blocklace,
+    pub pending: PendingBlockBuffer,
+    bonds: HashMap<NodeId, u64>,
+    validation_config: ValidationConfig,
+}
+
+impl SimNode {
+    pub fn new(
+        id: NodeId,
+        bonds: HashMap<NodeId, u64>,
+        validation_config: ValidationConfig,
+    ) -> Self {
+        Self {
+            id,
+            blocklace: Blocklace::new(),
+            pending: PendingBlockBuffer::new(),
+            bonds,
+            validation_config,
+        }
+    }
+
+    /// Deliver a block into the node's local view.
+    ///
+    /// Missing-predecessor blocks are buffered for later replay. Blocks that
+    /// fail for any other reason are rejected immediately.
+    pub fn receive_block(&mut self, block: Block) -> DeliveryOutcome {
+        match validated_insert(
+            block.clone(),
+            &mut self.blocklace,
+            &self.bonds,
+            &self.validation_config,
+        ) {
+            ValidationResult::Valid => DeliveryOutcome::Inserted,
+            ValidationResult::Invalid(errors) => {
+                if errors
+                    .iter()
+                    .all(|error| matches!(error, InvalidBlock::MissingPredecessors { .. }))
+                {
+                    self.pending.buffer_block_with_missing_predecessors(block);
+                    DeliveryOutcome::Buffered
+                } else {
+                    DeliveryOutcome::Rejected(errors)
+                }
+            }
+        }
+    }
+
+    /// Retry any buffered blocks against the current local view.
+    pub fn retry_buffered_blocks(&mut self) {
+        self.pending.retry_buffered_blocks(
+            &mut self.blocklace,
+            &self.bonds,
+            &self.validation_config,
+        );
+    }
+
+    pub fn knows_block(&self, id: &BlockIdentity) -> bool {
+        self.blocklace.content(id).is_some()
+    }
+
+    pub fn pending_len(&self) -> usize {
+        self.pending.buffered_blocks.len()
+    }
+}

--- a/crates/cordial-miners-core/src/simulation/dissemination.rs
+++ b/crates/cordial-miners-core/src/simulation/dissemination.rs
@@ -15,6 +15,12 @@ pub enum DeliveryOutcome {
     Rejected(Vec<InvalidBlock>),
 }
 
+#[derive(Debug, Clone)]
+struct PendingDelivery {
+    recipient: NodeId,
+    block: Block,
+}
+
 /// Minimal node model for dissemination simulations.
 ///
 /// This keeps only the local state needed for early dissemination tests:
@@ -85,5 +91,57 @@ impl SimNode {
 
     pub fn pending_len(&self) -> usize {
         self.pending.buffered_blocks.len()
+    }
+}
+
+/// Minimal network harness for dissemination simulations.
+///
+/// This keeps a set of simulated nodes plus an explicit delivery queue so tests
+/// can control message order.
+pub struct SimNetwork {
+    pub nodes: HashMap<NodeId, SimNode>,
+    pending_deliveries: Vec<PendingDelivery>,
+}
+
+impl SimNetwork {
+    pub fn new(nodes: Vec<SimNode>) -> Self {
+        let nodes = nodes.into_iter().map(|node| (node.id.clone(), node)).collect();
+        Self {
+            nodes,
+            pending_deliveries: Vec::new(),
+        }
+    }
+
+    pub fn node(&self, id: &NodeId) -> Option<&SimNode> {
+        self.nodes.get(id)
+    }
+
+    pub fn node_mut(&mut self, id: &NodeId) -> Option<&mut SimNode> {
+        self.nodes.get_mut(id)
+    }
+
+    pub fn queue_delivery(&mut self, recipient: NodeId, block: Block) {
+        self.pending_deliveries
+            .push(PendingDelivery { recipient, block });
+    }
+
+    pub fn queued_delivery_count(&self) -> usize {
+        self.pending_deliveries.len()
+    }
+
+    pub fn deliver_next_to(&mut self, recipient: &NodeId) -> Option<DeliveryOutcome> {
+        let idx = self
+            .pending_deliveries
+            .iter()
+            .position(|delivery| &delivery.recipient == recipient)?;
+        let delivery = self.pending_deliveries.remove(idx);
+        let node = self.nodes.get_mut(recipient)?;
+        Some(node.receive_block(delivery.block))
+    }
+
+    pub fn retry_all_buffers(&mut self) {
+        for node in self.nodes.values_mut() {
+            node.retry_buffered_blocks();
+        }
     }
 }

--- a/crates/cordial-miners-core/src/simulation/dissemination.rs
+++ b/crates/cordial-miners-core/src/simulation/dissemination.rs
@@ -4,8 +4,9 @@ use crate::Block;
 use crate::blocklace::Blocklace;
 use crate::consensus::{
     InvalidBlock, PendingBlockBuffer, ProposalError, ValidationConfig, ValidationResult,
-    build_block_candidate, validated_insert,
+    build_block_candidate, latest_final_leader, tau, validated_insert,
 };
+use crate::consensus::OrderingError;
 use crate::types::{BlockContent, BlockIdentity, NodeId};
 
 /// Outcome of delivering a block to a simulated node.
@@ -97,6 +98,32 @@ impl SimNode {
     /// Build a local block candidate from the node's current view.
     pub fn build_block_candidate(&self, payload: Vec<u8>) -> Result<BlockContent, ProposalError> {
         build_block_candidate(&self.blocklace, &self.bonds, payload)
+    }
+
+    pub fn latest_final_leader<F>(
+        &self,
+        wavelength: u64,
+        n: usize,
+        f: usize,
+        leader_selection: F,
+    ) -> Option<BlockIdentity>
+    where
+        F: Fn(u64) -> Option<NodeId> + Copy,
+    {
+        latest_final_leader(&self.blocklace, wavelength, n, f, leader_selection)
+    }
+
+    pub fn ordered_output<F>(
+        &self,
+        wavelength: u64,
+        n: usize,
+        f: usize,
+        leader_selection: F,
+    ) -> Result<Vec<BlockIdentity>, OrderingError>
+    where
+        F: Fn(u64) -> Option<NodeId> + Copy,
+    {
+        tau(&self.blocklace, wavelength, n, f, leader_selection)
     }
 }
 

--- a/crates/cordial-miners-core/src/simulation/dissemination.rs
+++ b/crates/cordial-miners-core/src/simulation/dissemination.rs
@@ -2,11 +2,11 @@ use std::collections::HashMap;
 
 use crate::Block;
 use crate::blocklace::Blocklace;
+use crate::consensus::OrderingError;
 use crate::consensus::{
     InvalidBlock, PendingBlockBuffer, ProposalError, ValidationConfig, ValidationResult,
     build_block_candidate, latest_final_leader, tau, validated_insert,
 };
-use crate::consensus::OrderingError;
 use crate::types::{BlockContent, BlockIdentity, NodeId};
 
 /// Outcome of delivering a block to a simulated node.

--- a/crates/cordial-miners-core/src/simulation/dissemination.rs
+++ b/crates/cordial-miners-core/src/simulation/dissemination.rs
@@ -111,7 +111,10 @@ pub struct SimNetwork {
 
 impl SimNetwork {
     pub fn new(nodes: Vec<SimNode>) -> Self {
-        let nodes = nodes.into_iter().map(|node| (node.id.clone(), node)).collect();
+        let nodes = nodes
+            .into_iter()
+            .map(|node| (node.id.clone(), node))
+            .collect();
         Self {
             nodes,
             pending_deliveries: Vec::new(),

--- a/crates/cordial-miners-core/src/simulation/dissemination.rs
+++ b/crates/cordial-miners-core/src/simulation/dissemination.rs
@@ -5,7 +5,8 @@ use crate::blocklace::Blocklace;
 use crate::consensus::OrderingError;
 use crate::consensus::{
     InvalidBlock, PendingBlockBuffer, ProposalError, ValidationConfig, ValidationResult,
-    build_block_candidate, latest_final_leader, tau, validated_insert,
+    build_block_candidate, latest_final_leader, latest_weighted_final_leader, tau,
+    validated_insert, weighted_tau,
 };
 use crate::types::{BlockContent, BlockIdentity, NodeId};
 
@@ -124,6 +125,28 @@ impl SimNode {
         F: Fn(u64) -> Option<NodeId> + Copy,
     {
         tau(&self.blocklace, wavelength, n, f, leader_selection)
+    }
+
+    pub fn latest_weighted_final_leader<F>(
+        &self,
+        wavelength: u64,
+        leader_selection: F,
+    ) -> Option<BlockIdentity>
+    where
+        F: Fn(u64) -> Option<NodeId> + Copy,
+    {
+        latest_weighted_final_leader(&self.blocklace, wavelength, &self.bonds, leader_selection)
+    }
+
+    pub fn weighted_ordered_output<F>(
+        &self,
+        wavelength: u64,
+        leader_selection: F,
+    ) -> Result<Vec<BlockIdentity>, OrderingError>
+    where
+        F: Fn(u64) -> Option<NodeId> + Copy,
+    {
+        weighted_tau(&self.blocklace, wavelength, &self.bonds, leader_selection)
     }
 }
 

--- a/crates/cordial-miners-core/src/simulation/dissemination.rs
+++ b/crates/cordial-miners-core/src/simulation/dissemination.rs
@@ -3,9 +3,10 @@ use std::collections::HashMap;
 use crate::Block;
 use crate::blocklace::Blocklace;
 use crate::consensus::{
-    InvalidBlock, PendingBlockBuffer, ValidationConfig, ValidationResult, validated_insert,
+    InvalidBlock, PendingBlockBuffer, ProposalError, ValidationConfig, ValidationResult,
+    build_block_candidate, validated_insert,
 };
-use crate::types::{BlockIdentity, NodeId};
+use crate::types::{BlockContent, BlockIdentity, NodeId};
 
 /// Outcome of delivering a block to a simulated node.
 #[derive(Debug, Clone, PartialEq)]
@@ -91,6 +92,11 @@ impl SimNode {
 
     pub fn pending_len(&self) -> usize {
         self.pending.buffered_blocks.len()
+    }
+
+    /// Build a local block candidate from the node's current view.
+    pub fn build_block_candidate(&self, payload: Vec<u8>) -> Result<BlockContent, ProposalError> {
+        build_block_candidate(&self.blocklace, &self.bonds, payload)
     }
 }
 

--- a/crates/cordial-miners-core/src/simulation/mod.rs
+++ b/crates/cordial-miners-core/src/simulation/mod.rs
@@ -1,0 +1,2 @@
+pub mod dissemination;
+

--- a/crates/cordial-miners-core/src/simulation/mod.rs
+++ b/crates/cordial-miners-core/src/simulation/mod.rs
@@ -1,2 +1,1 @@
 pub mod dissemination;
-

--- a/crates/cordial-miners-core/tests/test_dissemination.rs
+++ b/crates/cordial-miners-core/tests/test_dissemination.rs
@@ -2,9 +2,8 @@ use cordial_miners_core::Block;
 use cordial_miners_core::blocklace::Blocklace;
 use cordial_miners_core::consensus::{
     PendingBlockBuffer, ProposalError, ValidationConfig, build_block_candidate,
-    next_block_predecessors,
-    required_acknowledgements, select_predecessors, select_predecessors_sorted,
-    validator_visible_tips, weighted_required_acknowledgements,
+    next_block_predecessors, required_acknowledgements, select_predecessors,
+    select_predecessors_sorted, validator_visible_tips, weighted_required_acknowledgements,
 };
 use cordial_miners_core::crypto::CryptoVerifier;
 use cordial_miners_core::types::{BlockContent, BlockIdentity, NodeId};

--- a/crates/cordial-miners-core/tests/test_dissemination.rs
+++ b/crates/cordial-miners-core/tests/test_dissemination.rs
@@ -2,6 +2,7 @@ use cordial_miners_core::Block;
 use cordial_miners_core::blocklace::Blocklace;
 use cordial_miners_core::consensus::{
     PendingBlockBuffer, ProposalError, ValidationConfig, build_block_candidate,
+    next_block_predecessors,
     required_acknowledgements, select_predecessors, select_predecessors_sorted,
     validator_visible_tips, weighted_required_acknowledgements,
 };
@@ -80,21 +81,19 @@ fn dissemination_test_config() -> ValidationConfig {
 }
 
 #[test]
-fn build_block_candidate_allows_bootstrap_on_empty_blocklace() {
+fn next_block_predecessors_allows_bootstrap_on_empty_blocklace() {
     let blocklace = Blocklace::new();
     let mut bonds = HashMap::new();
     bonds.insert(node(1), 100);
 
-    let payload = vec![1, 2, 3];
-    let result = build_block_candidate(&blocklace, &bonds, payload.clone())
+    let predecessors = next_block_predecessors(&blocklace, &bonds)
         .expect("empty blocklace should allow the first block");
 
-    assert_eq!(result.payload, payload);
-    assert!(result.predecessors.is_empty());
+    assert!(predecessors.is_empty());
 }
 
 #[test]
-fn build_block_candidate_fails_when_no_predecessors_are_available() {
+fn next_block_predecessors_fails_when_no_predecessors_are_available() {
     let mut blocklace = Blocklace::new();
     let mut bonds = HashMap::new();
 
@@ -104,7 +103,7 @@ fn build_block_candidate_fails_when_no_predecessors_are_available() {
     insert(&mut blocklace, &e2);
     bonds.insert(node(1), 100);
 
-    let result = build_block_candidate(&blocklace, &bonds, vec![5, 6]);
+    let result = next_block_predecessors(&blocklace, &bonds);
 
     assert!(matches!(
         result,
@@ -113,7 +112,7 @@ fn build_block_candidate_fails_when_no_predecessors_are_available() {
 }
 
 #[test]
-fn build_block_candidate_fails_when_visible_tips_are_below_threshold() {
+fn next_block_predecessors_fails_when_visible_tips_are_below_threshold() {
     let mut blocklace = Blocklace::new();
     let mut bonds = HashMap::new();
 
@@ -126,7 +125,7 @@ fn build_block_candidate_fails_when_visible_tips_are_below_threshold() {
     insert(&mut blocklace, &tip1);
     insert(&mut blocklace, &tip2);
 
-    let result = build_block_candidate(&blocklace, &bonds, vec![9]);
+    let result = next_block_predecessors(&blocklace, &bonds);
 
     assert!(matches!(
         result,
@@ -135,6 +134,20 @@ fn build_block_candidate_fails_when_visible_tips_are_below_threshold() {
             required: 3,
         })
     ));
+}
+
+#[test]
+fn build_block_candidate_allows_bootstrap_on_empty_blocklace() {
+    let blocklace = Blocklace::new();
+    let mut bonds = HashMap::new();
+    bonds.insert(node(1), 100);
+
+    let payload = vec![1, 2, 3];
+    let result = build_block_candidate(&blocklace, &bonds, payload.clone())
+        .expect("empty blocklace should allow the first block");
+
+    assert_eq!(result.payload, payload);
+    assert!(result.predecessors.is_empty());
 }
 
 #[test]
@@ -157,6 +170,25 @@ fn build_block_candidate_returns_payload_and_selected_predecessors() {
         candidate.predecessors,
         select_predecessors(&blocklace, &bonds)
     );
+}
+
+#[test]
+fn build_block_candidate_uses_next_block_predecessors() {
+    let mut blocklace = Blocklace::new();
+    let mut bonds = HashMap::new();
+
+    for i in 1..=4u8 {
+        let block = create_mock_block(i, i, HashSet::new());
+        insert(&mut blocklace, &block);
+        bonds.insert(node(i), 100);
+    }
+
+    let predecessors = next_block_predecessors(&blocklace, &bonds)
+        .expect("healthy local view should select predecessors");
+    let candidate = build_block_candidate(&blocklace, &bonds, vec![3, 1, 4])
+        .expect("healthy local view should build a candidate");
+
+    assert_eq!(candidate.predecessors, predecessors);
 }
 
 #[test]

--- a/crates/cordial-miners-core/tests/test_dissemination_simulation.rs
+++ b/crates/cordial-miners-core/tests/test_dissemination_simulation.rs
@@ -1,7 +1,7 @@
-use cordial_miners_core::simulation::dissemination::{DeliveryOutcome, SimNetwork, SimNode};
 use cordial_miners_core::consensus::ProposalError;
-use cordial_miners_core::{Block, BlockContent, BlockIdentity, NodeId};
 use cordial_miners_core::consensus::ValidationConfig;
+use cordial_miners_core::simulation::dissemination::{DeliveryOutcome, SimNetwork, SimNode};
+use cordial_miners_core::{Block, BlockContent, BlockIdentity, NodeId};
 use std::collections::{HashMap, HashSet};
 
 fn node(id: u8) -> NodeId {
@@ -63,114 +63,115 @@ fn out_of_order_delivery_is_buffered_then_resolved_after_parent_arrives() {
 #[test]
 fn two_nodes_converge_after_receiving_the_same_blocks_in_different_orders() {
     let mut bonds = HashMap::new();
-    bonds.insert(node(1), 100);
-    bonds.insert(node(2), 100);
+    bonds.insert(node(1), 100); // Include a bond for the block creator to ensure blocks are considered valid
+    bonds.insert(node(2), 100); // Include a bond for the block creator to ensure blocks are considered valid
 
-    let node_a = SimNode::new(node(10), bonds.clone(), simulation_validation_config());
-    let node_b = SimNode::new(node(11), bonds, simulation_validation_config());
+    let node_a = SimNode::new(node(10), bonds.clone(), simulation_validation_config()); // Create a separate bonds map for node A to ensure it has the same bond information as node B
+    let node_b = SimNode::new(node(11), bonds, simulation_validation_config()); // Create a separate bonds map for node B to ensure it has the same bond information as node A
     let mut network = SimNetwork::new(vec![node_a, node_b]);
 
-    let genesis = create_block(1, 1, HashSet::new());
-    let child = create_block(2, 2, HashSet::from([genesis.identity.clone()]));
+    let genesis = create_block(1, 1, HashSet::new()); // Create a genesis block with a bond for the creator to ensure it's considered valid
+    let child = create_block(2, 2, HashSet::from([genesis.identity.clone()])); // Create a child block that references the genesis block
 
-    network.queue_delivery(node(10), genesis.clone());
-    network.queue_delivery(node(10), child.clone());
-    network.queue_delivery(node(11), child.clone());
-    network.queue_delivery(node(11), genesis.clone());
-    assert_eq!(network.queued_delivery_count(), 4);
+    network.queue_delivery(node(10), genesis.clone()); // Queue the genesis block for delivery to node A
+    network.queue_delivery(node(10), child.clone()); // Queue the child block for delivery to node A
+    network.queue_delivery(node(11), child.clone()); // Queue the child block for delivery to node B before the genesis block to simulate out-of-order delivery
+    network.queue_delivery(node(11), genesis.clone()); // Queue the genesis block for delivery to node B after the child block to simulate out-of-order delivery
+    // in the queue for node B, the child block will be attempted for delivery before the genesis block, which should result in it being buffered until the genesis block is delivered and processed
+    assert_eq!(network.queued_delivery_count(), 4); // Ensure all blocks are queued for delivery
 
     assert_eq!(
-        network.deliver_next_to(&node(10)),
+        network.deliver_next_to(&node(10)), // Deliver the genesis block to node A, which should be inserted successfully
         Some(DeliveryOutcome::Inserted)
     );
     assert_eq!(
-        network.deliver_next_to(&node(10)),
+        network.deliver_next_to(&node(10)), // Deliver the child block to node A, which should be inserted successfully since the genesis block is already known
         Some(DeliveryOutcome::Inserted)
     );
 
     assert_eq!(
         network.deliver_next_to(&node(11)),
-        Some(DeliveryOutcome::Buffered)
+        Some(DeliveryOutcome::Buffered) // Deliver the child block to node B, which should be buffered since the genesis block is not yet known
     );
     assert_eq!(
         network
             .node(&node(11))
             .expect("node B should exist")
-            .pending_len(),
+            .pending_len(), // Check that the child block is in the pending buffer of node B
         1
     );
 
     assert_eq!(
         network.deliver_next_to(&node(11)),
-        Some(DeliveryOutcome::Inserted)
+        Some(DeliveryOutcome::Inserted) // Deliver the genesis block to node B, which should be inserted successfully and trigger a retry of the buffered child block
     );
 
-    network.retry_all_buffers();
+    network.retry_all_buffers(); // Retry all buffered blocks in the network, which should result in the child block being inserted into node B since its parent (the genesis block) is now known
 
-    let node_a = network.node(&node(10)).expect("node A should exist");
-    let node_b = network.node(&node(11)).expect("node B should exist");
+    let node_a = network.node(&node(10)).expect("node A should exist"); // Retrieve node A from the network to check its known blocks
+    let node_b = network.node(&node(11)).expect("node B should exist"); // Retrieve node B from the network to check its known blocks
 
-    assert!(node_a.knows_block(&genesis.identity));
-    assert!(node_a.knows_block(&child.identity));
-    assert!(node_b.knows_block(&genesis.identity));
-    assert!(node_b.knows_block(&child.identity));
-    assert_eq!(node_b.pending_len(), 0);
+    assert!(node_a.knows_block(&genesis.identity)); // Check that node A knows the genesis block
+    assert!(node_a.knows_block(&child.identity)); // Check that node A knows the child block
+    assert!(node_b.knows_block(&genesis.identity)); // Check that node B knows the genesis block
+    assert!(node_b.knows_block(&child.identity)); // Check that node B knows the child block after the genesis block was delivered and the buffered child block was retried
+    assert_eq!(node_b.pending_len(), 0); // Check that node B's pending buffer is empty after the buffered child block was successfully inserted
 }
 
 #[test]
 fn proposal_construction_converges_after_nodes_catch_up_on_visible_tips() {
     let mut bonds = HashMap::new();
-    bonds.insert(node(1), 100);
-    bonds.insert(node(2), 100);
-    bonds.insert(node(3), 100);
-    bonds.insert(node(4), 100);
+    bonds.insert(node(1), 100); // Include a bond for the block creator to ensure blocks are considered valid
+    bonds.insert(node(2), 100); // Include a bond for the block creator to ensure blocks are considered valid
+    bonds.insert(node(3), 100); // Include a bond for the block creator to ensure blocks are considered valid
+    bonds.insert(node(4), 100); // Include a bond for the block creator to ensure blocks are considered valid
 
-    let node_a = SimNode::new(node(20), bonds.clone(), simulation_validation_config());
-    let node_b = SimNode::new(node(21), bonds, simulation_validation_config());
-    let mut network = SimNetwork::new(vec![node_a, node_b]);
+    let node_a = SimNode::new(node(20), bonds.clone(), simulation_validation_config()); // Create a separate bonds map for node A to ensure it has the same bond information as node B
+    let node_b = SimNode::new(node(21), bonds, simulation_validation_config()); // Create a separate bonds map for node B to ensure it has the same bond information as node A
+    let mut network = SimNetwork::new(vec![node_a, node_b]); // Create a simulation network with both nodes
 
-    let tip1 = create_block(1, 1, HashSet::new());
-    let tip2 = create_block(2, 2, HashSet::new());
-    let tip3 = create_block(3, 3, HashSet::new());
+    let tip1 = create_block(1, 1, HashSet::new()); // Create a tip block with a bond for the creator to ensure it's considered valid
+    let tip2 = create_block(2, 2, HashSet::new()); // Create another tip block with a bond for the creator to ensure it's considered valid
+    let tip3 = create_block(3, 3, HashSet::new()); // Create a third tip block with a bond for the creator to ensure it's considered valid
 
     for block in [&tip1, &tip2, &tip3] {
-        network.queue_delivery(node(20), block.clone());
+        network.queue_delivery(node(20), block.clone()); // Queue all three tip blocks for delivery to node A to ensure it has all the visible tips needed for proposal construction
     }
     for block in [&tip1, &tip2] {
-        network.queue_delivery(node(21), block.clone());
+        network.queue_delivery(node(21), block.clone()); // Queue only two of the tip blocks for delivery to node B to simulate it being slightly behind in terms of visible tips needed for proposal construction
     }
 
     assert_eq!(
         network.deliver_next_to(&node(20)),
-        Some(DeliveryOutcome::Inserted)
+        Some(DeliveryOutcome::Inserted) // Deliver the first tip block to node A, which should be inserted successfully
     );
     assert_eq!(
         network.deliver_next_to(&node(20)),
-        Some(DeliveryOutcome::Inserted)
+        Some(DeliveryOutcome::Inserted) // Deliver the second tip block to node A, which should be inserted successfully
     );
     assert_eq!(
         network.deliver_next_to(&node(20)),
-        Some(DeliveryOutcome::Inserted)
+        Some(DeliveryOutcome::Inserted) // Deliver the third tip block to node A, which should be inserted successfully
     );
 
     assert_eq!(
         network.deliver_next_to(&node(21)),
-        Some(DeliveryOutcome::Inserted)
+        Some(DeliveryOutcome::Inserted) // Deliver the first tip block to node B, which should be inserted successfully
     );
     assert_eq!(
         network.deliver_next_to(&node(21)),
-        Some(DeliveryOutcome::Inserted)
+        Some(DeliveryOutcome::Inserted) // Deliver the second tip block to node B, which should be inserted successfully
     );
 
     let payload = vec![9, 9];
 
-    let candidate_a = network
+    let candidate_a = network // Have node A attempt to build a block candidate using the three tip blocks it knows, which should succeed since it has all the required visible tips
         .node(&node(20))
         .expect("node A should exist")
         .build_block_candidate(payload.clone())
         .expect("node A should have enough visible tips to propose");
 
-    let candidate_b_before = network
+    let candidate_b_before = network // Have node B attempt to build a block candidate using the two tip blocks it knows, which should fail since it doesn't have all the required visible tips (it is missing tip3) and thus doesn't have enough acknowledgements to propose
         .node(&node(21))
         .expect("node B should exist")
         .build_block_candidate(payload.clone());
@@ -178,23 +179,24 @@ fn proposal_construction_converges_after_nodes_catch_up_on_visible_tips() {
     assert!(matches!(
         candidate_b_before,
         Err(ProposalError::InsufficientAcknowledgements {
+            // Check that the error is specifically about insufficient acknowledgements, which indicates that node B correctly identified that it doesn't have enough visible tips to propose
             observed: 2,
             required: 3,
         })
     ));
 
-    network.queue_delivery(node(21), tip3.clone());
+    network.queue_delivery(node(21), tip3.clone()); // Queue the missing tip block for delivery to node B to simulate it catching up on the visible tips needed for proposal construction
     assert_eq!(
         network.deliver_next_to(&node(21)),
         Some(DeliveryOutcome::Inserted)
     );
 
-    let candidate_b_after = network
+    let candidate_b_after = network // Have node B attempt to build a block candidate using the three tip blocks it now knows, which should succeed since it has all the required visible tips
         .node(&node(21))
         .expect("node B should exist")
         .build_block_candidate(payload)
         .expect("node B should propose after catching up");
 
-    assert_eq!(candidate_a.payload, candidate_b_after.payload);
-    assert_eq!(candidate_a.predecessors, candidate_b_after.predecessors);
+    assert_eq!(candidate_a.payload, candidate_b_after.payload); // Check that the payloads of the two candidates are the same, which indicates that both nodes constructed their candidates using the same set of visible tips and thus converged on the same proposal content
+    assert_eq!(candidate_a.predecessors, candidate_b_after.predecessors); // Check that the predecessors of the two candidates are the same, which indicates that both nodes constructed their candidates using the same set of visible tips and thus converged on the same proposal content
 }

--- a/crates/cordial-miners-core/tests/test_dissemination_simulation.rs
+++ b/crates/cordial-miners-core/tests/test_dissemination_simulation.rs
@@ -40,24 +40,31 @@ fn leader_node1(_wave: u64) -> Option<NodeId> {
 
 #[test]
 fn out_of_order_delivery_is_buffered_then_resolved_after_parent_arrives() {
+    // Minimal 2-validator setting: validator 1 creates the parent, validator 2
+    // creates a child that depends on it.
     let mut bonds = HashMap::new();
     bonds.insert(node(1), 100);
     bonds.insert(node(2), 100);
 
+    // Single simulated node receiving blocks from the network.
     let mut sim_node = SimNode::new(node(9), bonds, simulation_validation_config());
 
     let genesis = create_block(1, 1, HashSet::new());
     let child = create_block(2, 2, HashSet::from([genesis.identity.clone()]));
 
+    // The child arrives before its parent, so it cannot be inserted yet and
+    // must be buffered.
     let early_delivery = sim_node.receive_block(child.clone());
     assert_eq!(early_delivery, DeliveryOutcome::Buffered);
     assert_eq!(sim_node.pending_len(), 1);
     assert!(!sim_node.knows_block(&child.identity));
 
+    // Once the parent arrives, it is inserted normally.
     let parent_delivery = sim_node.receive_block(genesis.clone());
     assert_eq!(parent_delivery, DeliveryOutcome::Inserted);
     assert!(sim_node.knows_block(&genesis.identity));
 
+    // Retrying the buffer should now resolve the child as well.
     sim_node.retry_buffered_blocks();
 
     assert_eq!(sim_node.pending_len(), 0);
@@ -66,116 +73,129 @@ fn out_of_order_delivery_is_buffered_then_resolved_after_parent_arrives() {
 
 #[test]
 fn two_nodes_converge_after_receiving_the_same_blocks_in_different_orders() {
+    // Two bonded creators produce a tiny parent/child chain.
     let mut bonds = HashMap::new();
-    bonds.insert(node(1), 100); // Include a bond for the block creator to ensure blocks are considered valid
-    bonds.insert(node(2), 100); // Include a bond for the block creator to ensure blocks are considered valid
+    bonds.insert(node(1), 100);
+    bonds.insert(node(2), 100);
 
-    let node_a = SimNode::new(node(10), bonds.clone(), simulation_validation_config()); // Create a separate bonds map for node A to ensure it has the same bond information as node B
-    let node_b = SimNode::new(node(11), bonds, simulation_validation_config()); // Create a separate bonds map for node B to ensure it has the same bond information as node A
+    // Node A and node B start from empty local views.
+    let node_a = SimNode::new(node(10), bonds.clone(), simulation_validation_config());
+    let node_b = SimNode::new(node(11), bonds, simulation_validation_config());
     let mut network = SimNetwork::new(vec![node_a, node_b]);
 
-    let genesis = create_block(1, 1, HashSet::new()); // Create a genesis block with a bond for the creator to ensure it's considered valid
-    let child = create_block(2, 2, HashSet::from([genesis.identity.clone()])); // Create a child block that references the genesis block
+    let genesis = create_block(1, 1, HashSet::new());
+    let child = create_block(2, 2, HashSet::from([genesis.identity.clone()]));
 
-    network.queue_delivery(node(10), genesis.clone()); // Queue the genesis block for delivery to node A
-    network.queue_delivery(node(10), child.clone()); // Queue the child block for delivery to node A
-    network.queue_delivery(node(11), child.clone()); // Queue the child block for delivery to node B before the genesis block to simulate out-of-order delivery
-    network.queue_delivery(node(11), genesis.clone()); // Queue the genesis block for delivery to node B after the child block to simulate out-of-order delivery
-    // in the queue for node B, the child block will be attempted for delivery before the genesis block, which should result in it being buffered until the genesis block is delivered and processed
-    assert_eq!(network.queued_delivery_count(), 4); // Ensure all blocks are queued for delivery
+    // Node A receives the chain in order.
+    network.queue_delivery(node(10), genesis.clone());
+    network.queue_delivery(node(10), child.clone());
+    // Node B sees the same chain out of order and must buffer the child first.
+    network.queue_delivery(node(11), child.clone());
+    network.queue_delivery(node(11), genesis.clone());
+    assert_eq!(network.queued_delivery_count(), 4);
 
     assert_eq!(
-        network.deliver_next_to(&node(10)), // Deliver the genesis block to node A, which should be inserted successfully
+        network.deliver_next_to(&node(10)),
         Some(DeliveryOutcome::Inserted)
     );
     assert_eq!(
-        network.deliver_next_to(&node(10)), // Deliver the child block to node A, which should be inserted successfully since the genesis block is already known
+        network.deliver_next_to(&node(10)),
         Some(DeliveryOutcome::Inserted)
     );
 
+    // Node B cannot yet insert the child because it does not know the parent.
     assert_eq!(
         network.deliver_next_to(&node(11)),
-        Some(DeliveryOutcome::Buffered) // Deliver the child block to node B, which should be buffered since the genesis block is not yet known
+        Some(DeliveryOutcome::Buffered)
     );
     assert_eq!(
         network
             .node(&node(11))
             .expect("node B should exist")
-            .pending_len(), // Check that the child block is in the pending buffer of node B
+            .pending_len(),
         1
     );
 
+    // Once the parent arrives, node B can process it and later resolve the child.
     assert_eq!(
         network.deliver_next_to(&node(11)),
-        Some(DeliveryOutcome::Inserted) // Deliver the genesis block to node B, which should be inserted successfully and trigger a retry of the buffered child block
+        Some(DeliveryOutcome::Inserted)
     );
 
-    network.retry_all_buffers(); // Retry all buffered blocks in the network, which should result in the child block being inserted into node B since its parent (the genesis block) is now known
+    network.retry_all_buffers();
 
-    let node_a = network.node(&node(10)).expect("node A should exist"); // Retrieve node A from the network to check its known blocks
-    let node_b = network.node(&node(11)).expect("node B should exist"); // Retrieve node B from the network to check its known blocks
+    let node_a = network.node(&node(10)).expect("node A should exist");
+    let node_b = network.node(&node(11)).expect("node B should exist");
 
-    assert!(node_a.knows_block(&genesis.identity)); // Check that node A knows the genesis block
-    assert!(node_a.knows_block(&child.identity)); // Check that node A knows the child block
-    assert!(node_b.knows_block(&genesis.identity)); // Check that node B knows the genesis block
-    assert!(node_b.knows_block(&child.identity)); // Check that node B knows the child block after the genesis block was delivered and the buffered child block was retried
-    assert_eq!(node_b.pending_len(), 0); // Check that node B's pending buffer is empty after the buffered child block was successfully inserted
+    // After catch-up, both nodes should know the same chain and the buffer
+    // should be empty again.
+    assert!(node_a.knows_block(&genesis.identity));
+    assert!(node_a.knows_block(&child.identity));
+    assert!(node_b.knows_block(&genesis.identity));
+    assert!(node_b.knows_block(&child.identity));
+    assert_eq!(node_b.pending_len(), 0);
 }
 
 #[test]
 fn proposal_construction_converges_after_nodes_catch_up_on_visible_tips() {
+    // Four bonded validators so the unweighted acknowledgement threshold is 3.
     let mut bonds = HashMap::new();
-    bonds.insert(node(1), 100); // Include a bond for the block creator to ensure blocks are considered valid
-    bonds.insert(node(2), 100); // Include a bond for the block creator to ensure blocks are considered valid
-    bonds.insert(node(3), 100); // Include a bond for the block creator to ensure blocks are considered valid
-    bonds.insert(node(4), 100); // Include a bond for the block creator to ensure blocks are considered valid
+    bonds.insert(node(1), 100);
+    bonds.insert(node(2), 100);
+    bonds.insert(node(3), 100);
+    bonds.insert(node(4), 100);
 
-    let node_a = SimNode::new(node(20), bonds.clone(), simulation_validation_config()); // Create a separate bonds map for node A to ensure it has the same bond information as node B
-    let node_b = SimNode::new(node(21), bonds, simulation_validation_config()); // Create a separate bonds map for node B to ensure it has the same bond information as node A
-    let mut network = SimNetwork::new(vec![node_a, node_b]); // Create a simulation network with both nodes
+    // Node A will have a complete local view. Node B will initially miss one tip.
+    let node_a = SimNode::new(node(20), bonds.clone(), simulation_validation_config());
+    let node_b = SimNode::new(node(21), bonds, simulation_validation_config());
+    let mut network = SimNetwork::new(vec![node_a, node_b]);
 
-    let tip1 = create_block(1, 1, HashSet::new()); // Create a tip block with a bond for the creator to ensure it's considered valid
-    let tip2 = create_block(2, 2, HashSet::new()); // Create another tip block with a bond for the creator to ensure it's considered valid
-    let tip3 = create_block(3, 3, HashSet::new()); // Create a third tip block with a bond for the creator to ensure it's considered valid
+    let tip1 = create_block(1, 1, HashSet::new());
+    let tip2 = create_block(2, 2, HashSet::new());
+    let tip3 = create_block(3, 3, HashSet::new());
 
+    // Node A sees all three visible tips.
     for block in [&tip1, &tip2, &tip3] {
-        network.queue_delivery(node(20), block.clone()); // Queue all three tip blocks for delivery to node A to ensure it has all the visible tips needed for proposal construction
+        network.queue_delivery(node(20), block.clone());
     }
+    // Node B starts behind and sees only two of them.
     for block in [&tip1, &tip2] {
-        network.queue_delivery(node(21), block.clone()); // Queue only two of the tip blocks for delivery to node B to simulate it being slightly behind in terms of visible tips needed for proposal construction
+        network.queue_delivery(node(21), block.clone());
     }
 
     assert_eq!(
         network.deliver_next_to(&node(20)),
-        Some(DeliveryOutcome::Inserted) // Deliver the first tip block to node A, which should be inserted successfully
+        Some(DeliveryOutcome::Inserted)
     );
     assert_eq!(
         network.deliver_next_to(&node(20)),
-        Some(DeliveryOutcome::Inserted) // Deliver the second tip block to node A, which should be inserted successfully
+        Some(DeliveryOutcome::Inserted)
     );
     assert_eq!(
         network.deliver_next_to(&node(20)),
-        Some(DeliveryOutcome::Inserted) // Deliver the third tip block to node A, which should be inserted successfully
+        Some(DeliveryOutcome::Inserted)
     );
 
     assert_eq!(
         network.deliver_next_to(&node(21)),
-        Some(DeliveryOutcome::Inserted) // Deliver the first tip block to node B, which should be inserted successfully
+        Some(DeliveryOutcome::Inserted)
     );
     assert_eq!(
         network.deliver_next_to(&node(21)),
-        Some(DeliveryOutcome::Inserted) // Deliver the second tip block to node B, which should be inserted successfully
+        Some(DeliveryOutcome::Inserted)
     );
 
     let payload = vec![9, 9];
 
-    let candidate_a = network // Have node A attempt to build a block candidate using the three tip blocks it knows, which should succeed since it has all the required visible tips
+    // Node A can already build a proposal because it has enough visible tips.
+    let candidate_a = network
         .node(&node(20))
         .expect("node A should exist")
         .build_block_candidate(payload.clone())
         .expect("node A should have enough visible tips to propose");
 
-    let candidate_b_before = network // Have node B attempt to build a block candidate using the two tip blocks it knows, which should fail since it doesn't have all the required visible tips (it is missing tip3) and thus doesn't have enough acknowledgements to propose
+    // Node B cannot yet build a proposal because it is still missing one tip.
+    let candidate_b_before = network
         .node(&node(21))
         .expect("node B should exist")
         .build_block_candidate(payload.clone());
@@ -183,26 +203,27 @@ fn proposal_construction_converges_after_nodes_catch_up_on_visible_tips() {
     assert!(matches!(
         candidate_b_before,
         Err(ProposalError::InsufficientAcknowledgements {
-            // Check that the error is specifically about insufficient acknowledgements, which indicates that node B correctly identified that it doesn't have enough visible tips to propose
             observed: 2,
             required: 3,
         })
     ));
 
-    network.queue_delivery(node(21), tip3.clone()); // Queue the missing tip block for delivery to node B to simulate it catching up on the visible tips needed for proposal construction
+    // Once the missing tip arrives, node B should catch up to the same view.
+    network.queue_delivery(node(21), tip3.clone());
     assert_eq!(
         network.deliver_next_to(&node(21)),
         Some(DeliveryOutcome::Inserted)
     );
 
-    let candidate_b_after = network // Have node B attempt to build a block candidate using the three tip blocks it now knows, which should succeed since it has all the required visible tips
+    let candidate_b_after = network
         .node(&node(21))
         .expect("node B should exist")
         .build_block_candidate(payload)
         .expect("node B should propose after catching up");
 
-    assert_eq!(candidate_a.payload, candidate_b_after.payload); // Check that the payloads of the two candidates are the same, which indicates that both nodes constructed their candidates using the same set of visible tips and thus converged on the same proposal content
-    assert_eq!(candidate_a.predecessors, candidate_b_after.predecessors); // Check that the predecessors of the two candidates are the same, which indicates that both nodes constructed their candidates using the same set of visible tips and thus converged on the same proposal content
+    // After catch-up, both nodes should construct the same proposal.
+    assert_eq!(candidate_a.payload, candidate_b_after.payload);
+    assert_eq!(candidate_a.predecessors, candidate_b_after.predecessors);
 }
 
 #[test]

--- a/crates/cordial-miners-core/tests/test_dissemination_simulation.rs
+++ b/crates/cordial-miners-core/tests/test_dissemination_simulation.rs
@@ -382,3 +382,97 @@ fn equivocating_leader_attempt_is_rejected_and_honest_wave_still_converges() {
 
     assert_eq!(tau_a, tau_b);
 }
+
+#[test]
+fn partitioned_node_catches_up_on_finality_and_tau_after_heal() {
+    // Standard 4-validator setting with n = 4, f = 1 so a single honest wave
+    let mut bonds = HashMap::new();
+    bonds.insert(node(1), 100);
+    bonds.insert(node(2), 100);
+    bonds.insert(node(3), 100);
+    bonds.insert(node(4), 100);
+
+    // Node A will see the full wave and finalize the leader.
+    // Node B will see only part of the wave due to a network partition, then heal and receive the rest of the wave, but not necessarily in dependency order.
+    let node_a = SimNode::new(node(50), bonds.clone(), simulation_validation_config());
+    let node_b = SimNode::new(node(51), bonds, simulation_validation_config());
+    let mut network = SimNetwork::new(vec![node_a, node_b]);
+
+    // Set parameters such that a single honest wave can finalize its leader and produce non-empty tau, even if one node receives the blocks in a different order and has to buffer them until it can process them in the correct order.
+    let wavelength = 3u64;
+    let n = 4usize;
+    let f = 1usize;
+
+    // Honest wave: leader, round-1 witnesses, then round-2 super-ratifiers.
+    let leader = create_block(1, 1, HashSet::new());
+    let r1_v2 = create_block(2, 2, HashSet::from([leader.identity.clone()]));
+    let r1_v3 = create_block(3, 3, HashSet::from([leader.identity.clone()]));
+    let r1_v4 = create_block(4, 4, HashSet::from([leader.identity.clone()]));
+
+    let round1_preds = HashSet::from([
+        r1_v2.identity.clone(),
+        r1_v3.identity.clone(),
+        r1_v4.identity.clone(),
+    ]);
+    let r2_v2 = create_block(2, 5, round1_preds.clone());
+    let r2_v3 = create_block(3, 6, round1_preds.clone());
+    let r2_v4 = create_block(4, 7, round1_preds);
+
+    // Node A sees the full wave and can finalize normally.
+    for block in [&leader, &r1_v2, &r1_v3, &r1_v4, &r2_v2, &r2_v3, &r2_v4] {
+        network.queue_delivery(node(50), block.clone());
+    }
+
+    // During the partition, node B sees only the leader plus one witness.
+    // That is not enough to super-ratify the wave or to compute non-empty tau.
+    for block in [&leader, &r1_v2] {
+        network.queue_delivery(node(51), block.clone());
+    }
+
+    // Deliver what node B sees during the partition, then let any out-of-order dependencies resolve from the buffer.
+    while network.deliver_next_to(&node(50)).is_some() {}
+    while network.deliver_next_to(&node(51)).is_some() {}
+    network.retry_all_buffers();
+
+    let node_b_before_heal = network.node(&node(51)).expect("node B should exist");
+    assert_eq!(
+        node_b_before_heal.latest_final_leader(wavelength, n, f, leader_node1),
+        None
+    );
+    assert!(
+        node_b_before_heal
+            .ordered_output(wavelength, n, f, leader_node1)
+            .expect("partitioned node should still compute tau")
+            .is_empty(),
+        "partitioned node should not order anything before enough witnesses arrive"
+    );
+
+    // Partition heals: node B receives the missing witness and round-2 blocks,
+    // but not necessarily in dependency order.
+    for block in [&r2_v4, &r1_v4, &r2_v2, &r2_v3, &r1_v3] {
+        network.queue_delivery(node(51), block.clone());
+    }
+
+    // Deliver the remaining blocks to node B, then let any out-of-order dependencies resolve from the buffer.
+    while network.deliver_next_to(&node(51)).is_some() {}
+    network.retry_all_buffers();
+
+    // After healing, node B should have the same finalized leader and the same tau output as node A, demonstrating that it successfully caught up on the wave despite the initial partition and out-of-order delivery.
+    let node_a = network.node(&node(50)).expect("node A should exist");
+    let node_b = network.node(&node(51)).expect("node B should exist");
+
+    // Both nodes should finalize the same leader block, demonstrating that node B was able to catch up on the wave and achieve finality on the same leader as node A despite the initial partition and out-of-order delivery.
+    let final_a: Option<BlockIdentity> = node_a.latest_final_leader(wavelength, n, f, leader_node1);
+    let final_b = node_b.latest_final_leader(wavelength, n, f, leader_node1);
+    assert_eq!(final_a, Some(leader.identity.clone()));
+    assert_eq!(final_b, Some(leader.identity.clone()));
+
+    let tau_a = node_a
+        .ordered_output(wavelength, n, f, leader_node1)
+        .expect("node A should produce ordered output");
+    let tau_b = node_b
+        .ordered_output(wavelength, n, f, leader_node1)
+        .expect("node B should produce ordered output after healing");
+
+    assert_eq!(tau_a, tau_b); // Both nodes should produce the same tau output, demonstrating that node B successfully caught up on the wave and converged on the same view of finality and the same tau output as node A despite the initial partition and out-of-order delivery.
+}

--- a/crates/cordial-miners-core/tests/test_dissemination_simulation.rs
+++ b/crates/cordial-miners-core/tests/test_dissemination_simulation.rs
@@ -1,4 +1,5 @@
 use cordial_miners_core::simulation::dissemination::{DeliveryOutcome, SimNetwork, SimNode};
+use cordial_miners_core::consensus::ProposalError;
 use cordial_miners_core::{Block, BlockContent, BlockIdentity, NodeId};
 use cordial_miners_core::consensus::ValidationConfig;
 use std::collections::{HashMap, HashSet};
@@ -114,4 +115,86 @@ fn two_nodes_converge_after_receiving_the_same_blocks_in_different_orders() {
     assert!(node_b.knows_block(&genesis.identity));
     assert!(node_b.knows_block(&child.identity));
     assert_eq!(node_b.pending_len(), 0);
+}
+
+#[test]
+fn proposal_construction_converges_after_nodes_catch_up_on_visible_tips() {
+    let mut bonds = HashMap::new();
+    bonds.insert(node(1), 100);
+    bonds.insert(node(2), 100);
+    bonds.insert(node(3), 100);
+    bonds.insert(node(4), 100);
+
+    let node_a = SimNode::new(node(20), bonds.clone(), simulation_validation_config());
+    let node_b = SimNode::new(node(21), bonds, simulation_validation_config());
+    let mut network = SimNetwork::new(vec![node_a, node_b]);
+
+    let tip1 = create_block(1, 1, HashSet::new());
+    let tip2 = create_block(2, 2, HashSet::new());
+    let tip3 = create_block(3, 3, HashSet::new());
+
+    for block in [&tip1, &tip2, &tip3] {
+        network.queue_delivery(node(20), block.clone());
+    }
+    for block in [&tip1, &tip2] {
+        network.queue_delivery(node(21), block.clone());
+    }
+
+    assert_eq!(
+        network.deliver_next_to(&node(20)),
+        Some(DeliveryOutcome::Inserted)
+    );
+    assert_eq!(
+        network.deliver_next_to(&node(20)),
+        Some(DeliveryOutcome::Inserted)
+    );
+    assert_eq!(
+        network.deliver_next_to(&node(20)),
+        Some(DeliveryOutcome::Inserted)
+    );
+
+    assert_eq!(
+        network.deliver_next_to(&node(21)),
+        Some(DeliveryOutcome::Inserted)
+    );
+    assert_eq!(
+        network.deliver_next_to(&node(21)),
+        Some(DeliveryOutcome::Inserted)
+    );
+
+    let payload = vec![9, 9];
+
+    let candidate_a = network
+        .node(&node(20))
+        .expect("node A should exist")
+        .build_block_candidate(payload.clone())
+        .expect("node A should have enough visible tips to propose");
+
+    let candidate_b_before = network
+        .node(&node(21))
+        .expect("node B should exist")
+        .build_block_candidate(payload.clone());
+
+    assert!(matches!(
+        candidate_b_before,
+        Err(ProposalError::InsufficientAcknowledgements {
+            observed: 2,
+            required: 3,
+        })
+    ));
+
+    network.queue_delivery(node(21), tip3.clone());
+    assert_eq!(
+        network.deliver_next_to(&node(21)),
+        Some(DeliveryOutcome::Inserted)
+    );
+
+    let candidate_b_after = network
+        .node(&node(21))
+        .expect("node B should exist")
+        .build_block_candidate(payload)
+        .expect("node B should propose after catching up");
+
+    assert_eq!(candidate_a.payload, candidate_b_after.payload);
+    assert_eq!(candidate_a.predecessors, candidate_b_after.predecessors);
 }

--- a/crates/cordial-miners-core/tests/test_dissemination_simulation.rs
+++ b/crates/cordial-miners-core/tests/test_dissemination_simulation.rs
@@ -476,3 +476,89 @@ fn partitioned_node_catches_up_on_finality_and_tau_after_heal() {
 
     assert_eq!(tau_a, tau_b); // Both nodes should produce the same tau output, demonstrating that node B successfully caught up on the wave and converged on the same view of finality and the same tau output as node A despite the initial partition and out-of-order delivery.
 }
+
+#[test]
+fn unbonded_sender_injection_is_rejected_and_honest_nodes_still_converge() {
+    let mut bonds = HashMap::new();
+    bonds.insert(node(1), 100);
+    bonds.insert(node(2), 100);
+    bonds.insert(node(3), 100);
+    bonds.insert(node(4), 100);
+
+    let node_a = SimNode::new(node(60), bonds.clone(), simulation_validation_config());
+    let node_b = SimNode::new(node(61), bonds, simulation_validation_config());
+    let mut network = SimNetwork::new(vec![node_a, node_b]);
+
+    let wavelength = 3u64;
+    let n = 4usize;
+    let f = 1usize;
+
+    // Honest wave that should finalize normally.
+    let leader = create_block(1, 1, HashSet::new());
+    let r1_v2 = create_block(2, 2, HashSet::from([leader.identity.clone()]));
+    let r1_v3 = create_block(3, 3, HashSet::from([leader.identity.clone()]));
+    let r1_v4 = create_block(4, 4, HashSet::from([leader.identity.clone()]));
+
+    let round1_preds = HashSet::from([
+        r1_v2.identity.clone(),
+        r1_v3.identity.clone(),
+        r1_v4.identity.clone(),
+    ]);
+    let r2_v2 = create_block(2, 5, round1_preds.clone());
+    let r2_v3 = create_block(3, 6, round1_preds.clone());
+    let r2_v4 = create_block(4, 7, round1_preds);
+
+    // Block by an unbonded creator. It should be rejected immediately by node B.
+    let injected = create_block(9, 99, HashSet::from([leader.identity.clone()]));
+
+    for block in [&leader, &r1_v2, &r1_v3, &r1_v4, &r2_v2, &r2_v3, &r2_v4] {
+        network.queue_delivery(node(60), block.clone());
+    }
+
+    network.queue_delivery(node(61), leader.clone());
+    network.queue_delivery(node(61), injected.clone());
+    for block in [&r1_v2, &r1_v3, &r1_v4, &r2_v2, &r2_v3, &r2_v4] {
+        network.queue_delivery(node(61), block.clone());
+    }
+
+    while network.deliver_next_to(&node(60)).is_some() {}
+
+    assert_eq!(
+        network.deliver_next_to(&node(61)),
+        Some(DeliveryOutcome::Inserted)
+    );
+
+    let injected_outcome = network
+        .deliver_next_to(&node(61))
+        .expect("unbonded block should be delivered");
+    assert!(
+        matches!(injected_outcome, DeliveryOutcome::Rejected(errors)
+            if errors.iter().any(|error| matches!(
+                error,
+                cordial_miners_core::consensus::InvalidBlock::UnknownSender { .. }
+            ))),
+        "unbonded sender should be rejected by the receiving node"
+    );
+
+    while network.deliver_next_to(&node(61)).is_some() {}
+    network.retry_all_buffers();
+
+    let node_a = network.node(&node(60)).expect("node A should exist");
+    let node_b = network.node(&node(61)).expect("node B should exist");
+
+    assert!(!node_b.knows_block(&injected.identity));
+
+    let final_a = node_a.latest_final_leader(wavelength, n, f, leader_node1);
+    let final_b = node_b.latest_final_leader(wavelength, n, f, leader_node1);
+    assert_eq!(final_a, Some(leader.identity.clone()));
+    assert_eq!(final_b, Some(leader.identity.clone()));
+
+    let tau_a = node_a
+        .ordered_output(wavelength, n, f, leader_node1)
+        .expect("node A should produce ordered output");
+    let tau_b = node_b
+        .ordered_output(wavelength, n, f, leader_node1)
+        .expect("node B should produce ordered output");
+
+    assert_eq!(tau_a, tau_b);
+}

--- a/crates/cordial-miners-core/tests/test_dissemination_simulation.rs
+++ b/crates/cordial-miners-core/tests/test_dissemination_simulation.rs
@@ -664,3 +664,87 @@ fn duplicate_delivery_after_convergence_does_not_change_finality_or_tau() {
     assert_eq!(final_before, final_after);
     assert_eq!(tau_before, tau_after);
 }
+
+#[test]
+fn weighted_path_can_remain_empty_after_unweighted_convergence() {
+    // Four active validators build an honest wave, but a fifth bonded validator
+    // holds most of the stake and never appears in the blocklace. This should
+    // allow unweighted convergence while keeping the weighted path empty.
+    let mut bonds = HashMap::new();
+    bonds.insert(node(1), 1);
+    bonds.insert(node(2), 1);
+    bonds.insert(node(3), 1);
+    bonds.insert(node(4), 1);
+    bonds.insert(node(9), 100);
+
+    let node_a = SimNode::new(node(80), bonds.clone(), simulation_validation_config());
+    let node_b = SimNode::new(node(81), bonds, simulation_validation_config());
+    let mut network = SimNetwork::new(vec![node_a, node_b]);
+
+    let wavelength = 3u64;
+    let n = 4usize;
+    let f = 1usize;
+
+    let leader = create_block(1, 1, HashSet::new());
+    let r1_v2 = create_block(2, 2, HashSet::from([leader.identity.clone()]));
+    let r1_v3 = create_block(3, 3, HashSet::from([leader.identity.clone()]));
+    let r1_v4 = create_block(4, 4, HashSet::from([leader.identity.clone()]));
+
+    let round1_preds = HashSet::from([
+        r1_v2.identity.clone(),
+        r1_v3.identity.clone(),
+        r1_v4.identity.clone(),
+    ]);
+    let r2_v2 = create_block(2, 5, round1_preds.clone());
+    let r2_v3 = create_block(3, 6, round1_preds.clone());
+    let r2_v4 = create_block(4, 7, round1_preds);
+
+    for recipient in [node(80), node(81)] {
+        network.queue_delivery(recipient.clone(), leader.clone());
+        network.queue_delivery(recipient.clone(), r2_v3.clone());
+        network.queue_delivery(recipient.clone(), r1_v2.clone());
+        network.queue_delivery(recipient.clone(), r2_v2.clone());
+        network.queue_delivery(recipient.clone(), r1_v4.clone());
+        network.queue_delivery(recipient.clone(), r2_v4.clone());
+        network.queue_delivery(recipient, r1_v3.clone());
+    }
+
+    while network.deliver_next_to(&node(80)).is_some() {}
+    while network.deliver_next_to(&node(81)).is_some() {}
+    network.retry_all_buffers();
+
+    let node_a = network.node(&node(80)).expect("node A should exist");
+    let node_b = network.node(&node(81)).expect("node B should exist");
+
+    // Unweighted path converges normally on the honest leader and a non-empty tau.
+    assert_eq!(
+        node_a.latest_final_leader(wavelength, n, f, leader_node1),
+        Some(leader.identity.clone())
+    );
+    assert_eq!(
+        node_b.latest_final_leader(wavelength, n, f, leader_node1),
+        Some(leader.identity.clone())
+    );
+
+    let unweighted_tau_a = node_a
+        .ordered_output(wavelength, n, f, leader_node1)
+        .expect("node A should produce unweighted tau");
+    let unweighted_tau_b = node_b
+        .ordered_output(wavelength, n, f, leader_node1)
+        .expect("node B should produce unweighted tau");
+    assert!(!unweighted_tau_a.is_empty());
+    assert_eq!(unweighted_tau_a, unweighted_tau_b);
+
+    // Weighted path stays empty because the high-stake validator never contributes.
+    assert_eq!(node_a.latest_weighted_final_leader(wavelength, leader_node1), None);
+    assert_eq!(node_b.latest_weighted_final_leader(wavelength, leader_node1), None);
+
+    let weighted_tau_a = node_a
+        .weighted_ordered_output(wavelength, leader_node1)
+        .expect("node A should compute weighted tau");
+    let weighted_tau_b = node_b
+        .weighted_ordered_output(wavelength, leader_node1)
+        .expect("node B should compute weighted tau");
+    assert!(weighted_tau_a.is_empty());
+    assert_eq!(weighted_tau_a, weighted_tau_b);
+}

--- a/crates/cordial-miners-core/tests/test_dissemination_simulation.rs
+++ b/crates/cordial-miners-core/tests/test_dissemination_simulation.rs
@@ -274,3 +274,111 @@ fn finality_and_tau_converge_after_out_of_order_wave_delivery() {
     );
     assert_eq!(tau_a, tau_b);
 }
+
+#[test]
+fn equivocating_leader_attempt_is_rejected_and_honest_wave_still_converges() {
+    // Standard 4-validator setting with n = 4, f = 1 so a single honest wave
+    // can still finalize its leader after one adversarial attempt.
+    let mut bonds = HashMap::new();
+    bonds.insert(node(1), 100);
+    bonds.insert(node(2), 100);
+    bonds.insert(node(3), 100);
+    bonds.insert(node(4), 100);
+
+    // Node A will see only the honest path.
+    // Node B will see the honest leader first, then a conflicting leader block.
+    let node_a = SimNode::new(node(40), bonds.clone(), simulation_validation_config());
+    let node_b = SimNode::new(node(41), bonds, simulation_validation_config());
+    let mut network = SimNetwork::new(vec![node_a, node_b]);
+
+    let wavelength = 3u64;
+    let n = 4usize;
+    let f = 1usize;
+
+    // Honest leader block for wave 0.
+    let leader = create_block(1, 1, HashSet::new());
+    // Conflicting block by the same creator. Since node B will already know
+    // `leader`, this second block should be rejected as an equivocation.
+    let equivocated_leader = create_block(1, 99, HashSet::new());
+
+    // Round-1 witness blocks that ratify the honest leader.
+    let r1_v2 = create_block(2, 2, HashSet::from([leader.identity.clone()]));
+    let r1_v3 = create_block(3, 3, HashSet::from([leader.identity.clone()]));
+    let r1_v4 = create_block(4, 4, HashSet::from([leader.identity.clone()]));
+
+    // Round-2 witness blocks that super-ratify the wave by observing all
+    // round-1 witnesses.
+    let round1_preds = HashSet::from([
+        r1_v2.identity.clone(),
+        r1_v3.identity.clone(),
+        r1_v4.identity.clone(),
+    ]);
+    let r2_v2 = create_block(2, 5, round1_preds.clone());
+    let r2_v3 = create_block(3, 6, round1_preds.clone());
+    let r2_v4 = create_block(4, 7, round1_preds);
+
+    // Node A receives the honest wave in dependency order.
+    for block in [&leader, &r1_v2, &r1_v3, &r1_v4, &r2_v2, &r2_v3, &r2_v4] {
+        network.queue_delivery(node(40), block.clone());
+    }
+
+    // Node B receives the honest leader first, then the conflicting leader
+    // attempt, then the rest of the honest wave in mixed order.
+    network.queue_delivery(node(41), leader.clone());
+    network.queue_delivery(node(41), equivocated_leader.clone());
+    for block in [&r2_v3, &r1_v2, &r2_v2, &r1_v4, &r2_v4, &r1_v3] {
+        network.queue_delivery(node(41), block.clone());
+    }
+
+    // Node A processes the honest path completely.
+    while network.deliver_next_to(&node(40)).is_some() {}
+
+    // Node B first accepts the honest leader.
+    assert_eq!(
+        network.deliver_next_to(&node(41)),
+        Some(DeliveryOutcome::Inserted)
+    );
+
+    // Node B then sees a second incomparable block by the same creator and
+    // must reject it as an equivocation instead of buffering or inserting it.
+    let equivocation_outcome = network
+        .deliver_next_to(&node(41))
+        .expect("equivocating leader attempt should be delivered");
+    assert!(
+        matches!(equivocation_outcome, DeliveryOutcome::Rejected(errors)
+        if errors.iter().any(|error| matches!(
+            error,
+            cordial_miners_core::consensus::InvalidBlock::Equivocation { .. }
+        ))),
+        "equivocating leader should be rejected by the receiving node"
+    );
+
+    // Deliver the remaining honest witness blocks to node B, then let any
+    // out-of-order dependencies resolve from the buffer.
+    while network.deliver_next_to(&node(41)).is_some() {}
+    network.retry_all_buffers();
+
+    let node_a = network.node(&node(40)).expect("node A should exist");
+    let node_b = network.node(&node(41)).expect("node B should exist");
+
+    // The rejected equivocation must never enter node B's local DAG.
+    assert!(!node_b.knows_block(&equivocated_leader.identity));
+
+    // Despite the adversarial attempt, both nodes should still finalize the
+    // same honest leader.
+    let final_a = node_a.latest_final_leader(wavelength, n, f, leader_node1);
+    let final_b = node_b.latest_final_leader(wavelength, n, f, leader_node1);
+    assert_eq!(final_a, Some(leader.identity.clone()));
+    assert_eq!(final_b, Some(leader.identity.clone()));
+
+    // And once delivery stabilizes, both nodes should compute the same ordered
+    // output sequence from that finalized view.
+    let tau_a = node_a
+        .ordered_output(wavelength, n, f, leader_node1)
+        .expect("node A should produce ordered output");
+    let tau_b = node_b
+        .ordered_output(wavelength, n, f, leader_node1)
+        .expect("node B should produce ordered output");
+
+    assert_eq!(tau_a, tau_b);
+}

--- a/crates/cordial-miners-core/tests/test_dissemination_simulation.rs
+++ b/crates/cordial-miners-core/tests/test_dissemination_simulation.rs
@@ -562,3 +562,84 @@ fn unbonded_sender_injection_is_rejected_and_honest_nodes_still_converge() {
 
     assert_eq!(tau_a, tau_b);
 }
+
+#[test]
+fn duplicate_delivery_after_convergence_does_not_change_finality_or_tau() {
+    let mut bonds = HashMap::new();
+    bonds.insert(node(1), 100);
+    bonds.insert(node(2), 100);
+    bonds.insert(node(3), 100);
+    bonds.insert(node(4), 100);
+
+    let node_a = SimNode::new(node(70), bonds.clone(), simulation_validation_config());
+    let node_b = SimNode::new(node(71), bonds, simulation_validation_config());
+    let mut network = SimNetwork::new(vec![node_a, node_b]);
+
+    let wavelength = 3u64;
+    let n = 4usize;
+    let f = 1usize;
+
+    // Honest wave that should finalize leader 1.
+    let leader = create_block(1, 1, HashSet::new());
+    let r1_v2 = create_block(2, 2, HashSet::from([leader.identity.clone()]));
+    let r1_v3 = create_block(3, 3, HashSet::from([leader.identity.clone()]));
+    let r1_v4 = create_block(4, 4, HashSet::from([leader.identity.clone()]));
+
+    let round1_preds = HashSet::from([
+        r1_v2.identity.clone(),
+        r1_v3.identity.clone(),
+        r1_v4.identity.clone(),
+    ]);
+    let r2_v2 = create_block(2, 5, round1_preds.clone());
+    let r2_v3 = create_block(3, 6, round1_preds.clone());
+    let r2_v4 = create_block(4, 7, round1_preds);
+
+    for recipient in [node(70), node(71)] {
+        for block in [&leader, &r1_v2, &r1_v3, &r1_v4, &r2_v2, &r2_v3, &r2_v4] {
+            network.queue_delivery(recipient.clone(), block.clone());
+        }
+    }
+
+    while network.deliver_next_to(&node(70)).is_some() {}
+    while network.deliver_next_to(&node(71)).is_some() {}
+    network.retry_all_buffers();
+
+    let node_b = network.node(&node(71)).expect("node B should exist");
+    let final_before = node_b.latest_final_leader(wavelength, n, f, leader_node1);
+    let tau_before = node_b
+        .ordered_output(wavelength, n, f, leader_node1)
+        .expect("node B should produce ordered output");
+
+    assert_eq!(final_before, Some(leader.identity.clone()));
+    assert!(!tau_before.is_empty());
+
+    // The network replays already-known honest blocks to node B after it has
+    // already converged. They should be treated as harmless duplicates.
+    for block in [&leader, &r1_v2, &r2_v3] {
+        network.queue_delivery(node(71), block.clone());
+    }
+
+    assert_eq!(
+        network.deliver_next_to(&node(71)),
+        Some(DeliveryOutcome::Inserted)
+    );
+    assert_eq!(
+        network.deliver_next_to(&node(71)),
+        Some(DeliveryOutcome::Inserted)
+    );
+    assert_eq!(
+        network.deliver_next_to(&node(71)),
+        Some(DeliveryOutcome::Inserted)
+    );
+    network.retry_all_buffers();
+
+    let node_b = network.node(&node(71)).expect("node B should still exist");
+    let final_after = node_b.latest_final_leader(wavelength, n, f, leader_node1);
+    let tau_after = node_b
+        .ordered_output(wavelength, n, f, leader_node1)
+        .expect("node B should still produce ordered output");
+
+    assert_eq!(node_b.pending_len(), 0);
+    assert_eq!(final_before, final_after);
+    assert_eq!(tau_before, tau_after);
+}

--- a/crates/cordial-miners-core/tests/test_dissemination_simulation.rs
+++ b/crates/cordial-miners-core/tests/test_dissemination_simulation.rs
@@ -1,4 +1,4 @@
-use cordial_miners_core::simulation::dissemination::{DeliveryOutcome, SimNode};
+use cordial_miners_core::simulation::dissemination::{DeliveryOutcome, SimNetwork, SimNode};
 use cordial_miners_core::{Block, BlockContent, BlockIdentity, NodeId};
 use cordial_miners_core::consensus::ValidationConfig;
 use std::collections::{HashMap, HashSet};
@@ -59,3 +59,59 @@ fn out_of_order_delivery_is_buffered_then_resolved_after_parent_arrives() {
     assert!(sim_node.knows_block(&child.identity));
 }
 
+#[test]
+fn two_nodes_converge_after_receiving_the_same_blocks_in_different_orders() {
+    let mut bonds = HashMap::new();
+    bonds.insert(node(1), 100);
+    bonds.insert(node(2), 100);
+
+    let node_a = SimNode::new(node(10), bonds.clone(), simulation_validation_config());
+    let node_b = SimNode::new(node(11), bonds, simulation_validation_config());
+    let mut network = SimNetwork::new(vec![node_a, node_b]);
+
+    let genesis = create_block(1, 1, HashSet::new());
+    let child = create_block(2, 2, HashSet::from([genesis.identity.clone()]));
+
+    network.queue_delivery(node(10), genesis.clone());
+    network.queue_delivery(node(10), child.clone());
+    network.queue_delivery(node(11), child.clone());
+    network.queue_delivery(node(11), genesis.clone());
+    assert_eq!(network.queued_delivery_count(), 4);
+
+    assert_eq!(
+        network.deliver_next_to(&node(10)),
+        Some(DeliveryOutcome::Inserted)
+    );
+    assert_eq!(
+        network.deliver_next_to(&node(10)),
+        Some(DeliveryOutcome::Inserted)
+    );
+
+    assert_eq!(
+        network.deliver_next_to(&node(11)),
+        Some(DeliveryOutcome::Buffered)
+    );
+    assert_eq!(
+        network
+            .node(&node(11))
+            .expect("node B should exist")
+            .pending_len(),
+        1
+    );
+
+    assert_eq!(
+        network.deliver_next_to(&node(11)),
+        Some(DeliveryOutcome::Inserted)
+    );
+
+    network.retry_all_buffers();
+
+    let node_a = network.node(&node(10)).expect("node A should exist");
+    let node_b = network.node(&node(11)).expect("node B should exist");
+
+    assert!(node_a.knows_block(&genesis.identity));
+    assert!(node_a.knows_block(&child.identity));
+    assert!(node_b.knows_block(&genesis.identity));
+    assert!(node_b.knows_block(&child.identity));
+    assert_eq!(node_b.pending_len(), 0);
+}

--- a/crates/cordial-miners-core/tests/test_dissemination_simulation.rs
+++ b/crates/cordial-miners-core/tests/test_dissemination_simulation.rs
@@ -208,54 +208,58 @@ fn proposal_construction_converges_after_nodes_catch_up_on_visible_tips() {
 #[test]
 fn finality_and_tau_converge_after_out_of_order_wave_delivery() {
     let mut bonds = HashMap::new();
-    bonds.insert(node(1), 100);
+    bonds.insert(node(1), 100); // Include a bond for the block creator to ensure blocks are considered valid
     bonds.insert(node(2), 100);
     bonds.insert(node(3), 100);
     bonds.insert(node(4), 100);
 
-    let node_a = SimNode::new(node(30), bonds.clone(), simulation_validation_config());
-    let node_b = SimNode::new(node(31), bonds, simulation_validation_config());
+    let node_a = SimNode::new(node(30), bonds.clone(), simulation_validation_config()); // Create a separate bonds map for node A to ensure it has the same bond information as node B
+    let node_b = SimNode::new(node(31), bonds, simulation_validation_config()); // Create a separate bonds map for node B to ensure it has the same bond information as node A
     let mut network = SimNetwork::new(vec![node_a, node_b]);
 
-    let wavelength = 3u64;
-    let n = 4usize;
-    let f = 1usize;
+    let wavelength = 3u64; // Set the wavelength to 3 so that the leader selection will rotate every 3 waves, which allows us to test finality and tau convergence across multiple waves with the same leader and then a wave with a different leader
+    let n = 4usize; // Set n to 4 to allow for a small number of nodes while still enabling finality with f=1
+    let f = 1usize; // Set f to 1 to allow for finality with n=4 while still enabling some tolerance for out-of-order delivery and buffering, here f represents the maximum number of faulty nodes that can be tolerated while still achieving finality, and setting it to 1 allows us to test that the protocol can still achieve finality even if one node receives blocks in a different order and has to buffer them until it can process them in the correct order
 
-    let leader = create_block(1, 1, HashSet::new());
+    let leader = create_block(1, 1, HashSet::new()); // Create a leader block for the first wave with a bond for the creator to ensure it's considered valid, this will be the only block in the first wave and will be the parent of all subsequent blocks in the second wave, which allows us to test that both nodes can achieve finality on this leader block even if they receive the subsequent blocks in different orders
 
-    let r1_v2 = create_block(2, 2, HashSet::from([leader.identity.clone()]));
-    let r1_v3 = create_block(3, 3, HashSet::from([leader.identity.clone()]));
-    let r1_v4 = create_block(4, 4, HashSet::from([leader.identity.clone()]));
+    let r1_v2 = create_block(2, 2, HashSet::from([leader.identity.clone()])); // Create a block for the second wave that references the leader block, with a bond for the creator to ensure it's considered valid, this will be one of the blocks in the second wave and will be used to test that both nodes can achieve finality on the leader block even if they receive the blocks in different orders
+    let r1_v3 = create_block(3, 3, HashSet::from([leader.identity.clone()])); // Create another block for the second wave that references the leader block, with a bond for the creator to ensure it's considered valid, this will be another block in the second wave and will be used to test that both nodes can achieve finality on the leader block even if they receive the blocks in different orders
+    let r1_v4 = create_block(4, 4, HashSet::from([leader.identity.clone()])); // Create a third block for the second wave that references the leader block, with a bond for the creator to ensure it's considered valid, this will be another block in the second wave and will be used to test that both nodes can achieve finality on the leader block even if they receive the blocks in different orders
 
     let round1_preds = HashSet::from([
+        // Create a set of predecessors for the third wave blocks that includes all the blocks from the second wave, which allows us to test that both nodes can achieve finality on the leader block and then produce the same tau even if they receive the blocks in different orders
         r1_v2.identity.clone(),
         r1_v3.identity.clone(),
         r1_v4.identity.clone(),
     ]);
-    let r2_v2 = create_block(2, 5, round1_preds.clone());
-    let r2_v3 = create_block(3, 6, round1_preds.clone());
-    let r2_v4 = create_block(4, 7, round1_preds);
+    let r2_v2 = create_block(2, 5, round1_preds.clone()); // Create a block for the third wave that references all the blocks from the second wave, with a bond for the creator to ensure it's considered valid, this will be one of the blocks in the third wave and will be used to test that both nodes can produce the same tau even if they receive the blocks in different orders
+    let r2_v3 = create_block(3, 6, round1_preds.clone()); // Create another block for the third wave that references all the blocks from the second wave, with a bond for the creator to ensure it's considered valid, this will be another block in the third wave and will be used to test that both nodes can produce the same tau even if they receive the blocks in different orders
+    let r2_v4 = create_block(4, 7, round1_preds); // Create a third block for the third wave that references all the blocks from the second wave, with a bond for the creator to ensure it's considered valid, this will be another block in the third wave and will be used to test that both nodes can produce the same tau even if they receive the blocks in different orders
 
     for block in [&leader, &r1_v2, &r1_v3, &r1_v4, &r2_v2, &r2_v3, &r2_v4] {
+        // Queue all the blocks for delivery to node A in order of their creation, which simulates node A receiving the blocks in the order they were created and thus being able to process them without buffering
         network.queue_delivery(node(30), block.clone());
     }
 
     for block in [&r2_v3, &r1_v2, &r2_v2, &leader, &r1_v4, &r2_v4, &r1_v3] {
+        // Queue all the blocks for delivery to node B in a different order that simulates it receiving the blocks in a more jumbled order, which will require it to buffer some blocks until it can process them in the correct order based on their dependencies, this tests that even with out-of-order delivery and buffering, node B can still achieve finality on the leader block and produce the same tau as node A once it has processed all the blocks
         network.queue_delivery(node(31), block.clone());
     }
 
-    while network.deliver_next_to(&node(30)).is_some() {}
-    while network.deliver_next_to(&node(31)).is_some() {}
-    network.retry_all_buffers();
+    while network.deliver_next_to(&node(30)).is_some() {} // Deliver all the blocks to node A, which should be processed in order without buffering since they were queued in creation order
+    while network.deliver_next_to(&node(31)).is_some() {} // Deliver all the blocks to node B, which should require buffering for some blocks until their dependencies are processed, but should ultimately result in all blocks being processed once their dependencies are met
+    network.retry_all_buffers(); // Retry all buffered blocks in the network to ensure that any blocks that were buffered due to out-of-order delivery are now processed once their dependencies have been met, this is especially important for node B which received the blocks in a jumbled order and thus likely had to buffer several blocks until it could process them in the correct order
 
-    let node_a = network.node(&node(30)).expect("node A should exist");
-    let node_b = network.node(&node(31)).expect("node B should exist");
+    let node_a = network.node(&node(30)).expect("node A should exist"); // Retrieve node A from the network to check its finality and tau output
+    let node_b = network.node(&node(31)).expect("node B should exist"); // Retrieve node B from the network to check its finality and tau output
 
-    let final_a = node_a.latest_final_leader(wavelength, n, f, leader_node1);
-    let final_b = node_b.latest_final_leader(wavelength, n, f, leader_node1);
-    assert_eq!(final_a, Some(leader.identity.clone()));
-    assert_eq!(final_b, Some(leader.identity.clone()));
+    let final_a = node_a.latest_final_leader(wavelength, n, f, leader_node1); // Check the latest final leader for node A, which should be the leader block since both nodes should have achieved finality on it despite the out-of-order delivery and buffering
+    let final_b = node_b.latest_final_leader(wavelength, n, f, leader_node1); // Check the latest final leader for node B, which should also be the leader block since both nodes should have achieved finality on it despite the out-of-order delivery and buffering
+    assert_eq!(final_a, Some(leader.identity.clone())); // Assert that the final leader for node A is the leader block, which indicates that node A successfully achieved finality on the leader block despite the out-of-order delivery and buffering of subsequent blocks
+    assert_eq!(final_b, Some(leader.identity.clone())); // Assert that the final leader for node B is also the leader block, which indicates that node B successfully achieved finality on the leader block despite the out-of-order delivery and buffering of subsequent blocks
 
+    // Check the tau output for both nodes, which should be the same and should reflect the same set of finalized blocks and their dependencies, thus demonstrating that both nodes converged on the same view of finality and the same tau output despite receiving the blocks in different orders and having to buffer some blocks until they could process them in the correct order
     let tau_a = node_a
         .ordered_output(wavelength, n, f, leader_node1)
         .expect("node A should produce ordered output");
@@ -263,6 +267,10 @@ fn finality_and_tau_converge_after_out_of_order_wave_delivery() {
         .ordered_output(wavelength, n, f, leader_node1)
         .expect("node B should produce ordered output");
 
-    assert!(!tau_a.is_empty(), "finalized wave should produce non-empty tau");
+    // Assert that the tau output for both nodes is not empty, which indicates that they were able to produce a tau output based on the finalized blocks and their dependencies, and that the tau output reflects the same view of finality and the same set of blocks despite the out-of-order delivery and buffering
+    assert!(
+        !tau_a.is_empty(),
+        "finalized wave should produce non-empty tau"
+    );
     assert_eq!(tau_a, tau_b);
 }

--- a/crates/cordial-miners-core/tests/test_dissemination_simulation.rs
+++ b/crates/cordial-miners-core/tests/test_dissemination_simulation.rs
@@ -554,10 +554,10 @@ fn unbonded_sender_injection_is_rejected_and_honest_nodes_still_converge() {
         .expect("unbonded block should be delivered");
     assert!(
         matches!(injected_outcome, DeliveryOutcome::Rejected(errors)
-            if errors.iter().any(|error| matches!(
-                error,
-                cordial_miners_core::consensus::InvalidBlock::UnknownSender { .. }
-            ))),
+        if errors.iter().any(|error| matches!(
+            error,
+            cordial_miners_core::consensus::InvalidBlock::UnknownSender { .. }
+        ))),
         "unbonded sender should be rejected by the receiving node"
     );
 
@@ -736,8 +736,14 @@ fn weighted_path_can_remain_empty_after_unweighted_convergence() {
     assert_eq!(unweighted_tau_a, unweighted_tau_b);
 
     // Weighted path stays empty because the high-stake validator never contributes.
-    assert_eq!(node_a.latest_weighted_final_leader(wavelength, leader_node1), None);
-    assert_eq!(node_b.latest_weighted_final_leader(wavelength, leader_node1), None);
+    assert_eq!(
+        node_a.latest_weighted_final_leader(wavelength, leader_node1),
+        None
+    );
+    assert_eq!(
+        node_b.latest_weighted_final_leader(wavelength, leader_node1),
+        None
+    );
 
     let weighted_tau_a = node_a
         .weighted_ordered_output(wavelength, leader_node1)
@@ -746,5 +752,102 @@ fn weighted_path_can_remain_empty_after_unweighted_convergence() {
         .weighted_ordered_output(wavelength, leader_node1)
         .expect("node B should compute weighted tau");
     assert!(weighted_tau_a.is_empty());
+    assert_eq!(weighted_tau_a, weighted_tau_b);
+}
+
+#[test]
+fn weighted_finality_and_tau_converge_after_high_stake_participants_catch_up() {
+    // Stake is skewed toward validators 2 and 3, so the weighted path depends
+    // on them participating in the witness rounds.
+    let mut bonds = HashMap::new();
+    bonds.insert(node(1), 1);
+    bonds.insert(node(2), 45);
+    bonds.insert(node(3), 45);
+    bonds.insert(node(4), 9);
+
+    let node_a = SimNode::new(node(90), bonds.clone(), simulation_validation_config());
+    let node_b = SimNode::new(node(91), bonds, simulation_validation_config());
+    let mut network = SimNetwork::new(vec![node_a, node_b]);
+
+    let wavelength = 3u64;
+
+    // Honest wave led by node 1. Weighted finality should depend on the
+    // participation of the high-stake validators 2 and 3.
+    let leader = create_block(1, 1, HashSet::new());
+    let r1_v2 = create_block(2, 2, HashSet::from([leader.identity.clone()]));
+    let r1_v3 = create_block(3, 3, HashSet::from([leader.identity.clone()]));
+    let r1_v4 = create_block(4, 4, HashSet::from([leader.identity.clone()]));
+
+    let round1_preds = HashSet::from([
+        r1_v2.identity.clone(),
+        r1_v3.identity.clone(),
+        r1_v4.identity.clone(),
+    ]);
+    let r2_v2 = create_block(2, 5, round1_preds.clone());
+    let r2_v3 = create_block(3, 6, round1_preds.clone());
+    let r2_v4 = create_block(4, 7, round1_preds);
+
+    // Node A sees the complete wave and should achieve weighted finality.
+    for block in [&leader, &r1_v2, &r1_v3, &r1_v4, &r2_v2, &r2_v3, &r2_v4] {
+        network.queue_delivery(node(90), block.clone());
+    }
+
+    // Node B is temporarily missing the high-stake validator 3 path, so the
+    // weighted path should stay empty until the partition heals.
+    for block in [&leader, &r1_v2, &r1_v4, &r2_v2, &r2_v4] {
+        network.queue_delivery(node(91), block.clone());
+    }
+
+    while network.deliver_next_to(&node(90)).is_some() {}
+    while network.deliver_next_to(&node(91)).is_some() {}
+    network.retry_all_buffers();
+
+    let node_b_before_heal = network.node(&node(91)).expect("node B should exist");
+
+    assert_eq!(
+        network
+            .node(&node(90))
+            .expect("node A should exist")
+            .latest_weighted_final_leader(wavelength, leader_node1),
+        Some(leader.identity.clone())
+    );
+    assert_eq!(
+        node_b_before_heal.latest_weighted_final_leader(wavelength, leader_node1),
+        None
+    );
+    assert!(
+        node_b_before_heal
+            .weighted_ordered_output(wavelength, leader_node1)
+            .expect("partitioned node should still compute weighted tau")
+            .is_empty(),
+        "without the missing high-stake path, weighted tau should stay empty"
+    );
+
+    // Heal the partition by delivering the missing high-stake validator 3 path.
+    for block in [&r1_v3, &r2_v3] {
+        network.queue_delivery(node(91), block.clone());
+    }
+
+    while network.deliver_next_to(&node(91)).is_some() {}
+    network.retry_all_buffers();
+
+    let node_a = network.node(&node(90)).expect("node A should exist");
+    let node_b = network
+        .node(&node(91))
+        .expect("node B should exist after heal");
+
+    let weighted_final_a = node_a.latest_weighted_final_leader(wavelength, leader_node1);
+    let weighted_final_b = node_b.latest_weighted_final_leader(wavelength, leader_node1);
+    assert_eq!(weighted_final_a, Some(leader.identity.clone()));
+    assert_eq!(weighted_final_b, Some(leader.identity.clone()));
+
+    let weighted_tau_a = node_a
+        .weighted_ordered_output(wavelength, leader_node1)
+        .expect("node A should produce weighted tau");
+    let weighted_tau_b = node_b
+        .weighted_ordered_output(wavelength, leader_node1)
+        .expect("node B should produce weighted tau after healing");
+
+    assert!(!weighted_tau_a.is_empty());
     assert_eq!(weighted_tau_a, weighted_tau_b);
 }

--- a/crates/cordial-miners-core/tests/test_dissemination_simulation.rs
+++ b/crates/cordial-miners-core/tests/test_dissemination_simulation.rs
@@ -851,3 +851,124 @@ fn weighted_finality_and_tau_converge_after_high_stake_participants_catch_up() {
     assert!(!weighted_tau_a.is_empty());
     assert_eq!(weighted_tau_a, weighted_tau_b);
 }
+
+#[test]
+fn tau_grows_monotonically_across_multiple_finalized_waves_after_catch_up() {
+    let mut bonds = HashMap::new();
+    bonds.insert(node(1), 100);
+    bonds.insert(node(2), 100);
+    bonds.insert(node(3), 100);
+    bonds.insert(node(4), 100);
+
+    let node_a = SimNode::new(node(100), bonds.clone(), simulation_validation_config());
+    let node_b = SimNode::new(node(101), bonds, simulation_validation_config());
+    let mut network = SimNetwork::new(vec![node_a, node_b]);
+
+    let wavelength = 3u64;
+    let n = 4usize;
+    let f = 1usize;
+
+    // Wave 0 led by validator 1.
+    let w0_leader = create_block(1, 1, HashSet::new());
+    let w0_r1_v2 = create_block(2, 2, HashSet::from([w0_leader.identity.clone()]));
+    let w0_r1_v3 = create_block(3, 3, HashSet::from([w0_leader.identity.clone()]));
+    let w0_r1_v4 = create_block(4, 4, HashSet::from([w0_leader.identity.clone()]));
+    let w0_r1_preds = HashSet::from([
+        w0_r1_v2.identity.clone(),
+        w0_r1_v3.identity.clone(),
+        w0_r1_v4.identity.clone(),
+    ]);
+    let w0_r2_v2 = create_block(2, 5, w0_r1_preds.clone());
+    let w0_r2_v3 = create_block(3, 6, w0_r1_preds.clone());
+    let w0_r2_v4 = create_block(4, 7, w0_r1_preds);
+
+    // Wave 1 leader extends the finalized wave-0 witnesses.
+    let w1_leader = create_block(
+        1,
+        8,
+        HashSet::from([
+            w0_r2_v2.identity.clone(),
+            w0_r2_v3.identity.clone(),
+            w0_r2_v4.identity.clone(),
+        ]),
+    );
+    let w1_r1_v2 = create_block(2, 9, HashSet::from([w1_leader.identity.clone()]));
+    let w1_r1_v3 = create_block(3, 10, HashSet::from([w1_leader.identity.clone()]));
+    let w1_r1_v4 = create_block(4, 11, HashSet::from([w1_leader.identity.clone()]));
+    let w1_r1_preds = HashSet::from([
+        w1_r1_v2.identity.clone(),
+        w1_r1_v3.identity.clone(),
+        w1_r1_v4.identity.clone(),
+    ]);
+    let w1_r2_v2 = create_block(2, 12, w1_r1_preds.clone());
+    let w1_r2_v3 = create_block(3, 13, w1_r1_preds.clone());
+    let w1_r2_v4 = create_block(4, 14, w1_r1_preds);
+
+    // Both nodes first learn only wave 0, though node B receives it scrambled.
+    for block in [
+        &w0_leader, &w0_r1_v2, &w0_r1_v3, &w0_r1_v4, &w0_r2_v2, &w0_r2_v3, &w0_r2_v4,
+    ] {
+        network.queue_delivery(node(100), block.clone());
+    }
+    for block in [
+        &w0_r2_v3, &w0_r1_v2, &w0_r2_v2, &w0_leader, &w0_r1_v4, &w0_r2_v4, &w0_r1_v3,
+    ] {
+        network.queue_delivery(node(101), block.clone());
+    }
+
+    while network.deliver_next_to(&node(100)).is_some() {}
+    while network.deliver_next_to(&node(101)).is_some() {}
+    network.retry_all_buffers();
+
+    let node_a = network.node(&node(100)).expect("node A should exist");
+    let node_b = network.node(&node(101)).expect("node B should exist");
+
+    let tau_wave0_a = node_a
+        .ordered_output(wavelength, n, f, leader_node1)
+        .expect("node A should produce tau after wave 0");
+    let tau_wave0_b = node_b
+        .ordered_output(wavelength, n, f, leader_node1)
+        .expect("node B should produce tau after wave 0");
+    assert!(!tau_wave0_a.is_empty());
+    assert_eq!(tau_wave0_a, tau_wave0_b);
+
+    // Now both nodes receive wave 1. We already stressed out-of-order recovery
+    // in earlier scenarios, so this test focuses on monotonic growth across
+    // finalized waves rather than adding another source of variance here.
+    for block in [
+        &w1_leader, &w1_r1_v2, &w1_r1_v3, &w1_r1_v4, &w1_r2_v2, &w1_r2_v3, &w1_r2_v4,
+    ] {
+        network.queue_delivery(node(100), block.clone());
+    }
+    for block in [
+        &w1_leader, &w1_r1_v2, &w1_r1_v3, &w1_r1_v4, &w1_r2_v2, &w1_r2_v3, &w1_r2_v4,
+    ] {
+        network.queue_delivery(node(101), block.clone());
+    }
+
+    while network.deliver_next_to(&node(100)).is_some() {}
+    while network.deliver_next_to(&node(101)).is_some() {}
+    network.retry_all_buffers();
+
+    let node_a = network.node(&node(100)).expect("node A should still exist");
+    let node_b = network.node(&node(101)).expect("node B should still exist");
+
+    let tau_wave1_a = node_a
+        .ordered_output(wavelength, n, f, leader_node1)
+        .expect("node A should produce tau after wave 1");
+    let tau_wave1_b = node_b
+        .ordered_output(wavelength, n, f, leader_node1)
+        .expect("node B should produce tau after wave 1");
+
+    assert_eq!(tau_wave1_a, tau_wave1_b);
+    assert_eq!(node_b.pending_len(), 0);
+    assert!(
+        tau_wave1_a.len() > tau_wave0_a.len(),
+        "later finalized waves should extend the ordered output"
+    );
+    assert_eq!(
+        &tau_wave1_a[..tau_wave0_a.len()],
+        tau_wave0_a.as_slice(),
+        "tau should grow monotonically without rewriting earlier output"
+    );
+}

--- a/crates/cordial-miners-core/tests/test_dissemination_simulation.rs
+++ b/crates/cordial-miners-core/tests/test_dissemination_simulation.rs
@@ -34,6 +34,10 @@ fn simulation_validation_config() -> ValidationConfig {
     }
 }
 
+fn leader_node1(_wave: u64) -> Option<NodeId> {
+    Some(node(1))
+}
+
 #[test]
 fn out_of_order_delivery_is_buffered_then_resolved_after_parent_arrives() {
     let mut bonds = HashMap::new();
@@ -199,4 +203,66 @@ fn proposal_construction_converges_after_nodes_catch_up_on_visible_tips() {
 
     assert_eq!(candidate_a.payload, candidate_b_after.payload); // Check that the payloads of the two candidates are the same, which indicates that both nodes constructed their candidates using the same set of visible tips and thus converged on the same proposal content
     assert_eq!(candidate_a.predecessors, candidate_b_after.predecessors); // Check that the predecessors of the two candidates are the same, which indicates that both nodes constructed their candidates using the same set of visible tips and thus converged on the same proposal content
+}
+
+#[test]
+fn finality_and_tau_converge_after_out_of_order_wave_delivery() {
+    let mut bonds = HashMap::new();
+    bonds.insert(node(1), 100);
+    bonds.insert(node(2), 100);
+    bonds.insert(node(3), 100);
+    bonds.insert(node(4), 100);
+
+    let node_a = SimNode::new(node(30), bonds.clone(), simulation_validation_config());
+    let node_b = SimNode::new(node(31), bonds, simulation_validation_config());
+    let mut network = SimNetwork::new(vec![node_a, node_b]);
+
+    let wavelength = 3u64;
+    let n = 4usize;
+    let f = 1usize;
+
+    let leader = create_block(1, 1, HashSet::new());
+
+    let r1_v2 = create_block(2, 2, HashSet::from([leader.identity.clone()]));
+    let r1_v3 = create_block(3, 3, HashSet::from([leader.identity.clone()]));
+    let r1_v4 = create_block(4, 4, HashSet::from([leader.identity.clone()]));
+
+    let round1_preds = HashSet::from([
+        r1_v2.identity.clone(),
+        r1_v3.identity.clone(),
+        r1_v4.identity.clone(),
+    ]);
+    let r2_v2 = create_block(2, 5, round1_preds.clone());
+    let r2_v3 = create_block(3, 6, round1_preds.clone());
+    let r2_v4 = create_block(4, 7, round1_preds);
+
+    for block in [&leader, &r1_v2, &r1_v3, &r1_v4, &r2_v2, &r2_v3, &r2_v4] {
+        network.queue_delivery(node(30), block.clone());
+    }
+
+    for block in [&r2_v3, &r1_v2, &r2_v2, &leader, &r1_v4, &r2_v4, &r1_v3] {
+        network.queue_delivery(node(31), block.clone());
+    }
+
+    while network.deliver_next_to(&node(30)).is_some() {}
+    while network.deliver_next_to(&node(31)).is_some() {}
+    network.retry_all_buffers();
+
+    let node_a = network.node(&node(30)).expect("node A should exist");
+    let node_b = network.node(&node(31)).expect("node B should exist");
+
+    let final_a = node_a.latest_final_leader(wavelength, n, f, leader_node1);
+    let final_b = node_b.latest_final_leader(wavelength, n, f, leader_node1);
+    assert_eq!(final_a, Some(leader.identity.clone()));
+    assert_eq!(final_b, Some(leader.identity.clone()));
+
+    let tau_a = node_a
+        .ordered_output(wavelength, n, f, leader_node1)
+        .expect("node A should produce ordered output");
+    let tau_b = node_b
+        .ordered_output(wavelength, n, f, leader_node1)
+        .expect("node B should produce ordered output");
+
+    assert!(!tau_a.is_empty(), "finalized wave should produce non-empty tau");
+    assert_eq!(tau_a, tau_b);
 }

--- a/crates/cordial-miners-core/tests/test_dissemination_simulation.rs
+++ b/crates/cordial-miners-core/tests/test_dissemination_simulation.rs
@@ -1,0 +1,61 @@
+use cordial_miners_core::simulation::dissemination::{DeliveryOutcome, SimNode};
+use cordial_miners_core::{Block, BlockContent, BlockIdentity, NodeId};
+use cordial_miners_core::consensus::ValidationConfig;
+use std::collections::{HashMap, HashSet};
+
+fn node(id: u8) -> NodeId {
+    NodeId(vec![id])
+}
+
+fn create_block(creator_id: u8, tag: u8, predecessors: HashSet<BlockIdentity>) -> Block {
+    let mut content_hash = [0u8; 32];
+    content_hash[0] = creator_id;
+    content_hash[1] = tag;
+
+    Block {
+        identity: BlockIdentity {
+            content_hash,
+            creator: node(creator_id),
+            signature: vec![tag],
+        },
+        content: BlockContent {
+            payload: vec![tag],
+            predecessors,
+        },
+    }
+}
+
+fn simulation_validation_config() -> ValidationConfig {
+    ValidationConfig {
+        check_content_hash: false,
+        check_signature: false,
+        ..ValidationConfig::default()
+    }
+}
+
+#[test]
+fn out_of_order_delivery_is_buffered_then_resolved_after_parent_arrives() {
+    let mut bonds = HashMap::new();
+    bonds.insert(node(1), 100);
+    bonds.insert(node(2), 100);
+
+    let mut sim_node = SimNode::new(node(9), bonds, simulation_validation_config());
+
+    let genesis = create_block(1, 1, HashSet::new());
+    let child = create_block(2, 2, HashSet::from([genesis.identity.clone()]));
+
+    let early_delivery = sim_node.receive_block(child.clone());
+    assert_eq!(early_delivery, DeliveryOutcome::Buffered);
+    assert_eq!(sim_node.pending_len(), 1);
+    assert!(!sim_node.knows_block(&child.identity));
+
+    let parent_delivery = sim_node.receive_block(genesis.clone());
+    assert_eq!(parent_delivery, DeliveryOutcome::Inserted);
+    assert!(sim_node.knows_block(&genesis.identity));
+
+    sim_node.retry_buffered_blocks();
+
+    assert_eq!(sim_node.pending_len(), 0);
+    assert!(sim_node.knows_block(&child.identity));
+}
+


### PR DESCRIPTION
Closes: #84 

## Summary

This PR adds a dissemination simulation harness for Cordial Miners and uses it to test multi-node convergence under asynchronous and adversarial delivery conditions.

It introduces a small reusable simulation layer and covers:

- out-of-order delivery and buffering
- multi-node catch-up
- proposal construction after visibility catch-up
- finality and `tau` convergence
- equivocation rejection
- partition-and-heal recovery
- unbonded sender rejection
- duplicate delivery stability
- weighted/unweighted divergence
- weighted catch-up convergence
- multi-wave monotonic `tau` growth

## What changed

### Simulation module

Added:

- `crates/cordial-miners-core/src/simulation/mod.rs`
- `crates/cordial-miners-core/src/simulation/dissemination.rs`

This introduces:

- `SimNode`
- `SimNetwork`
- `DeliveryOutcome`

### Simulation tests

Added / expanded:

- `crates/cordial-miners-core/tests/test_dissemination_simulation.rs`

The test suite now exercises:
- buffering and replay after missing predecessors
- convergence after different delivery orders
- proposal construction once enough tips are visible
- finality and `tau` agreement after catch-up
- rejection of equivocating leader attempts
- rejection of unbonded sender blocks
- recovery after partition healing
- duplicate-delivery stability
- weighted path remaining empty when stake support is insufficient
- weighted path converging once high-stake validators participate
- monotonic `tau` growth across multiple finalized waves

## Why this matters

This PR turns dissemination from a set of local helpers into a tested multi-node execution story.

It shows that:
- nodes with different local views can recover through buffering and replay
- honest nodes converge on the same final leader and ordered output
- invalid adversarial blocks are rejected without poisoning convergence
- weighted and unweighted paths both behave consistently under dissemination

## Verification

```bash
cargo test -p cordial-miners-core --test test_dissemination_simulation -- --nocapture
cargo check -p cordial-miners-core