### PR TITLE
feat: add consensus evidence and slash formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -694,6 +694,7 @@ dependencies = [
  "either",
  "k256",
  "models",
+ "prost",
  "rand 0.8.5",
  "serde",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 bincode = "1"
 anyhow = "1.0"
+prost = "0.14"
 
 # Used only by the blocklace-f1r3node adapter crate for crypto alignment
 # with f1r3node (Blake2b-256 block hashing, Secp256k1 validator signatures).

--- a/crates/cordial-f1r3node-adapter/Cargo.toml
+++ b/crates/cordial-f1r3node-adapter/Cargo.toml
@@ -13,6 +13,7 @@ sha2.workspace = true
 serde.workspace = true
 bincode.workspace = true
 anyhow.workspace = true
+prost = "0.14"
 
 # Phase 3.4 — crypto alignment with f1r3node.
 blake2.workspace = true

--- a/crates/cordial-f1r3node-adapter/Cargo.toml
+++ b/crates/cordial-f1r3node-adapter/Cargo.toml
@@ -13,7 +13,7 @@ sha2.workspace = true
 serde.workspace = true
 bincode.workspace = true
 anyhow.workspace = true
-prost = "0.14"
+prost.workspace = true
 
 # Phase 3.4 — crypto alignment with f1r3node.
 blake2.workspace = true

--- a/crates/cordial-f1r3node-adapter/src/lib.rs
+++ b/crates/cordial-f1r3node-adapter/src/lib.rs
@@ -28,4 +28,5 @@ pub mod repository;
 pub mod rspace_runtime;
 pub mod runtime_bridge;
 pub mod shard_conf;
+pub mod slashing;
 pub mod snapshot;

--- a/crates/cordial-f1r3node-adapter/src/slashing.rs
+++ b/crates/cordial-f1r3node-adapter/src/slashing.rs
@@ -131,12 +131,15 @@ fn select_invalid_block_hash(
         bail!("slash evidence contains a block from a different validator");
     }
 
+    // f1r3node's SlashDeploy names one invalid block hash. Cordial evidence
+    // retains the full conflicting set separately, so choose the lowest content
+    // hash as the deterministic representative independent of signature bytes.
     let mut identities = record
         .blocks
         .iter()
         .map(|block| &block.identity)
         .collect::<Vec<_>>();
-    identities.sort();
+    identities.sort_by_key(|identity| identity.content_hash);
 
     Ok(identities[0].content_hash)
 }

