### PR TITLE
Add live ingress scaffold for f1r3node interception

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,7 +432,6 @@ dependencies = [
  "hex",
  "imbl",
  "lz4_flex",
- "metrics",
  "models",
  "once_cell",
  "proptest",
@@ -492,7 +491,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "lz4_flex",
- "metrics",
+ "metrics 0.23.1",
  "models",
  "num_cpus",
  "proptest",
@@ -626,7 +625,7 @@ dependencies = [
  "hyper 1.9.0",
  "igd-next",
  "local-ip-address",
- "metrics",
+ "metrics 0.23.1",
  "models",
  "p256",
  "paste",
@@ -652,18 +651,6 @@ dependencies = [
  "url",
  "webpki",
  "x509-parser",
-]
-
-[[package]]
-name = "console"
-version = "0.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
-dependencies = [
- "encode_unicode",
- "libc",
- "unicode-width",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1160,12 +1147,6 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
-
-[[package]]
-name = "encode_unicode"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -2351,6 +2332,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics"
+version = "0.24.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
+dependencies = [
+ "portable-atomic",
+ "rapidhash",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3202,6 +3193,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rapidhash"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3383,12 +3383,9 @@ dependencies = [
 name = "rholang"
 version = "0.1.0"
 dependencies = [
- "anyhow",
- "async-trait",
  "bincode",
  "cc",
  "clap",
- "console",
  "crypto",
  "dotenv",
  "futures",
@@ -3397,7 +3394,7 @@ dependencies = [
  "itertools",
  "k256",
  "lazy_static",
- "metrics",
+ "metrics 0.24.6",
  "models",
  "num-bigint",
  "num-integer",
@@ -3498,7 +3495,7 @@ dependencies = [
  "hex",
  "itertools",
  "lazy_static",
- "metrics",
+ "metrics 0.23.1",
  "monadic",
  "multiset",
  "once_cell",
@@ -3865,7 +3862,7 @@ dependencies = [
  "http-body-util",
  "indexmap",
  "lz4_flex",
- "metrics",
+ "metrics 0.24.6",
  "proptest",
  "prost",
  "rand 0.9.4",
@@ -4585,12 +4582,6 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-width"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"

--- a/crates/cordial-f1r3node-adapter/src/lib.rs
+++ b/crates/cordial-f1r3node-adapter/src/lib.rs
@@ -23,6 +23,7 @@ pub mod block_translation;
 pub mod casper_adapter;
 pub mod crypto_bridge;
 pub mod grpc_ingest;
+pub mod live_ingress;
 pub mod proposer;
 pub mod repository;
 pub mod rspace_runtime;

--- a/crates/cordial-f1r3node-adapter/src/live_ingress.rs
+++ b/crates/cordial-f1r3node-adapter/src/live_ingress.rs
@@ -1,0 +1,94 @@
+//! Live ingress scaffolding for Cordial Miners integration with f1r3node.
+//!
+//! This module is the adapter-side home for the "live interception" path.
+//! It is intentionally narrow in scope for now: the first step is to make
+//! the responsibility boundary explicit before wiring real transport traffic.
+//!
+//! ## Responsibility
+//!
+//! `live_ingress` is where runtime-facing integration should live once we
+//! connect the adapter crate to real `f1r3node` message flow.
+//!
+//! In future steps this module will be responsible for:
+//!
+//! - receiving live block-bearing messages from a host node
+//! - translating them through existing adapter logic
+//! - feeding translated blocks into a local Cordial blocklace mirror
+//! - exposing enough state for snapshot, finality, and ordering work
+//!
+//! ## Non-goals in this first step
+//!
+//! This module does **not** yet:
+//!
+//! - attach to a real gRPC or transport server
+//! - maintain a full blocklace mirror
+//! - run finality or tau ordering
+//! - compare against HTTP-visible node state
+//!
+//! Those come in follow-up increments.
+
+/// High-level runtime phase for the live ingress adapter.
+///
+/// Keeping this explicit helps later commits avoid mixing "discovery only"
+/// state with fully wired live ingestion state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum LiveIngressPhase {
+    /// Module exists, but no live runtime path is attached yet.
+    #[default]
+    Defined,
+    /// A host-side ingress seam has been identified and documented.
+    Traced,
+    /// Live block messages are being accepted by the adapter boundary.
+    Connected,
+}
+
+/// Minimal adapter-side entry point for future live interception work.
+///
+/// The generic `A` is the stateful adapter/runtime component that later
+/// commits will use to store mirrored state, update snapshots, or expose
+/// ordered output. This first increment keeps the shape intentionally small.
+#[derive(Debug)]
+pub struct LiveIngress<A> {
+    phase: LiveIngressPhase,
+    adapter: A,
+}
+
+impl<A> LiveIngress<A> {
+    /// Create a new live-ingress wrapper around an adapter-side component.
+    pub fn new(adapter: A) -> Self {
+        Self {
+            phase: LiveIngressPhase::Defined,
+            adapter,
+        }
+    }
+
+    /// Return the current runtime phase of the live ingress component.
+    pub fn phase(&self) -> LiveIngressPhase {
+        self.phase
+    }
+
+    /// Mark that the host ingress seam has been traced and identified.
+    pub fn mark_traced(&mut self) {
+        self.phase = LiveIngressPhase::Traced;
+    }
+
+    /// Mark that live block-bearing traffic is attached to this adapter.
+    pub fn mark_connected(&mut self) {
+        self.phase = LiveIngressPhase::Connected;
+    }
+
+    /// Borrow the wrapped adapter/runtime component.
+    pub fn adapter(&self) -> &A {
+        &self.adapter
+    }
+
+    /// Mutably borrow the wrapped adapter/runtime component.
+    pub fn adapter_mut(&mut self) -> &mut A {
+        &mut self.adapter
+    }
+
+    /// Consume the wrapper and return the inner adapter/runtime component.
+    pub fn into_inner(self) -> A {
+        self.adapter
+    }
+}

--- a/crates/cordial-f1r3node-adapter/tests/test_live_ingress.rs
+++ b/crates/cordial-f1r3node-adapter/tests/test_live_ingress.rs
@@ -1,0 +1,20 @@
+use cordial_f1r3node_adapter::live_ingress::{LiveIngress, LiveIngressPhase};
+
+#[test]
+fn new_live_ingress_starts_in_defined_phase() {
+    let ingress = LiveIngress::new(());
+    assert_eq!(ingress.phase(), LiveIngressPhase::Defined);
+}
+
+#[test]
+fn live_ingress_phase_can_progress_without_changing_adapter() {
+    let mut ingress = LiveIngress::new(String::from("adapter"));
+
+    ingress.mark_traced();
+    assert_eq!(ingress.phase(), LiveIngressPhase::Traced);
+    assert_eq!(ingress.adapter(), "adapter");
+
+    ingress.mark_connected();
+    assert_eq!(ingress.phase(), LiveIngressPhase::Connected);
+    assert_eq!(ingress.into_inner(), "adapter");
+}

--- a/docs/cordial-miners/integration/00-index.md
+++ b/docs/cordial-miners/integration/00-index.md
@@ -1,0 +1,33 @@
+# Cordial Miners Integration Index
+
+This folder tracks the incremental integration work that connects the
+implemented Cordial Miners consensus logic in this repository to a running
+`f1r3node` instance.
+
+The purpose of this index is to keep the integration track modular, readable,
+and easy to extend as new implementation notes are added.
+
+## Documents
+
+1. [01-live-ingress-scaffold.md](./01-live-ingress-scaffold.md)
+   - Introduces the first adapter-side runtime scaffold for live interception
+   - Establishes the `live_ingress` module as the home for future runtime wiring
+
+## Scope Of This Track
+
+The integration notes in this folder focus on:
+
+- how `f1r3node` traffic is traced and understood
+- how live ingress is attached from this repository
+- how intercepted messages are translated into Cordial Miners state
+- how live state is compared, validated, and eventually ordered
+
+## Planned Follow-up Topics
+
+Future notes in this folder are expected to cover:
+
+- live `BlockMessage` ingestion through the existing `grpc_ingest` pipeline
+- stateful blocklace mirroring from intercepted traffic
+- snapshot, finality, and tau ordering on live mirrored state
+- HTTP-based comparison harnesses
+- deploy ingress tracing and later interception candidates

--- a/docs/cordial-miners/integration/01-live-ingress-scaffold.md
+++ b/docs/cordial-miners/integration/01-live-ingress-scaffold.md
@@ -1,0 +1,101 @@
+# 01. Live Ingress Scaffold
+
+## Summary
+
+This note documents the first implementation step in the live `f1r3node`
+integration track: introducing a dedicated `live_ingress` module inside
+`crates/cordial-f1r3node-adapter`.
+
+This step is intentionally structural. It does not attach to a running node
+yet. Its purpose is to create a clear adapter-side home for future runtime
+interception work.
+
+## Why This Step Exists
+
+Most of the adapter-side integration primitives already exist in
+`crates/cordial-f1r3node-adapter`, including:
+
+- block/message translation
+- protobuf ingestion validation
+- Casper-facing adapter work
+- snapshot support
+- crypto alignment
+- proposer, repository, and runtime bridge support
+
+What was missing was a narrow runtime-facing entry point for live interception.
+
+Without that boundary, future work would risk being spread across unrelated
+modules. The scaffold added here prevents that by making the live integration
+path explicit before attaching real traffic.
+
+## Files
+
+### Implementation
+
+- `crates/cordial-f1r3node-adapter/src/live_ingress.rs`
+- `crates/cordial-f1r3node-adapter/src/lib.rs`
+
+### Tests
+
+- `crates/cordial-f1r3node-adapter/tests/test_live_ingress.rs`
+
+## What Was Added
+
+The new `live_ingress` module contains:
+
+- `LiveIngressPhase`
+  - a small runtime phase enum describing the current integration state
+- `LiveIngress<A>`
+  - a minimal wrapper around an adapter-side runtime component
+  - intentionally generic so later steps can plug in richer state
+
+The first supported phases are:
+
+- `Defined`
+  - module exists, but no live transport is attached
+- `Traced`
+  - host ingress seam has been identified and documented
+- `Connected`
+  - live message flow is attached to the adapter boundary
+
+## Responsibility Boundary
+
+This module is the adapter-side home for future work that will:
+
+- receive live block-bearing messages from `f1r3node`
+- translate them through existing adapter logic
+- feed translated blocks into a local Cordial blocklace mirror
+- expose enough state for snapshot, finality, and ordering work
+
+## What This Step Does Not Do
+
+This scaffold does **not** yet:
+
+- attach to a real gRPC or transport server
+- ingest live `BlockMessage` traffic
+- maintain a stateful blocklace mirror
+- run snapshot, finality, or tau ordering
+- compare adapter state with HTTP-visible node state
+
+Those are deferred to the next integration notes and implementation issues.
+
+## Verification
+
+The scaffold is covered by a dedicated adapter test file:
+
+- `cargo test -p cordial-f1r3node-adapter --test test_live_ingress`
+
+The tests verify:
+
+- new live ingress starts in the `Defined` phase
+- phase progression does not disturb the wrapped adapter value
+
+## Outcome
+
+This step completes the first live-integration sub-issue:
+
+> create the adapter-side home for live interception work
+
+The result is modest by design, but important. Future commits can now build on
+an explicit runtime boundary instead of introducing live interception behavior
+indirectly through unrelated adapter modules.


### PR DESCRIPTION
Closes #100 

## Summary
This PR introduces the first adapter-side runtime scaffold for live `f1r3node` interception work.

It does not wire real gRPC traffic yet. Instead, it creates a dedicated `live_ingress` module in `cordial-f1r3node-adapter` so the live integration path has an explicit home before we start attaching runtime behavior.

## What changed
- added `crates/cordial-f1r3node-adapter/src/live_ingress.rs`
- exported `live_ingress` from `crates/cordial-f1r3node-adapter/src/lib.rs`
- defined a minimal `LiveIngress` wrapper and `LiveIngressPhase` state model
- moved live-ingress checks into a dedicated test file:
  - `crates/cordial-f1r3node-adapter/tests/test_live_ingress.rs`

## Why
Most adapter-side integration primitives already exist in `cordial-f1r3node-adapter`, but the live interception path did not yet have a clear runtime entry point.

This PR fixes that by establishing a narrow, documented boundary for future work:
- live block-bearing message intake
- translation through existing adapter logic
- local blocklace mirroring
- later snapshot / finality / ordering integration

## Scope
This PR is intentionally structural.

It does **not** yet:
- attach to real gRPC transport
- ingest live `BlockMessage` traffic
- maintain a live blocklace mirror
- run snapshot, finality, or tau ordering
- compare against HTTP-visible node state

## Verification
Ran:

```bash
cargo test -p cordial-f1r3node-adapter --test test_live_ingress