### PR TITLE
Route live block messages through the existing gRPC ingest pipeline

### DIFF
--- a/crates/cordial-f1r3node-adapter/src/live_ingress.rs
+++ b/crates/cordial-f1r3node-adapter/src/live_ingress.rs
@@ -27,6 +27,12 @@
 //!
 //! Those come in follow-up increments.
 
+use cordial_miners_core::Block;
+use cordial_miners_core::types::BlockIdentity;
+
+use crate::block_translation::BlockMessage;
+use crate::grpc_ingest::{BlocklaceAdapter, GrpcBlockMapper};
+
 /// High-level runtime phase for the live ingress adapter.
 ///
 /// Keeping this explicit helps later commits avoid mixing "discovery only"
@@ -48,9 +54,27 @@ pub enum LiveIngressPhase {
 /// commits will use to store mirrored state, update snapshots, or expose
 /// ordered output. This first increment keeps the shape intentionally small.
 #[derive(Debug)]
+pub enum LiveIngressError {
+    Mapping(anyhow::Error),
+    Adapter(anyhow::Error),
+}
+
+impl std::fmt::Display for LiveIngressError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Mapping(err) => write!(f, "failed to map live BlockMessage: {err}"),
+            Self::Adapter(err) => write!(f, "adapter rejected live block: {err}"),
+        }
+    }
+}
+
+impl std::error::Error for LiveIngressError {}
+
+#[derive(Debug)]
 pub struct LiveIngress<A> {
     phase: LiveIngressPhase,
     adapter: A,
+    mapper: GrpcBlockMapper,
 }
 
 impl<A> LiveIngress<A> {
@@ -59,6 +83,7 @@ impl<A> LiveIngress<A> {
         Self {
             phase: LiveIngressPhase::Defined,
             adapter,
+            mapper: GrpcBlockMapper::new(),
         }
     }
 
@@ -90,5 +115,31 @@ impl<A> LiveIngress<A> {
     /// Consume the wrapper and return the inner adapter/runtime component.
     pub fn into_inner(self) -> A {
         self.adapter
+    }
+}
+
+impl<A> LiveIngress<A>
+where
+    A: BlocklaceAdapter<BlockIdentity>,
+{
+    /// Accept a live protobuf block message and route it through the existing
+    /// gRPC ingestion pipeline before handing the translated block to the
+    /// adapter callback.
+    pub fn ingest_block_message(
+        &mut self,
+        block_msg: &BlockMessage,
+    ) -> Result<Block, LiveIngressError> {
+        let block = self
+            .mapper
+            .from_protobuf(block_msg)
+            .map_err(LiveIngressError::Mapping)?;
+
+        self.adapter
+            .on_block(block.clone())
+            .map_err(LiveIngressError::Adapter)?;
+
+        self.phase = LiveIngressPhase::Connected;
+
+        Ok(block)
     }
 }

--- a/crates/cordial-f1r3node-adapter/tests/test_live_ingress.rs
+++ b/crates/cordial-f1r3node-adapter/tests/test_live_ingress.rs
@@ -1,4 +1,14 @@
-use cordial_f1r3node_adapter::live_ingress::{LiveIngress, LiveIngressPhase};
+use std::collections::HashSet;
+
+use cordial_f1r3node_adapter::block_translation::{
+    BlockMessage, Body, F1r3flyState, Header, Justification,
+};
+use cordial_f1r3node_adapter::grpc_ingest::BlocklaceAdapter;
+use cordial_f1r3node_adapter::live_ingress::{LiveIngress, LiveIngressError, LiveIngressPhase};
+use cordial_miners_core::Block;
+use cordial_miners_core::crypto::{hash_content, sign};
+use cordial_miners_core::execution::{BlockState, CordialBlockPayload};
+use cordial_miners_core::types::{BlockContent, BlockIdentity, NodeId};
 
 #[test]
 fn new_live_ingress_starts_in_defined_phase() {
@@ -17,4 +27,172 @@ fn live_ingress_phase_can_progress_without_changing_adapter() {
     ingress.mark_connected();
     assert_eq!(ingress.phase(), LiveIngressPhase::Connected);
     assert_eq!(ingress.into_inner(), "adapter");
+}
+
+#[test]
+fn live_ingress_routes_valid_block_messages_through_grpc_ingest() {
+    let signing_key = test_signing_key(7);
+    let creator = test_public_key(&signing_key);
+    let block_msg = build_test_block_message(&creator, &[], &signing_key, "secp256k1");
+
+    let mut ingress = LiveIngress::new(RecordingAdapter::default());
+    let block = ingress
+        .ingest_block_message(&block_msg)
+        .expect("live ingress should accept a valid block message");
+
+    assert_eq!(ingress.phase(), LiveIngressPhase::Connected);
+    assert_eq!(
+        block.identity.content_hash,
+        <[u8; 32]>::try_from(block_msg.block_hash.as_slice()).expect("valid 32-byte block hash")
+    );
+    assert_eq!(ingress.adapter().callback_count, 1);
+    assert_eq!(ingress.adapter().received_blocks.len(), 1);
+}
+
+#[test]
+fn live_ingress_surfaces_adapter_rejections_after_mapping() {
+    let signing_key = test_signing_key(9);
+    let creator = test_public_key(&signing_key);
+    let block_msg = build_test_block_message(&creator, &[], &signing_key, "secp256k1");
+
+    let mut ingress = LiveIngress::new(RecordingAdapter::rejecting());
+    let err = ingress
+        .ingest_block_message(&block_msg)
+        .expect_err("adapter rejection should be surfaced");
+
+    match err {
+        LiveIngressError::Adapter(inner) => {
+            assert!(inner.to_string().contains("Adapter rejected block"));
+        }
+        other => panic!("expected adapter error, got {other:?}"),
+    }
+
+    assert_eq!(ingress.phase(), LiveIngressPhase::Defined);
+    assert_eq!(ingress.adapter().callback_count, 1);
+    assert!(ingress.adapter().received_blocks.is_empty());
+}
+
+#[derive(Default)]
+struct RecordingAdapter {
+    received_blocks: Vec<Block>,
+    callback_count: usize,
+    reject: bool,
+}
+
+impl RecordingAdapter {
+    fn rejecting() -> Self {
+        Self {
+            received_blocks: Vec::new(),
+            callback_count: 0,
+            reject: true,
+        }
+    }
+}
+
+impl BlocklaceAdapter<BlockIdentity> for RecordingAdapter {
+    fn on_block(&mut self, block: Block) -> anyhow::Result<()> {
+        self.callback_count += 1;
+
+        if self.reject {
+            return Err(anyhow::anyhow!("Adapter rejected block"));
+        }
+
+        self.received_blocks.push(block);
+        Ok(())
+    }
+}
+
+fn test_signing_key(seed: u8) -> Vec<u8> {
+    let mut key = vec![0u8; 32];
+    key[0] = seed;
+    for (i, item) in key.iter_mut().enumerate().skip(1) {
+        *item = ((seed as u16).wrapping_mul(i as u16 + 1)) as u8;
+    }
+    key
+}
+
+fn test_public_key(signing_key: &[u8]) -> Vec<u8> {
+    use k256::ecdsa::SigningKey as SecpSigningKey;
+
+    let sk = SecpSigningKey::from_slice(signing_key)
+        .expect("failed to create secp256k1 signing key from seed");
+    sk.verifying_key().to_encoded_point(true).as_bytes().to_vec()
+}
+
+fn build_test_block_message(
+    creator: &[u8],
+    parent_hashes: &[Vec<u8>],
+    signing_key: &[u8],
+    sig_algorithm: &str,
+) -> BlockMessage {
+    let justifications: Vec<Justification> = parent_hashes
+        .iter()
+        .enumerate()
+        .filter(|(_, h)| h.len() == 32)
+        .map(|(i, hash)| Justification {
+            validator: vec![i as u8; 33],
+            latest_block_hash: hash.clone(),
+        })
+        .collect();
+
+    let payload = CordialBlockPayload {
+        state: BlockState {
+            pre_state_hash: vec![0u8; 32],
+            post_state_hash: vec![1u8; 32],
+            bonds: vec![],
+            block_number: 0,
+        },
+        deploys: vec![],
+        rejected_deploys: vec![],
+        system_deploys: vec![],
+    };
+    let payload_bytes = payload.to_bytes();
+
+    let mut predecessors = HashSet::new();
+    for jus in &justifications {
+        let mut hash_array = [0u8; 32];
+        hash_array.copy_from_slice(&jus.latest_block_hash);
+        predecessors.insert(BlockIdentity {
+            content_hash: hash_array,
+            creator: NodeId(jus.validator.clone()),
+            signature: vec![],
+        });
+    }
+
+    let content = BlockContent {
+        payload: payload_bytes,
+        predecessors,
+    };
+
+    let content_hash = hash_content(&content);
+    let signature = sign(&content_hash, signing_key);
+
+    BlockMessage {
+        block_hash: content_hash.to_vec(),
+        header: Header {
+            parents_hash_list: parent_hashes.to_vec(),
+            timestamp: 0,
+            version: 1,
+            extra_bytes: vec![],
+        },
+        body: Body {
+            state: F1r3flyState {
+                pre_state_hash: vec![0u8; 32],
+                post_state_hash: vec![1u8; 32],
+                bonds: vec![],
+                block_number: 0,
+            },
+            deploys: vec![],
+            rejected_deploys: vec![],
+            system_deploys: vec![],
+            extra_bytes: vec![],
+        },
+        justifications,
+        sender: creator.to_vec(),
+        seq_num: 0,
+        sig: signature,
+        sig_algorithm: sig_algorithm.to_string(),
+        shard_id: "0".to_string(),
+        extra_bytes: vec![],
+    }
 }

--- a/crates/cordial-f1r3node-adapter/tests/test_live_ingress.rs
+++ b/crates/cordial-f1r3node-adapter/tests/test_live_ingress.rs
@@ -116,7 +116,10 @@ fn test_public_key(signing_key: &[u8]) -> Vec<u8> {
 
     let sk = SecpSigningKey::from_slice(signing_key)
         .expect("failed to create secp256k1 signing key from seed");
-    sk.verifying_key().to_encoded_point(true).as_bytes().to_vec()
+    sk.verifying_key()
+        .to_encoded_point(true)
+        .as_bytes()
+        .to_vec()
 }
 
 fn build_test_block_message(

--- a/docs/cordial-miners/integration/00-index.md
+++ b/docs/cordial-miners/integration/00-index.md
@@ -12,6 +12,9 @@ and easy to extend as new implementation notes are added.
 1. [01-live-ingress-scaffold.md](./01-live-ingress-scaffold.md)
    - Introduces the first adapter-side runtime scaffold for live interception
    - Establishes the `live_ingress` module as the home for future runtime wiring
+2. [02-live-blockmessage-ingestion.md](./02-live-blockmessage-ingestion.md)
+   - Connects `live_ingress` to the existing `grpc_ingest` pipeline
+   - Documents the first live `BlockMessage` adapter-side acceptance path
 
 ## Scope Of This Track
 
@@ -26,7 +29,6 @@ The integration notes in this folder focus on:
 
 Future notes in this folder are expected to cover:
 
-- live `BlockMessage` ingestion through the existing `grpc_ingest` pipeline
 - stateful blocklace mirroring from intercepted traffic
 - snapshot, finality, and tau ordering on live mirrored state
 - HTTP-based comparison harnesses

--- a/docs/cordial-miners/integration/02-live-blockmessage-ingestion.md
+++ b/docs/cordial-miners/integration/02-live-blockmessage-ingestion.md
@@ -1,0 +1,108 @@
+# 02. Live BlockMessage Ingestion
+
+## Summary
+
+This note documents the second integration increment: wiring the
+`live_ingress` module into the existing `grpc_ingest` pipeline so it can accept
+live protobuf `BlockMessage` values and route them through the already
+implemented translation and structural validation path.
+
+This step still stops short of a full live blocklace mirror. Its purpose is to
+ensure that live ingress does not introduce a parallel or ad hoc decoding path.
+
+## Why This Step Exists
+
+The adapter crate already had a reusable protobuf-first ingestion layer in
+`grpc_ingest.rs`, built around:
+
+- `GrpcBlockMapper`
+- `BlocklaceAdapter`
+
+The new `live_ingress` scaffold from the previous step established a runtime
+home for live interception work, but it did not yet accept real block-bearing
+messages.
+
+This increment closes that gap by making `live_ingress` reuse the existing
+mapping path instead of inventing a second one.
+
+## Files
+
+### Implementation
+
+- `crates/cordial-f1r3node-adapter/src/live_ingress.rs`
+
+### Tests
+
+- `crates/cordial-f1r3node-adapter/tests/test_live_ingress.rs`
+
+## What Was Added
+
+The `live_ingress` module now:
+
+- owns a `GrpcBlockMapper`
+- accepts protobuf `BlockMessage` values
+- translates them through the existing `grpc_ingest` logic
+- hands the translated block to the adapter callback
+- surfaces errors separately for:
+  - mapping/validation failures
+  - adapter-side rejection failures
+
+## Error Model
+
+This step introduces a small `LiveIngressError` boundary so the live ingress
+path can distinguish:
+
+- `Mapping`
+  - failed to translate or structurally validate the incoming `BlockMessage`
+- `Adapter`
+  - the translated block was rejected by the adapter callback
+
+This keeps future debugging cleaner once real traffic is attached.
+
+## Runtime Behavior
+
+On successful ingestion:
+
+- `live_ingress` routes the message through `GrpcBlockMapper`
+- the adapter callback receives the translated internal `Block`
+- the ingress phase advances to `Connected`
+
+On adapter rejection:
+
+- the error is returned as `LiveIngressError::Adapter`
+- the ingress phase does not advance
+
+## What This Step Does Not Do
+
+This increment does **not** yet:
+
+- attach to a real transport or gRPC server
+- buffer or reorder live messages
+- maintain a persistent blocklace mirror
+- compute snapshots or run finality
+- perform tau ordering
+
+Those remain separate follow-up increments.
+
+## Verification
+
+The dedicated live-ingress test file covers:
+
+- initial phase behavior
+- phase progression
+- successful `BlockMessage` ingestion through `grpc_ingest`
+- adapter rejection after successful mapping
+
+Verification command:
+
+- `cargo test -p cordial-f1r3node-adapter --test test_live_ingress`
+
+## Outcome
+
+This completes the second live-integration sub-issue:
+
+> wire live `BlockMessage` ingestion into the existing `grpc_ingest` pipeline
+
+The adapter now has a real ingestion boundary for block-bearing protobuf
+messages, while still keeping state mirroring and live runtime attachment as
+separate, modular steps.


### PR DESCRIPTION
Closes #101 

## Summary
This PR connects the new `live_ingress` adapter boundary to the existing `grpc_ingest` pipeline.

With this change, `live_ingress` can now accept protobuf `BlockMessage` values, translate and structurally validate them through the already-implemented `GrpcBlockMapper`, and then hand the translated block to the adapter callback.

This keeps live ingress aligned with the existing adapter architecture and avoids introducing a parallel decoding path.

## What changed
### Adapter code
- updated `crates/cordial-f1r3node-adapter/src/live_ingress.rs`
- added a `GrpcBlockMapper` to the live-ingress path
- added `ingest_block_message(...)` for protobuf `BlockMessage` ingestion
- added `LiveIngressError` to distinguish:
  - mapping / validation failures
  - adapter callback failures

### Tests
- expanded `crates/cordial-f1r3node-adapter/tests/test_live_ingress.rs`
- added coverage for:
  - valid `BlockMessage` ingestion through `grpc_ingest`
  - adapter rejection after successful mapping
  - phase behavior and progression

### Docs
- updated `docs/cordial-miners/integration/00-index.md`
- added `docs/cordial-miners/integration/02-live-blockmessage-ingestion.md`

## Why
The adapter crate already had a reusable protobuf-first ingestion layer in `grpc_ingest.rs`, but the new `live_ingress` scaffold was still only structural.

This PR closes that gap by making `live_ingress` reuse the existing ingestion pipeline instead of inventing a second message path.

That gives us a cleaner foundation for the next steps:
- stateful blocklace mirroring
- live snapshot/finality/ordering
- node comparison and verification

## Scope
This PR is intentionally limited to adapter-side ingestion.

It does **not** yet:
- attach to a real transport or running node
- maintain a persistent local blocklace mirror
- handle missing dependencies or out-of-order live traffic
- run snapshot, finality, or tau ordering
- compare against HTTP-visible node state

## Verification
Ran:

```bash
cargo test -p cordial-f1r3node-adapter --test test_live_ingress