--- a/crates/cordial-f1r3node-adapter/src/slashing.rs
+++ b/crates/cordial-f1r3node-adapter/src/slashing.rs
@@ -1,0 +1,154 @@
+//! Formatting Cordial Miners equivocation evidence as f1r3node slash deploys.
+//!
+//! The core crate retains raw equivocation evidence without host-node types.
+//! This adapter crosses that boundary and emits the byte-identical protobuf
+//! payload f1r3node stores in block bodies for slash system deploys.
+
+use anyhow::{Result, bail};
+use prost::Message;
+use prost::bytes::Bytes;
+
+use cordial_miners_core::block::Block;
+use cordial_miners_core::consensus::EquivocationEvidence;
+use cordial_miners_core::types::{BlockIdentity, NodeId};
+
+use models::casper::{
+    ProcessedSystemDeployProto, SlashSystemDeployDataProto, SystemDeployDataProto,
+    system_deploy_data_proto::SystemDeploy,
+};
+
+/// Converts pure-core equivocation evidence into host-specific slash deploy bytes.
+pub trait SlashDeployFormatter<V, P, Id> {
+    fn to_slash_system_deploys(
+        &self,
+        evidence: &[EquivocationEvidence<V, P, Id>],
+    ) -> Result<Vec<Vec<u8>>>;
+}
+
+/// Adapter-local proof package: f1r3node slash bytes plus raw Cordial block bytes.
+///
+/// RSpace only consumes the `slash_system_deploy` bytes. The serialized
+/// `conflicting_block_bytes` are retained for later proof transport, audits,
+/// and signature verification without changing the f1r3node protobuf shape.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FormattedSlashEvidence {
+    pub slash_system_deploy: Vec<u8>,
+    pub conflicting_block_bytes: Vec<Vec<u8>>,
+}
+
+/// f1r3node formatter for Cordial Miners slash evidence.
+///
+/// `issuer_public_key` is the public key of the validator proposing the slash
+/// deploy, matching CBC Casper's `SlashDeploy(invalidBlockHash, issuerPublicKey, ...)`
+/// construction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct F1r3SlashDeployFormatter {
+    issuer_public_key: Vec<u8>,
+}
+
+impl F1r3SlashDeployFormatter {
+    pub fn new(issuer_public_key: Vec<u8>) -> Self {
+        Self { issuer_public_key }
+    }
+
+    pub fn issuer_public_key(&self) -> &[u8] {
+        &self.issuer_public_key
+    }
+
+    pub fn to_slash_evidence_envelopes(
+        &self,
+        evidence: &[EquivocationEvidence<NodeId, Block, BlockIdentity>],
+    ) -> Result<Vec<FormattedSlashEvidence>> {
+        evidence
+            .iter()
+            .map(|record| {
+                let slash_system_deploy = self.encode_record(record)?;
+                let conflicting_block_bytes = serialize_conflicting_blocks(record)?;
+                Ok(FormattedSlashEvidence {
+                    slash_system_deploy,
+                    conflicting_block_bytes,
+                })
+            })
+            .collect()
+    }
+
+    fn encode_record(
+        &self,
+        record: &EquivocationEvidence<NodeId, Block, BlockIdentity>,
+    ) -> Result<Vec<u8>> {
+        let invalid_block_hash = select_invalid_block_hash(record)?;
+        Ok(encode_slash_processed_system_deploy(
+            invalid_block_hash,
+            &self.issuer_public_key,
+        ))
+    }
+}
+
+impl SlashDeployFormatter<NodeId, Block, BlockIdentity> for F1r3SlashDeployFormatter {
+    fn to_slash_system_deploys(
+        &self,
+        evidence: &[EquivocationEvidence<NodeId, Block, BlockIdentity>],
+    ) -> Result<Vec<Vec<u8>>> {
+        evidence
+            .iter()
+            .map(|record| self.encode_record(record))
+            .collect()
+    }
+}
+
+fn encode_slash_processed_system_deploy(
+    invalid_block_hash: [u8; 32],
+    issuer_public_key: &[u8],
+) -> Vec<u8> {
+    let proto = ProcessedSystemDeployProto {
+        system_deploy: Some(SystemDeployDataProto {
+            system_deploy: Some(SystemDeploy::SlashSystemDeploy(
+                SlashSystemDeployDataProto {
+                    invalid_block_hash: Bytes::copy_from_slice(&invalid_block_hash),
+                    issuer_public_key: Bytes::copy_from_slice(issuer_public_key),
+                },
+            )),
+        }),
+        deploy_log: vec![],
+        error_msg: String::new(),
+    };
+
+    proto.encode_to_vec()
+}
+
+fn select_invalid_block_hash(
+    record: &EquivocationEvidence<NodeId, Block, BlockIdentity>,
+) -> Result<[u8; 32]> {
+    if record.blocks.len() < 2 {
+        bail!("slash evidence requires at least two conflicting blocks");
+    }
+
+    if record
+        .blocks
+        .iter()
+        .any(|block| block.identity.creator != record.validator)
+    {
+        bail!("slash evidence contains a block from a different validator");
+    }
+
+    let mut identities = record
+        .blocks
+        .iter()
+        .map(|block| &block.identity)
+        .collect::<Vec<_>>();
+    identities.sort();
+
+    Ok(identities[0].content_hash)
+}
+
+fn serialize_conflicting_blocks(
+    record: &EquivocationEvidence<NodeId, Block, BlockIdentity>,
+) -> Result<Vec<Vec<u8>>> {
+    let mut blocks = record.blocks.iter().collect::<Vec<_>>();
+    blocks.sort_by(|a, b| a.identity.cmp(&b.identity));
+
+    blocks
+        .into_iter()
+        .map(|block| bincode::serialize(block).map_err(Into::into))
+        .collect()
+}

