### PR TITLE
Add a stateful live blocklace mirror to `live_ingress`

### DIFF
--- a/crates/cordial-f1r3node-adapter/src/live_ingress.rs
+++ b/crates/cordial-f1r3node-adapter/src/live_ingress.rs
@@ -27,7 +27,12 @@
 //!
 //! Those come in follow-up increments.
 
+use std::collections::HashMap;
+
 use cordial_miners_core::Block;
+use cordial_miners_core::blocklace::Blocklace;
+use cordial_miners_core::crypto::CryptoVerifier;
+use cordial_miners_core::types::{BlockContent, NodeId};
 use cordial_miners_core::types::BlockIdentity;
 
 use crate::block_translation::BlockMessage;
@@ -70,11 +75,166 @@ impl std::fmt::Display for LiveIngressError {
 
 impl std::error::Error for LiveIngressError {}
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MirrorDisposition {
+    Applied,
+    Buffered,
+    Duplicate,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MirrorUpdate {
+    pub disposition: MirrorDisposition,
+    pub released_from_buffer: usize,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct AlreadyValidatedVerifier;
+
+impl CryptoVerifier for AlreadyValidatedVerifier {
+    type Error = &'static str;
+
+    fn verify_block(
+        &self,
+        _content: &BlockContent,
+        _signature: &[u8],
+        _creator: &NodeId,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+pub struct LiveBlocklaceMirror<V = AlreadyValidatedVerifier> {
+    blocklace: Blocklace,
+    pending: HashMap<BlockIdentity, Block>,
+    verifier: V,
+}
+
+impl<V> LiveBlocklaceMirror<V>
+where
+    V: CryptoVerifier,
+{
+    pub fn new(verifier: V) -> Self {
+        Self {
+            blocklace: Blocklace::new(),
+            pending: HashMap::new(),
+            verifier,
+        }
+    }
+
+    pub fn blocklace(&self) -> &Blocklace {
+        &self.blocklace
+    }
+
+    pub fn pending(&self) -> &HashMap<BlockIdentity, Block> {
+        &self.pending
+    }
+
+    pub fn ingest(&mut self, block: Block) -> Result<MirrorUpdate, String> {
+        let block = self.canonicalize_block(block);
+
+        if self.blocklace.get(&block.identity).is_some() {
+            return Ok(MirrorUpdate {
+                disposition: MirrorDisposition::Duplicate,
+                released_from_buffer: 0,
+            });
+        }
+
+        if self.pending.contains_key(&block.identity) {
+            return Ok(MirrorUpdate {
+                disposition: MirrorDisposition::Duplicate,
+                released_from_buffer: 0,
+            });
+        }
+
+        if !self.predecessors_available(&block) {
+            self.pending.insert(block.identity.clone(), block);
+            return Ok(MirrorUpdate {
+                disposition: MirrorDisposition::Buffered,
+                released_from_buffer: 0,
+            });
+        }
+
+        self.blocklace.insert(block, &self.verifier)?;
+        let released_from_buffer = self.release_pending()?;
+
+        Ok(MirrorUpdate {
+            disposition: MirrorDisposition::Applied,
+            released_from_buffer,
+        })
+    }
+
+    fn predecessors_available(&self, block: &Block) -> bool {
+        block.content
+            .predecessors
+            .iter()
+            .all(|pred_id| self.resolve_known_identity(pred_id).is_some())
+    }
+
+    fn release_pending(&mut self) -> Result<usize, String> {
+        let mut released = 0usize;
+
+        loop {
+            let ready_ids: Vec<BlockIdentity> = self
+                .pending
+                .iter()
+                .filter(|(_, block)| self.predecessors_available(block))
+                .map(|(id, _)| id.clone())
+                .collect();
+
+            if ready_ids.is_empty() {
+                break;
+            }
+
+            for id in ready_ids {
+                let block = self
+                    .pending
+                    .remove(&id)
+                    .expect("ready pending block should still exist");
+                let block = self.canonicalize_block(block);
+                self.blocklace.insert(block, &self.verifier)?;
+                released += 1;
+            }
+        }
+
+        Ok(released)
+    }
+
+    fn canonicalize_block(&self, mut block: Block) -> Block {
+        block.content.predecessors = block
+            .content
+            .predecessors
+            .iter()
+            .map(|pred_id| {
+                self.resolve_known_identity(pred_id)
+                    .unwrap_or_else(|| pred_id.clone())
+            })
+            .collect();
+        block
+    }
+
+    fn resolve_known_identity(&self, pred_id: &BlockIdentity) -> Option<BlockIdentity> {
+        self.blocklace
+            .dom()
+            .into_iter()
+            .find(|known| {
+                known.content_hash == pred_id.content_hash && known.creator == pred_id.creator
+            })
+            .cloned()
+    }
+}
+
+impl Default for LiveBlocklaceMirror<AlreadyValidatedVerifier> {
+    fn default() -> Self {
+        Self::new(AlreadyValidatedVerifier)
+    }
+}
+
 pub struct LiveIngress<A> {
     phase: LiveIngressPhase,
     adapter: A,
     mapper: GrpcBlockMapper,
+    mirror: LiveBlocklaceMirror,
 }
 
 impl<A> LiveIngress<A> {
@@ -84,6 +244,7 @@ impl<A> LiveIngress<A> {
             phase: LiveIngressPhase::Defined,
             adapter,
             mapper: GrpcBlockMapper::new(),
+            mirror: LiveBlocklaceMirror::default(),
         }
     }
 
@@ -116,6 +277,16 @@ impl<A> LiveIngress<A> {
     pub fn into_inner(self) -> A {
         self.adapter
     }
+
+    /// Return the current local blocklace mirror.
+    pub fn blocklace(&self) -> &Blocklace {
+        self.mirror.blocklace()
+    }
+
+    /// Return blocks that are waiting on missing predecessors.
+    pub fn pending_blocks(&self) -> &HashMap<BlockIdentity, Block> {
+        self.mirror.pending()
+    }
 }
 
 impl<A> LiveIngress<A>
@@ -137,6 +308,10 @@ where
         self.adapter
             .on_block(block.clone())
             .map_err(LiveIngressError::Adapter)?;
+
+        self.mirror
+            .ingest(block.clone())
+            .map_err(|err| LiveIngressError::Adapter(anyhow::anyhow!(err)))?;
 
         self.phase = LiveIngressPhase::Connected;
 

--- a/crates/cordial-f1r3node-adapter/src/live_ingress.rs
+++ b/crates/cordial-f1r3node-adapter/src/live_ingress.rs
@@ -32,8 +32,8 @@ use std::collections::HashMap;
 use cordial_miners_core::Block;
 use cordial_miners_core::blocklace::Blocklace;
 use cordial_miners_core::crypto::CryptoVerifier;
-use cordial_miners_core::types::{BlockContent, NodeId};
 use cordial_miners_core::types::BlockIdentity;
+use cordial_miners_core::types::{BlockContent, NodeId};
 
 use crate::block_translation::BlockMessage;
 use crate::grpc_ingest::{BlocklaceAdapter, GrpcBlockMapper};
@@ -165,7 +165,8 @@ where
     }
 
     fn predecessors_available(&self, block: &Block) -> bool {
-        block.content
+        block
+            .content
             .predecessors
             .iter()
             .all(|pred_id| self.resolve_known_identity(pred_id).is_some())

--- a/crates/cordial-f1r3node-adapter/tests/test_live_ingress.rs
+++ b/crates/cordial-f1r3node-adapter/tests/test_live_ingress.rs
@@ -47,6 +47,8 @@ fn live_ingress_routes_valid_block_messages_through_grpc_ingest() {
     );
     assert_eq!(ingress.adapter().callback_count, 1);
     assert_eq!(ingress.adapter().received_blocks.len(), 1);
+    assert_eq!(ingress.blocklace().dom().len(), 1);
+    assert!(ingress.pending_blocks().is_empty());
 }
 
 #[test]
@@ -70,6 +72,57 @@ fn live_ingress_surfaces_adapter_rejections_after_mapping() {
     assert_eq!(ingress.phase(), LiveIngressPhase::Defined);
     assert_eq!(ingress.adapter().callback_count, 1);
     assert!(ingress.adapter().received_blocks.is_empty());
+    assert_eq!(ingress.blocklace().dom().len(), 0);
+    assert!(ingress.pending_blocks().is_empty());
+}
+
+#[test]
+fn live_ingress_buffers_out_of_order_blocks_until_predecessors_arrive() {
+    let parent_signing_key = test_signing_key(11);
+    let parent_creator = test_public_key(&parent_signing_key);
+    let parent = build_test_block_message(&parent_creator, &[], &parent_signing_key, "secp256k1");
+
+    let child_signing_key = test_signing_key(12);
+    let child_creator = test_public_key(&child_signing_key);
+    let child = build_test_block_message(
+        &child_creator,
+        &[(parent.block_hash.clone(), parent.sender.clone())],
+        &child_signing_key,
+        "secp256k1",
+    );
+
+    let mut ingress = LiveIngress::new(RecordingAdapter::default());
+
+    ingress
+        .ingest_block_message(&child)
+        .expect("child block should be accepted into pending state");
+    assert_eq!(ingress.blocklace().dom().len(), 0);
+    assert_eq!(ingress.pending_blocks().len(), 1);
+
+    ingress
+        .ingest_block_message(&parent)
+        .expect("parent block should release buffered child");
+    assert_eq!(ingress.blocklace().dom().len(), 2);
+    assert!(ingress.pending_blocks().is_empty());
+}
+
+#[test]
+fn live_ingress_ignores_duplicate_blocks_in_mirror_state() {
+    let signing_key = test_signing_key(13);
+    let creator = test_public_key(&signing_key);
+    let block_msg = build_test_block_message(&creator, &[], &signing_key, "secp256k1");
+
+    let mut ingress = LiveIngress::new(RecordingAdapter::default());
+
+    ingress
+        .ingest_block_message(&block_msg)
+        .expect("first block ingestion should succeed");
+    ingress
+        .ingest_block_message(&block_msg)
+        .expect("duplicate block ingestion should not error");
+
+    assert_eq!(ingress.blocklace().dom().len(), 1);
+    assert!(ingress.pending_blocks().is_empty());
 }
 
 #[derive(Default)]
@@ -124,16 +177,15 @@ fn test_public_key(signing_key: &[u8]) -> Vec<u8> {
 
 fn build_test_block_message(
     creator: &[u8],
-    parent_hashes: &[Vec<u8>],
+    parents: &[(Vec<u8>, Vec<u8>)],
     signing_key: &[u8],
     sig_algorithm: &str,
 ) -> BlockMessage {
-    let justifications: Vec<Justification> = parent_hashes
+    let justifications: Vec<Justification> = parents
         .iter()
-        .enumerate()
-        .filter(|(_, h)| h.len() == 32)
-        .map(|(i, hash)| Justification {
-            validator: vec![i as u8; 33],
+        .filter(|(hash, _)| hash.len() == 32)
+        .map(|(hash, validator)| Justification {
+            validator: validator.clone(),
             latest_block_hash: hash.clone(),
         })
         .collect();
@@ -173,7 +225,7 @@ fn build_test_block_message(
     BlockMessage {
         block_hash: content_hash.to_vec(),
         header: Header {
-            parents_hash_list: parent_hashes.to_vec(),
+            parents_hash_list: parents.iter().map(|(hash, _)| hash.clone()).collect(),
             timestamp: 0,
             version: 1,
             extra_bytes: vec![],

--- a/docs/cordial-miners/integration/00-index.md
+++ b/docs/cordial-miners/integration/00-index.md
@@ -15,6 +15,9 @@ and easy to extend as new implementation notes are added.
 2. [02-live-blockmessage-ingestion.md](./02-live-blockmessage-ingestion.md)
    - Connects `live_ingress` to the existing `grpc_ingest` pipeline
    - Documents the first live `BlockMessage` adapter-side acceptance path
+3. [03-live-blocklace-mirror.md](./03-live-blocklace-mirror.md)
+   - Adds a stateful local blocklace mirror behind `live_ingress`
+   - Documents buffering and release of out-of-order block traffic
 
 ## Scope Of This Track
 
@@ -29,7 +32,6 @@ The integration notes in this folder focus on:
 
 Future notes in this folder are expected to cover:
 
-- stateful blocklace mirroring from intercepted traffic
 - snapshot, finality, and tau ordering on live mirrored state
 - HTTP-based comparison harnesses
 - deploy ingress tracing and later interception candidates

--- a/docs/cordial-miners/integration/03-live-blocklace-mirror.md
+++ b/docs/cordial-miners/integration/03-live-blocklace-mirror.md
@@ -1,0 +1,117 @@
+# 03. Live Blocklace Mirror
+
+## Summary
+
+This note documents the third live integration increment: adding a stateful
+local blocklace mirror behind `live_ingress`.
+
+With this step, live-ingested blocks are no longer only translated and passed
+through an adapter callback. They are also accumulated into a long-lived local
+`Blocklace` view inside the adapter crate.
+
+## Why This Step Exists
+
+The previous increment established a live protobuf ingestion boundary using the
+existing `grpc_ingest` pipeline. That was enough to accept and validate
+`BlockMessage` values, but it still left the adapter without persistent
+consensus-facing runtime state.
+
+This increment addresses that by introducing a local mirror that can:
+
+- store accepted blocks
+- buffer out-of-order arrivals whose predecessors are not yet available
+- release buffered blocks once their dependencies are satisfied
+
+This is the first step where live ingress begins to look like a real mirrored
+consensus view rather than a stateless translation edge.
+
+## Files
+
+### Implementation
+
+- `crates/cordial-f1r3node-adapter/src/live_ingress.rs`
+
+### Tests
+
+- `crates/cordial-f1r3node-adapter/tests/test_live_ingress.rs`
+
+## What Was Added
+
+The live-ingress path now owns a `LiveBlocklaceMirror`, which contains:
+
+- a local `Blocklace`
+- a pending buffer for blocks with missing predecessors
+- a verifier used for final blocklace insertion
+
+The mirror supports three outcomes for incoming blocks:
+
+- `Applied`
+  - block inserted immediately into the local blocklace
+- `Buffered`
+  - block held until required predecessors arrive
+- `Duplicate`
+  - block already known in blocklace or pending state
+
+## Runtime Behavior
+
+The mirror currently follows this flow:
+
+1. `live_ingress` maps and structurally validates a protobuf `BlockMessage`
+2. the adapter callback accepts the translated internal block
+3. the mirror checks whether all predecessors are already present
+4. if yes:
+   - the block is inserted into the local blocklace
+   - pending blocks are scanned and dependency-free blocks are released
+5. if no:
+   - the block is kept in a pending buffer until predecessors arrive
+
+## Why This Design Is Useful
+
+This keeps the live interception path modular:
+
+- structural translation remains in `grpc_ingest`
+- runtime accumulation now lives in `live_ingress`
+- finality and ordering remain deferred
+
+It also matches the reality of live traffic: block-bearing messages may arrive
+out of order, so the mirror needs buffering before higher-level consensus logic
+can safely run.
+
+## What This Step Does Not Do
+
+This increment still does **not** yet:
+
+- attach to a real running transport server
+- run snapshot construction automatically
+- execute finality checks
+- execute tau ordering
+- compare the local mirror with HTTP-visible node state
+
+Those remain separate follow-up increments.
+
+## Verification
+
+The dedicated live-ingress test file now covers:
+
+- successful ingestion into the local blocklace
+- adapter rejection without mirror mutation
+- buffering of out-of-order blocks
+- release of buffered blocks after predecessor arrival
+- duplicate handling inside the mirror
+
+Verification command:
+
+- `cargo test -p cordial-f1r3node-adapter --test test_live_ingress`
+
+## Outcome
+
+This completes the third live-integration sub-issue:
+
+> add a stateful live blocklace mirror for intercepted block traffic
+
+The adapter now has long-lived local state and basic dependency buffering,
+which makes the next steps possible:
+
+- snapshot reconstruction from live state
+- finality and tau execution on the mirror
+- comparison against node-visible state


### PR DESCRIPTION
Closes #102 

## Summary
This PR extends the live integration path by adding a stateful local blocklace mirror behind `live_ingress`.

Previously, `live_ingress` could accept protobuf `BlockMessage` values and route them through the existing `grpc_ingest` mapping path, but it did not retain any long-lived consensus-facing state.

With this change, accepted blocks are now accumulated into a local `Blocklace` view, and out-of-order blocks can be buffered until their predecessors arrive.

## What changed
### Adapter code
- updated `crates/cordial-f1r3node-adapter/src/live_ingress.rs`
- added `LiveBlocklaceMirror`
- added local mirror state:
  - `Blocklace`
  - pending block buffer
- added mirror outcomes for:
  - applied blocks
  - buffered blocks
  - duplicate blocks
- added release logic for dependency-free pending blocks

### Trust boundary clarification
- `grpc_ingest` remains the structural/signature validation boundary
- the local mirror may canonicalize predecessor identities for closure bookkeeping
- canonicalized in-memory blocks are not re-verified as if they were unchanged wire-format payloads

### Tests
- expanded `crates/cordial-f1r3node-adapter/tests/test_live_ingress.rs`
- added coverage for:
  - successful insertion into the local blocklace
  - buffering of out-of-order blocks
  - release of buffered blocks after predecessor arrival
  - duplicate handling
  - adapter rejection without mirror mutation

### Docs
- updated `docs/cordial-miners/integration/00-index.md`
- added `docs/cordial-miners/integration/03-live-blocklace-mirror.md`

## Why
This is the first step where the live integration path becomes stateful.

The previous increment gave us a live protobuf ingestion boundary. This increment gives us a persistent local consensus-facing view that can later support:

- snapshot reconstruction
- finality checks
- tau ordering
- comparison against node-visible state

Without this mirror, `live_ingress` would remain a translation edge rather than a real runtime component.

## Scope
This PR is intentionally limited to block accumulation and dependency buffering.

It does **not** yet:
- attach to a real running transport server
- build snapshots automatically
- run finality
- run tau ordering
- compare against HTTP-visible node state
- intercept deploy flow

## Verification
Ran:

```bash
cargo test -p cordial-f1r3node-adapter --test test_live_ingress