--- a/crates/cordial-f1r3node-adapter/tests/test_slashing.rs
+++ b/crates/cordial-f1r3node-adapter/tests/test_slashing.rs
@@ -1,0 +1,128 @@
+use std::collections::HashSet;
+
+use cordial_f1r3node_adapter::slashing::{F1r3SlashDeployFormatter, SlashDeployFormatter};
+use cordial_miners_core::consensus::EquivocationEvidence;
+use cordial_miners_core::{Block, BlockContent, BlockIdentity, NodeId};
+use models::casper::{
+    ProcessedSystemDeployProto, SlashSystemDeployDataProto, SystemDeployDataProto,
+    system_deploy_data_proto::SystemDeploy,
+};
+use prost::Message;
+use prost::bytes::Bytes;
+
+fn node(byte: u8) -> NodeId {
+    NodeId(vec![byte; 33])
+}
+
+fn block(creator: NodeId, tag: u8, signature: Vec<u8>) -> Block {
+    let mut content_hash = [0u8; 32];
+    content_hash[0] = tag;
+    content_hash[31] = tag.wrapping_add(1);
+
+    Block {
+        identity: BlockIdentity {
+            content_hash,
+            creator,
+            signature,
+        },
+        content: BlockContent {
+            payload: vec![tag, tag.wrapping_add(2)],
+            predecessors: HashSet::new(),
+        },
+    }
+}
+
+fn expected_slash_bytes(invalid_block_hash: [u8; 32], issuer_public_key: &[u8]) -> Vec<u8> {
+    ProcessedSystemDeployProto {
+        system_deploy: Some(SystemDeployDataProto {
+            system_deploy: Some(SystemDeploy::SlashSystemDeploy(
+                SlashSystemDeployDataProto {
+                    invalid_block_hash: Bytes::copy_from_slice(&invalid_block_hash),
+                    issuer_public_key: Bytes::copy_from_slice(issuer_public_key),
+                },
+            )),
+        }),
+        deploy_log: vec![],
+        error_msg: String::new(),
+    }
+    .encode_to_vec()
+}
+
+#[test]
+fn evidence_serializes_to_byte_identical_f1r3fly_slash_payload() {
+    let validator = node(7);
+    let issuer_public_key = vec![0xaa; 33];
+    let lower_hash_block = block(validator.clone(), 0x01, vec![0x10; 64]);
+    let higher_hash_block = block(validator.clone(), 0x02, vec![0x20; 64]);
+    let evidence = vec![EquivocationEvidence::new(
+        validator,
+        3,
+        vec![higher_hash_block.clone(), lower_hash_block.clone()],
+    )];
+    let formatter = F1r3SlashDeployFormatter::new(issuer_public_key.clone());
+
+    let slash_deploys = formatter.to_slash_system_deploys(&evidence).unwrap();
+
+    assert_eq!(slash_deploys.len(), 1);
+    assert_eq!(
+        slash_deploys[0],
+        expected_slash_bytes(lower_hash_block.identity.content_hash, &issuer_public_key)
+    );
+
+    let decoded = ProcessedSystemDeployProto::decode(slash_deploys[0].as_slice()).unwrap();
+    let system_deploy = decoded.system_deploy.unwrap().system_deploy.unwrap();
+    match system_deploy {
+        SystemDeploy::SlashSystemDeploy(slash) => {
+            assert_eq!(
+                slash.invalid_block_hash,
+                Bytes::copy_from_slice(&lower_hash_block.identity.content_hash)
+            );
+            assert_eq!(
+                slash.issuer_public_key,
+                Bytes::copy_from_slice(&issuer_public_key)
+            );
+        }
+        other => panic!("expected slash system deploy, got {other:?}"),
+    }
+}
+
+#[test]
+fn evidence_envelope_preserves_original_block_signatures() {
+    let validator = node(9);
+    let left = block(validator.clone(), 0x01, vec![0x11, 0x12, 0x13]);
+    let right = block(validator.clone(), 0x02, vec![0x21, 0x22, 0x23]);
+    let evidence = vec![EquivocationEvidence::new(
+        validator,
+        4,
+        vec![right.clone(), left.clone()],
+    )];
+    let formatter = F1r3SlashDeployFormatter::new(vec![0xbb; 33]);
+
+    let envelopes = formatter.to_slash_evidence_envelopes(&evidence).unwrap();
+
+    assert_eq!(envelopes.len(), 1);
+    assert_eq!(envelopes[0].conflicting_block_bytes.len(), 2);
+
+    let recovered = envelopes[0]
+        .conflicting_block_bytes
+        .iter()
+        .map(|bytes| bincode::deserialize::<Block>(bytes).unwrap())
+        .collect::<Vec<_>>();
+
+    assert_eq!(recovered[0].identity.signature, left.identity.signature);
+    assert_eq!(recovered[0].content.payload, left.content.payload);
+    assert_eq!(recovered[1].identity.signature, right.identity.signature);
+    assert_eq!(recovered[1].content.payload, right.content.payload);
+}
+
+#[test]
+fn slash_formatter_rejects_non_conflicting_single_block_evidence() {
+    let validator = node(1);
+    let only = block(validator.clone(), 0x01, vec![0x55]);
+    let evidence = vec![EquivocationEvidence::new(validator, 0, vec![only])];
+    let formatter = F1r3SlashDeployFormatter::new(vec![0xcc; 33]);
+
+    let err = formatter.to_slash_system_deploys(&evidence).unwrap_err();
+
+    assert!(err.to_string().contains("at least two conflicting blocks"));
+}

--- a/crates/cordial-f1r3space-adapter/Cargo.toml
+++ b/crates/cordial-f1r3space-adapter/Cargo.toml
@@ -23,7 +23,7 @@ shared = { path = "../../../f1r3node/shared" }
 
 # Direct deps we use in translation code. All come transitively via
 # f1r3node anyway; listing them explicitly keeps the imports working.
-prost = "0.14"
+prost.workspace = true
 tokio.workspace = true
 
 # LMDB — same library F1R3FLY uses in rspace_store_manager.rs

--- a/crates/cordial-miners-core/src/consensus/evidence.rs
+++ b/crates/cordial-miners-core/src/consensus/evidence.rs
@@ -1,0 +1,144 @@
+//! Equivocation evidence retention for Cordial Miners.
+//!
+//! Consensus validation can detect equivocation from the blocklace, but later
+//! slashing needs the original conflicting blocks as cryptographic proof. This
+//! module keeps that proof in the pure core crate without depending on host
+//! node or wire-serialization types.
+
+use std::collections::BTreeMap;
+use std::marker::PhantomData;
+
+use crate::block::Block;
+use crate::types::{BlockIdentity, NodeId};
+
+/// A block-like value that can expose a stable identity for evidence
+/// deduplication and deterministic ordering.
+pub trait EvidenceBlock<Id> {
+    fn evidence_id(&self) -> Id;
+}
+
+impl EvidenceBlock<BlockIdentity> for Block {
+    fn evidence_id(&self) -> BlockIdentity {
+        self.identity.clone()
+    }
+}
+
+/// Raw proof that one validator created conflicting blocks in one round.
+///
+/// `P` is intentionally generic so the core can retain the host's native block
+/// object without knowing how that host serializes it. In this crate, the
+/// concrete Cordial block type is [`Block`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EquivocationEvidence<V, P, Id> {
+    pub validator: V,
+    pub round: u64,
+    pub blocks: Vec<P>,
+    _identity: PhantomData<fn() -> Id>,
+}
+
+impl<V, P, Id> EquivocationEvidence<V, P, Id> {
+    pub fn new(validator: V, round: u64, blocks: Vec<P>) -> Self {
+        Self {
+            validator,
+            round,
+            blocks,
+            _identity: PhantomData,
+        }
+    }
+}
+
+/// Storage interface for retaining equivocation proof.
+pub trait EvidencePool<V, P, Id> {
+    /// Record one conflicting block set for `(validator, round)`.
+    ///
+    /// Returns `true` when a new evidence record was inserted and `false` when
+    /// the evidence was already present or fewer than two distinct blocks were
+    /// supplied.
+    fn record_equivocation<I>(&mut self, validator: V, round: u64, blocks: I) -> bool
+    where
+        I: IntoIterator<Item = P>;
+
+    /// Return all evidence known for a validator in deterministic order.
+    fn evidence_for(&self, validator: &V) -> Vec<EquivocationEvidence<V, P, Id>>;
+}
+
+/// In-memory evidence pool keyed first by `(validator, round)`.
+///
+/// Within each `(validator, round)` bucket, records are deduplicated by the
+/// sorted identities of the conflicting blocks. This means recording the same
+/// pair in the opposite order still produces one evidence record.
+type EvidenceBucket<P, Id, V> = BTreeMap<Vec<Id>, EquivocationEvidence<V, P, Id>>;
+type EvidenceRecords<V, P, Id> = BTreeMap<(V, u64), EvidenceBucket<P, Id, V>>;
+
+#[derive(Debug, Clone)]
+pub struct InMemoryEvidencePool<V, P, Id> {
+    records: EvidenceRecords<V, P, Id>,
+}
+
+impl<V, P, Id> Default for InMemoryEvidencePool<V, P, Id> {
+    fn default() -> Self {
+        Self {
+            records: BTreeMap::new(),
+        }
+    }
+}
+
+impl<V, P, Id> InMemoryEvidencePool<V, P, Id> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn len(&self) -> usize {
+        self.records.values().map(|bucket| bucket.len()).sum()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl<V, P, Id> EvidencePool<V, P, Id> for InMemoryEvidencePool<V, P, Id>
+where
+    V: Ord + Clone,
+    P: EvidenceBlock<Id> + Clone,
+    Id: Ord + Clone,
+{
+    fn record_equivocation<I>(&mut self, validator: V, round: u64, blocks: I) -> bool
+    where
+        I: IntoIterator<Item = P>,
+    {
+        let mut unique_blocks = BTreeMap::<Id, P>::new();
+        for block in blocks {
+            unique_blocks.entry(block.evidence_id()).or_insert(block);
+        }
+
+        if unique_blocks.len() < 2 {
+            return false;
+        }
+
+        let evidence_key: Vec<Id> = unique_blocks.keys().cloned().collect();
+        let evidence_blocks: Vec<P> = unique_blocks.into_values().collect();
+        let bucket = self.records.entry((validator.clone(), round)).or_default();
+
+        if bucket.contains_key(&evidence_key) {
+            return false;
+        }
+
+        bucket.insert(
+            evidence_key,
+            EquivocationEvidence::new(validator, round, evidence_blocks),
+        );
+        true
+    }
+
+    fn evidence_for(&self, validator: &V) -> Vec<EquivocationEvidence<V, P, Id>> {
+        self.records
+            .iter()
+            .filter(|((record_validator, _), _)| record_validator == validator)
+            .flat_map(|(_, bucket)| bucket.values().cloned())
+            .collect()
+    }
+}
+
+pub type CordialEquivocationEvidence = EquivocationEvidence<NodeId, Block, BlockIdentity>;
+pub type CordialEvidencePool = InMemoryEvidencePool<NodeId, Block, BlockIdentity>;

--- a/crates/cordial-miners-core/src/consensus/evidence.rs
+++ b/crates/cordial-miners-core/src/consensus/evidence.rs
@@ -62,13 +62,14 @@ pub trait EvidencePool<V, P, Id> {
     fn evidence_for(&self, validator: &V) -> Vec<EquivocationEvidence<V, P, Id>>;
 }
 
-/// In-memory evidence pool keyed first by `(validator, round)`.
+/// In-memory evidence pool keyed first by validator, then by round.
 ///
-/// Within each `(validator, round)` bucket, records are deduplicated by the
+/// Within each validator/round bucket, records are deduplicated by the
 /// sorted identities of the conflicting blocks. This means recording the same
 /// pair in the opposite order still produces one evidence record.
 type EvidenceBucket<P, Id, V> = BTreeMap<Vec<Id>, EquivocationEvidence<V, P, Id>>;
-type EvidenceRecords<V, P, Id> = BTreeMap<(V, u64), EvidenceBucket<P, Id, V>>;
+type EvidenceRounds<V, P, Id> = BTreeMap<u64, EvidenceBucket<P, Id, V>>;
+type EvidenceRecords<V, P, Id> = BTreeMap<V, EvidenceRounds<V, P, Id>>;
 
 #[derive(Debug, Clone)]
 pub struct InMemoryEvidencePool<V, P, Id> {
@@ -89,7 +90,11 @@ impl<V, P, Id> InMemoryEvidencePool<V, P, Id> {
     }
 
     pub fn len(&self) -> usize {
-        self.records.values().map(|bucket| bucket.len()).sum()
+        self.records
+            .values()
+            .flat_map(|rounds| rounds.values())
+            .map(|bucket| bucket.len())
+            .sum()
     }
 
     pub fn is_empty(&self) -> bool {
@@ -118,7 +123,12 @@ where
 
         let evidence_key: Vec<Id> = unique_blocks.keys().cloned().collect();
         let evidence_blocks: Vec<P> = unique_blocks.into_values().collect();
-        let bucket = self.records.entry((validator.clone(), round)).or_default();
+        let bucket = self
+            .records
+            .entry(validator.clone())
+            .or_default()
+            .entry(round)
+            .or_default();
 
         if bucket.contains_key(&evidence_key) {
             return false;
@@ -133,9 +143,10 @@ where
 
     fn evidence_for(&self, validator: &V) -> Vec<EquivocationEvidence<V, P, Id>> {
         self.records
-            .iter()
-            .filter(|((record_validator, _), _)| record_validator == validator)
-            .flat_map(|(_, bucket)| bucket.values().cloned())
+            .get(validator)
+            .into_iter()
+            .flat_map(|rounds| rounds.values())
+            .flat_map(|bucket| bucket.values().cloned())
             .collect()
     }
 }

--- a/crates/cordial-miners-core/src/consensus/mod.rs
+++ b/crates/cordial-miners-core/src/consensus/mod.rs
@@ -1,6 +1,7 @@
 pub mod approval;
 pub mod cordiality;
 pub mod dissemination;
+pub mod evidence;
 pub mod finality;
 pub mod fork_choice;
 pub mod ordering;
@@ -19,6 +20,10 @@ pub use cordiality::{
 pub use dissemination::{
     PendingBlockBuffer, required_acknowledgements, select_predecessors, select_predecessors_sorted,
     validator_visible_tips, weighted_required_acknowledgements,
+};
+pub use evidence::{
+    CordialEquivocationEvidence, CordialEvidencePool, EquivocationEvidence, EvidenceBlock,
+    EvidencePool, InMemoryEvidencePool,
 };
 pub use finality::{
     final_leader_for_wave, is_final_leader, is_weighted_final_leader, latest_final_leader,

--- a/crates/cordial-miners-core/tests/test_evidence_pool.rs
+++ b/crates/cordial-miners-core/tests/test_evidence_pool.rs
@@ -1,0 +1,111 @@
+use cordial_miners_core::consensus::{CordialEvidencePool, EvidencePool};
+use cordial_miners_core::{Block, BlockContent, BlockIdentity, NodeId};
+use std::collections::HashSet;
+
+fn node(byte: u8) -> NodeId {
+    NodeId(vec![byte])
+}
+
+fn identity(creator: NodeId, tag: u8) -> BlockIdentity {
+    let mut content_hash = [0u8; 32];
+    content_hash[0] = creator.0[0];
+    content_hash[1] = tag;
+
+    BlockIdentity {
+        content_hash,
+        creator,
+        signature: vec![tag, tag.wrapping_add(1)],
+    }
+}
+
+fn block(creator: NodeId, tag: u8, payload: Vec<u8>) -> Block {
+    Block {
+        identity: identity(creator, tag),
+        content: BlockContent {
+            payload,
+            predecessors: HashSet::new(),
+        },
+    }
+}
+
+#[test]
+fn duplicate_conflicting_pair_is_recorded_once() {
+    let validator = node(1);
+    let left = block(validator.clone(), 1, vec![0xa1]);
+    let right = block(validator.clone(), 2, vec![0xb1]);
+    let mut pool = CordialEvidencePool::new();
+
+    assert!(pool.record_equivocation(validator.clone(), 0, vec![left.clone(), right.clone()]));
+    assert!(!pool.record_equivocation(validator.clone(), 0, vec![left.clone(), right.clone()]));
+    assert!(!pool.record_equivocation(validator.clone(), 0, vec![right, left]));
+
+    let evidence = pool.evidence_for(&validator);
+    assert_eq!(evidence.len(), 1);
+    assert_eq!(pool.len(), 1);
+}
+
+#[test]
+fn evidence_retains_original_cordial_blocks() {
+    let validator = node(1);
+    let left = block(validator.clone(), 0x0a, vec![0xde, 0xad]);
+    let right = block(validator.clone(), 0x0b, vec![0xbe, 0xef]);
+    let mut pool = CordialEvidencePool::new();
+
+    assert!(pool.record_equivocation(validator.clone(), 0, vec![left.clone(), right.clone()]));
+
+    let evidence = pool.evidence_for(&validator);
+    assert_eq!(evidence.len(), 1);
+    assert_eq!(evidence[0].validator, validator);
+    assert_eq!(evidence[0].round, 0);
+    assert_eq!(evidence[0].blocks, vec![left, right]);
+    assert_eq!(evidence[0].blocks[0].content.payload, vec![0xde, 0xad]);
+    assert_eq!(evidence[0].blocks[0].identity.signature, vec![0x0a, 0x0b]);
+    assert_eq!(evidence[0].blocks[1].content.payload, vec![0xbe, 0xef]);
+    assert_eq!(evidence[0].blocks[1].identity.signature, vec![0x0b, 0x0c]);
+}
+
+#[test]
+fn evidence_for_validator_is_deterministically_ordered() {
+    let validator = node(1);
+    let other_validator = node(2);
+    let round_zero_left = block(validator.clone(), 1, vec![1]);
+    let round_zero_right = block(validator.clone(), 2, vec![2]);
+    let round_one_left = block(validator.clone(), 3, vec![3]);
+    let round_one_right = block(validator.clone(), 4, vec![4]);
+    let other_left = block(other_validator.clone(), 5, vec![5]);
+    let other_right = block(other_validator, 6, vec![6]);
+    let mut pool = CordialEvidencePool::new();
+
+    assert!(pool.record_equivocation(
+        validator.clone(),
+        1,
+        vec![round_one_right.clone(), round_one_left.clone()],
+    ));
+    assert!(pool.record_equivocation(
+        validator.clone(),
+        0,
+        vec![round_zero_right.clone(), round_zero_left.clone()],
+    ));
+    assert!(pool.record_equivocation(node(2), 0, vec![other_right, other_left]));
+
+    let evidence = pool.evidence_for(&validator);
+    assert_eq!(evidence.len(), 2);
+    assert_eq!(evidence[0].round, 0);
+    assert_eq!(
+        evidence[0]
+            .blocks
+            .iter()
+            .map(|block| block.identity.clone())
+            .collect::<Vec<_>>(),
+        vec![round_zero_left.identity, round_zero_right.identity]
+    );
+    assert_eq!(evidence[1].round, 1);
+    assert_eq!(
+        evidence[1]
+            .blocks
+            .iter()
+            .map(|block| block.identity.clone())
+            .collect::<Vec<_>>(),
+        vec![round_one_left.identity, round_one_right.identity]
+    );
+}

--- a/docs/cordial-miners/06-evidence-pool.md
+++ b/docs/cordial-miners/06-evidence-pool.md
@@ -1,0 +1,85 @@
+# Cordial Miners Evidence Pool
+
+## Purpose
+
+Cordiality checks can detect that a validator equivocated, but slashing needs
+more than a boolean decision. The network must retain the original conflicting
+`CordialBlock` values so a later slashing path can verify the signatures,
+validator identity, round, payload, and parent set exactly as they were observed.
+
+The evidence pool is the pure-core retention layer for that proof. It does not
+know how F1R3FLY serializes blocks on the network, how an adapter encodes them,
+or how a slashing transaction will later be submitted. It only keeps the raw
+core block objects and indexes them deterministically.
+
+## Data Model
+
+`EquivocationEvidence<V, P, Id>` contains:
+
+- `validator`: the validator accused of producing conflicting blocks.
+- `round`: the Cordial Miners round where the conflict happened.
+- `blocks`: the original conflicting block objects.
+
+The type is generic so the core can retain native block objects without pulling
+host-chain serialization types into the consensus math. For the in-tree Cordial
+core, `CordialEquivocationEvidence` is an alias for:
+
+```rust
+EquivocationEvidence<NodeId, Block, BlockIdentity>
+```
+
+`Block` is stored directly. The pool does not convert payloads into bytes, does
+not re-sign blocks, and does not rebuild the structure. This is important
+because later signature verification and slashing proof generation must operate
+on the same block data that triggered equivocation detection.
+
+## Pool Interface
+
+The `EvidencePool<V, P, Id>` trait exposes two operations:
+
+- `record_equivocation(validator, round, blocks)` records one conflicting block
+  set for a validator and round.
+- `evidence_for(validator)` returns all retained evidence for that validator in
+  stable deterministic order.
+
+`InMemoryEvidencePool` is keyed first by `(validator, round)`. Inside each
+bucket, records are keyed by the sorted block identities in the conflicting set.
+That gives two properties:
+
+- Replaying the exact same conflicting pair does not duplicate evidence.
+- Replaying the same pair in the opposite order still maps to the same evidence
+  key.
+
+The pool ignores records with fewer than two distinct block identities because a
+single block is not cryptographic evidence of equivocation.
+
+## Deterministic Query Order
+
+The implementation uses `BTreeMap` for both the outer `(validator, round)` index
+and the inner block-identity index. Querying by validator therefore returns a
+stable ordering:
+
+1. validator key order from the outer map,
+2. increasing round for the queried validator,
+3. sorted conflicting block-identity sets within the round.
+
+This deterministic ordering matters for tests, replay, audits, and future proof
+packaging.
+
+## Boundary With F1R3FLY
+
+The evidence pool is intentionally below the adapter boundary:
+
+- It imports only Cordial Miners core types.
+- It has no dependency on node, adapter, gRPC, protobuf, or network wire types.
+- It performs no byte-array payload formatting.
+- It does not decide slashing economics or build a slashing transaction.
+
+The expected lifecycle is:
+
+1. Cordiality logic detects conflicting blocks for a validator in a round.
+2. The caller records the original blocks in `EvidencePool`.
+3. Finality or slashing logic later asks `evidence_for(validator)`.
+4. A higher layer verifies signatures and packages the retained raw blocks into
+   whatever proof format the host chain requires.
+

--- a/docs/cordial-miners/07-slash-formatting.md
+++ b/docs/cordial-miners/07-slash-formatting.md
@@ -1,0 +1,81 @@
+# Cordial Miners Slash Formatting
+
+## Purpose
+
+The core evidence pool keeps `EquivocationEvidence` free of F1R3FLY types. The
+adapter is the boundary where that pure evidence becomes a host-chain system
+deploy that F1R3FLY can execute and replay.
+
+CBC Casper creates slashing deploys in `BlockCreator.prepareSlashingDeploys` by
+taking an invalid block hash and wrapping it in:
+
+```text
+SlashDeploy(invalidBlockHash, issuerPublicKey, slashRandomSeed)
+```
+
+During replay, F1R3FLY stores and replays the block-body form as
+`ProcessedSystemDeployProto` containing:
+
+```text
+SystemDeployDataProto::slashSystemDeploy {
+  invalidBlockHash,
+  issuerPublicKey
+}
+```
+
+The Cordial adapter emits that exact protobuf byte payload.
+
+## Formatter API
+
+`SlashDeployFormatter<V, P, Id>` exposes:
+
+```rust
+to_slash_system_deploys(
+    evidence: &[EquivocationEvidence<V, P, Id>],
+) -> anyhow::Result<Vec<Vec<u8>>>
+```
+
+For Cordial Miners, `F1r3SlashDeployFormatter` implements the trait for:
+
+```rust
+EquivocationEvidence<NodeId, Block, BlockIdentity>
+```
+
+The formatter is constructed with the issuer public key. This mirrors CBC
+Casper: the slash deploy identifies the invalid block being reported, while the
+issuer key is the validator proposing the system deploy.
+
+## Evidence Mapping
+
+For each evidence record:
+
+1. Require at least two conflicting blocks.
+2. Require every conflicting block to be from the evidence validator.
+3. Sort the conflicting block identities deterministically.
+4. Select the first sorted content hash as the `invalidBlockHash`.
+5. Encode a successful `ProcessedSystemDeployProto` with a slash system deploy.
+
+The deterministic selection keeps repeated formatting stable even if the same
+evidence arrives in a different block order.
+
+## Signature Preservation
+
+The F1R3FLY slash protobuf carries only `invalidBlockHash` and
+`issuerPublicKey`; it does not carry raw conflicting block signatures. For that
+reason, the adapter also exposes an evidence envelope containing:
+
+- the byte-identical F1R3FLY slash system deploy bytes,
+- serialized raw Cordial blocks from the evidence record.
+
+Those raw block bytes preserve the original signatures and payloads for later
+proof transport, auditing, and cryptographic verification. RSpace consumes the
+slash system deploy bytes; proof packaging can consume the retained block bytes.
+
+## Boundary Rules
+
+- The core evidence pool remains pure and has no dependency on F1R3FLY models.
+- The adapter uses real F1R3FLY protobuf/model types for slash deploy encoding.
+- The formatter does not re-sign, re-hash, or mutate the original Cordial
+  blocks.
+- The protobuf encoding is deterministic and covered by byte-for-byte tests.
+


### PR DESCRIPTION
## Summary

Closes #12.

This PR completes the Issue #12 economic-safety path around Cordial Miners consensus evidence:

- adds a pure-core equivocation evidence pool for retaining raw conflicting Cordial blocks
- keeps core evidence free of F1R3FLY adapter, protobuf, gRPC, and node serialization types
- adds deterministic evidence deduplication keyed by validator, round, and sorted conflicting block identities
- adds adapter-side slash deploy formatting using F1R3FLY protobuf/model types
- emits byte-identical F1R3FLY slash system deploy payloads for RSpace/block replay compatibility
- preserves raw conflicting block bytes and signatures in an adapter evidence envelope for later proof packaging and audit flows
- documents both the core evidence pool and adapter slash formatting boundary

## Commit Structure

- feat(core): add equivocation evidence pool
- feat(adapter): format slash evidence for f1r3node

## Validation

Passed locally:

- cargo fmt -p cordial-miners-core --check
- cargo fmt -p cordial-f1r3node-adapter --check
- cargo fmt -p cordial-f1r3space-adapter --check
- cargo clippy -p cordial-miners-core -p cordial-f1r3node-adapter -p cordial-f1r3space-adapter --all-targets --all-features --no-deps -- -D warnings
- cargo build --verbose
- cargo test -p cordial-miners-core --test test_evidence_pool
- cargo test -p cordial-f1r3node-adapter --test test_slashing
- cargo test -p cordial-miners-core, rerun outside sandbox after sandbox-only node socket PermissionDenied failures

Attempted locally:

- timeout 900 cargo test --verbose

That broad CI-style test command timed out locally while linking heavy adapter/f1r3space test binaries, without emitting a Rust test failure. The focused tests for the new issue scope and the full core suite passed. GitHub Actions should run the full workflow on this PR in the CI environment.

## Notes

There is an unrelated local modification to crates/cordial-f1r3node-adapter/src/casper_adapter.rs in my working tree. It was intentionally left out of this PR.