### PR TITLE
Add live mirror verification harness for running f1r3node

### DIFF
--- a/crates/cordial-f1r3node-adapter/src/bin/live_mirror_check.rs
+++ b/crates/cordial-f1r3node-adapter/src/bin/live_mirror_check.rs
@@ -1,0 +1,666 @@
+use std::collections::{BTreeSet, HashMap, HashSet};
+
+use anyhow::{Context, Result, bail};
+use clap::Parser;
+use cordial_f1r3node_adapter::grpc_ingest::BlocklaceAdapter;
+use cordial_f1r3node_adapter::http_observer::HttpObserver;
+use cordial_f1r3node_adapter::live_grpc::{
+    LiveGrpcBlockClient, light_block_info_to_block_message,
+    trusted_block_from_light_block_info_with_options,
+};
+use cordial_f1r3node_adapter::live_ingress::LiveIngress;
+use cordial_f1r3node_adapter::shard_conf::CasperShardConf;
+use cordial_miners_core::Block;
+use cordial_miners_core::consensus::{
+    depth, is_weighted_final_leader, leader_block_for_wave, wave_of_round,
+    weighted_final_leader_for_wave,
+};
+use cordial_miners_core::execution::CordialBlockPayload;
+use cordial_miners_core::types::{BlockIdentity, NodeId};
+use models::rust::casper::pretty_printer::PrettyPrinter;
+use models::rust::string_ops::StringOps;
+
+#[derive(Parser, Debug)]
+#[command(name = "live-mirror-check")]
+#[command(about = "Mirror live f1r3node blocks into Cordial state and compare against HTTP-visible node state")]
+struct Args {
+    #[arg(long, default_value = "http://127.0.0.1:40401")]
+    grpc_url: String,
+
+    #[arg(long, default_value = "http://127.0.0.1:40403")]
+    http_url: String,
+
+    #[arg(long, default_value_t = 128)]
+    depth: i32,
+
+    #[arg(long, default_value = "root")]
+    shard_id: String,
+
+    #[arg(long, default_value_t = 8)]
+    max_backfill_rounds: usize,
+
+    #[arg(long, default_value_t = 256)]
+    max_backfill_blocks: usize,
+
+    #[arg(long, default_value_t = false)]
+    parents_only_bootstrap: bool,
+
+    #[arg(long, default_value_t = true)]
+    height_bootstrap: bool,
+
+    #[arg(long, default_value_t = 64)]
+    height_batch_size: i64,
+
+    #[arg(long, default_value_t = false)]
+    skip_ordering: bool,
+
+    #[arg(long, default_value_t = false)]
+    skip_http_compare: bool,
+}
+
+struct PassthroughAdapter;
+
+impl BlocklaceAdapter<BlockIdentity> for PassthroughAdapter {
+    fn on_block(&mut self, _block: Block) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+
+    let mut grpc = LiveGrpcBlockClient::connect(args.grpc_url.clone())
+        .await
+        .with_context(|| format!("failed to connect to gRPC endpoint {}", args.grpc_url))?;
+
+    println!("[phase] querying initial gRPC last finalized block");
+    let initial_grpc_last_finalized = grpc
+        .last_finalized_block_hash()
+        .await
+        .context("failed to query initial gRPC last finalized block")?
+        .map(hex_string);
+
+    let recent_blocks = grpc
+        .recent_light_blocks(args.depth)
+        .await
+        .with_context(|| format!("failed to fetch recent blocks at depth {}", args.depth))?;
+
+    if recent_blocks.is_empty() {
+        bail!("no blocks were returned from the live node");
+    }
+
+    let bonds = derive_uniform_bonds(&recent_blocks);
+    let shard_conf = CasperShardConf {
+        shard_name: args.shard_id.clone(),
+        max_number_of_parents: 16,
+        fault_tolerance_threshold: 0.333,
+        deploy_lifespan: 50,
+        min_phlo_price: 1,
+        ..CasperShardConf::default()
+    };
+
+    let mut ingress =
+        LiveIngress::with_consensus_view(PassthroughAdapter, bonds, shard_conf, &args.shard_id);
+
+    let mut decoded_messages = 0usize;
+    let mut height_bootstrapped = 0usize;
+    let target_max_height = recent_blocks
+        .iter()
+        .map(|block| block.block_number)
+        .max()
+        .unwrap_or(0);
+
+    if args.height_bootstrap {
+        height_bootstrapped = bootstrap_by_heights(
+            &mut grpc,
+            &mut ingress,
+            target_max_height,
+            args.height_batch_size.max(1),
+            args.parents_only_bootstrap,
+            &mut decoded_messages,
+        )
+        .await?;
+    } else {
+        for info in &recent_blocks {
+            let _ = light_block_info_to_block_message(info)
+                .with_context(|| format!("failed to decode live block {}", info.block_hash))?;
+            decoded_messages += 1;
+
+            let block = trusted_block_from_light_block_info_with_options(
+                info,
+                !args.parents_only_bootstrap,
+            )
+            .with_context(|| format!("failed to reconstruct trusted block {}", info.block_hash))?;
+            ingress
+                .ingest_trusted_block(block)
+                .with_context(|| format!("failed to mirror live block {}", info.block_hash))?;
+        }
+    }
+
+    let backfilled = if ingress.blocklace().dom().is_empty() {
+        backfill_missing_predecessors(
+            &mut grpc,
+            &mut ingress,
+            args.max_backfill_rounds,
+            args.max_backfill_blocks,
+            args.parents_only_bootstrap,
+        )
+        .await?
+    } else {
+        0
+    };
+
+    println!("[phase] bootstrap complete");
+
+    println!("[phase] computing mirror last finalized block");
+    let mirror_last_finalized = ingress
+        .last_finalized_block_hash()
+        .map_err(|err| anyhow::anyhow!("failed to compute mirror last finalized block: {err:?}"))?
+        .map(hex_string);
+
+    println!("[phase] querying gRPC last finalized block");
+    let grpc_last_finalized = grpc
+        .last_finalized_block_hash()
+        .await
+        .context("failed to query gRPC last finalized block")?
+        .map(hex_string);
+
+    let mirror_lfb_meta = mirror_last_finalized
+        .as_ref()
+        .and_then(|hash| describe_mirror_block(&ingress, hash));
+
+    let grpc_lfb_meta = match grpc_last_finalized.as_ref() {
+        Some(hash) => Some(
+            grpc.light_block_by_hash(hash.clone())
+                .await
+                .with_context(|| format!("failed to fetch gRPC LFB metadata for {hash}"))?,
+        ),
+        None => None,
+    };
+
+    let initial_grpc_lfb_meta = match initial_grpc_last_finalized.as_ref() {
+        Some(hash) => Some(
+            grpc.light_block_by_hash(hash.clone())
+                .await
+                .with_context(|| format!("failed to fetch initial gRPC LFB metadata for {hash}"))?,
+        ),
+        None => None,
+    };
+
+    let ordered_count = if args.skip_ordering {
+        println!("[phase] skipping ordered finalized blocks");
+        0
+    } else {
+        println!("[phase] computing ordered finalized blocks");
+        ingress
+            .ordered_finalized_blocks()
+            .map_err(|err| anyhow::anyhow!("failed to compute ordered finalized blocks: {err:?}"))?
+            .len()
+    };
+
+    let comparison = if args.skip_http_compare {
+        println!("[phase] skipping HTTP comparison");
+        None
+    } else {
+        println!("[phase] querying HTTP observer and comparing mirror");
+        let observer = HttpObserver::new(args.http_url.clone());
+        Some(
+            observer
+                .compare_live_ingress(&ingress)
+                .await
+                .with_context(|| {
+                    format!("failed to compare mirror against HTTP endpoint {}", args.http_url)
+                })?,
+        )
+    };
+
+    println!("Cordial live mirror check");
+    println!("=========================");
+    println!("gRPC URL:          {}", args.grpc_url);
+    println!("HTTP URL:          {}", args.http_url);
+    println!("Depth:             {}", args.depth);
+    println!("Max rounds:        {}", args.max_backfill_rounds);
+    println!("Max backfill:      {}", args.max_backfill_blocks);
+    println!("Parents-only:      {}", args.parents_only_bootstrap);
+    println!("Height bootstrap:  {}", args.height_bootstrap);
+    println!("Height batch:      {}", args.height_batch_size);
+    println!("Skip ordering:     {}", args.skip_ordering);
+    println!("Skip HTTP compare: {}", args.skip_http_compare);
+    println!("Mirrored blocks:   {}", ingress.blocklace().dom().len());
+    println!("Pending blocks:    {}", ingress.pending_blocks().len());
+    println!("Decoded messages:  {}", decoded_messages);
+    println!("Height bootstrapped: {}", height_bootstrapped);
+    println!("Backfilled blocks: {}", backfilled);
+    println!(
+        "Unresolved preds:  {}",
+        unresolved_predecessor_hashes(&ingress).len()
+    );
+    println!("Ordered blocks:    {}", ordered_count);
+    println!(
+        "Initial gRPC LFB:  {}",
+        initial_grpc_last_finalized.as_deref().unwrap_or("<none>")
+    );
+    if let Some(meta) = initial_grpc_lfb_meta.as_ref() {
+        println!(
+            "Initial gRPC Meta: creator={} block_number={}",
+            meta.sender, meta.block_number
+        );
+    }
+    println!(
+        "Mirror LFB:        {}",
+        mirror_last_finalized.as_deref().unwrap_or("<none>")
+    );
+    if let Some(meta) = mirror_lfb_meta.as_ref() {
+        println!(
+            "Mirror LFB Meta:   creator={} block_number={} round={} wave={}",
+            meta.creator, meta.block_number, meta.round, meta.wave
+        );
+    }
+    println!(
+        "HTTP LFB:          {}",
+        comparison
+            .as_ref()
+            .and_then(|c| c.http_last_finalized.as_deref())
+            .unwrap_or("<none>")
+    );
+    println!(
+        "gRPC LFB:          {}",
+        grpc_last_finalized.as_deref().unwrap_or("<none>")
+    );
+    if let Some(meta) = grpc_lfb_meta.as_ref() {
+        println!(
+            "gRPC LFB Meta:     creator={} block_number={}",
+            meta.sender, meta.block_number
+        );
+    }
+
+    print_finality_neighborhood(&ingress, mirror_lfb_meta.as_ref(), grpc_lfb_meta.as_ref());
+    println!(
+        "Comparison:        {}",
+        match comparison.as_ref() {
+            Some(report) if report.is_match() => "MATCH",
+            Some(_) => "MISMATCH",
+            None => "SKIPPED",
+        }
+    );
+
+    if let Some(comparison) = comparison.as_ref().filter(|c| !c.missing_from_mirror.is_empty()) {
+        println!("Missing from mirror:");
+        for hash in &comparison.missing_from_mirror {
+            println!("  - {}", hash);
+        }
+    }
+
+    if let Some(comparison) = comparison.as_ref().filter(|c| !c.missing_from_http.is_empty()) {
+        println!("Missing from HTTP:");
+        for hash in &comparison.missing_from_http {
+            println!("  - {}", hash);
+        }
+    }
+
+    if comparison
+        .as_ref()
+        .is_some_and(|comparison| !comparison.last_finalized_matches)
+    {
+        println!("Last finalized block mismatch detected.");
+    }
+
+    Ok(())
+}
+
+fn derive_uniform_bonds(blocks: &[models::casper::LightBlockInfo]) -> HashMap<NodeId, u64> {
+    let mut bonds = HashMap::new();
+    for block in blocks {
+        if let Some(sender) = StringOps::decode_hex(block.sender.clone()) {
+            bonds.entry(NodeId(sender)).or_insert(100);
+        }
+    }
+    bonds
+}
+
+fn hex_string(bytes: Vec<u8>) -> String {
+    PrettyPrinter::build_string_no_limit(&bytes)
+}
+
+#[derive(Debug, Clone)]
+struct MirrorBlockMeta {
+    creator: String,
+    block_number: u64,
+    round: u64,
+    wave: u64,
+}
+
+fn describe_mirror_block(
+    ingress: &LiveIngress<PassthroughAdapter>,
+    hash_hex: &str,
+) -> Option<MirrorBlockMeta> {
+    let hash = StringOps::decode_hex(hash_hex.to_string())?;
+    let id = ingress
+        .blocklace()
+        .dom()
+        .iter()
+        .find(|id| id.content_hash.as_slice() == hash.as_slice())?
+        .to_owned();
+    let round = depth(ingress.blocklace(), &id)?;
+    let wave = wave_of_round(round, 3)?;
+    let content = ingress.blocklace().content(&id)?;
+    let payload = CordialBlockPayload::from_bytes(&content.payload).ok()?;
+
+    Some(MirrorBlockMeta {
+        creator: hex_string(id.creator.0.clone()),
+        block_number: payload.state.block_number,
+        round,
+        wave,
+    })
+}
+
+fn ordered_validators_for_debug(ingress: &LiveIngress<PassthroughAdapter>) -> Vec<NodeId> {
+    let mut validators: Vec<NodeId> = ingress.bonds().keys().cloned().collect();
+    validators.sort();
+    validators
+}
+
+fn print_finality_neighborhood(
+    ingress: &LiveIngress<PassthroughAdapter>,
+    mirror_lfb_meta: Option<&MirrorBlockMeta>,
+    grpc_lfb_meta: Option<&models::casper::LightBlockInfo>,
+) {
+    let validators = ordered_validators_for_debug(ingress);
+    if validators.is_empty() {
+        println!("Validator order:   <none>");
+        return;
+    }
+
+    println!("Validator order:");
+    for (idx, validator) in validators.iter().enumerate() {
+        println!("  [{}] {}", idx, hex_string(validator.0.clone()));
+    }
+
+    let focus_wave = mirror_lfb_meta.map(|m| m.wave).unwrap_or(0);
+    println!("Wave neighborhood:");
+    for wave in focus_wave.saturating_sub(1)..=focus_wave + 1 {
+        let selected = validators
+            .get((wave as usize) % validators.len())
+            .map(|id| hex_string(id.0.clone()))
+            .unwrap_or_else(|| "<none>".to_string());
+        let leader_block = leader_block_for_wave(ingress.blocklace(), wave, 3, |w| {
+            validators.get((w as usize) % validators.len()).cloned()
+        })
+        .map(|id| hex_string(id.content_hash.to_vec()))
+        .unwrap_or_else(|| "<none>".to_string());
+        let final_block = weighted_final_leader_for_wave(ingress.blocklace(), wave, 3, ingress.bonds(), |w| {
+            validators.get((w as usize) % validators.len()).cloned()
+        })
+        .map(|id| hex_string(id.content_hash.to_vec()))
+        .unwrap_or_else(|| "<none>".to_string());
+
+        println!(
+            "  wave {}: selected_leader={} leader_block={} weighted_final={}",
+            wave, selected, leader_block, final_block
+        );
+    }
+
+    let mut interesting_heights = Vec::new();
+    if let Some(meta) = mirror_lfb_meta {
+        interesting_heights.push(meta.block_number);
+    }
+    if let Some(info) = grpc_lfb_meta {
+        interesting_heights.push(info.block_number as u64);
+    }
+    interesting_heights.sort_unstable();
+    interesting_heights.dedup();
+
+    if let (Some(min), Some(max)) = (
+        interesting_heights.first().copied(),
+        interesting_heights.last().copied(),
+    ) {
+        println!("Block neighborhood:");
+        for block in mirrored_blocks_in_height_range(ingress, min.saturating_sub(1), max + 1) {
+            let hash = hex_string(block.identity.content_hash.to_vec());
+            let creator = hex_string(block.identity.creator.0.clone());
+            let payload = match ingress
+                .blocklace()
+                .content(&block.identity)
+                .and_then(|content| CordialBlockPayload::from_bytes(&content.payload).ok())
+            {
+                Some(payload) => payload,
+                None => continue,
+            };
+            let round = match depth(ingress.blocklace(), &block.identity) {
+                Some(round) => round,
+                None => continue,
+            };
+            let wave = match wave_of_round(round, 3) {
+                Some(wave) => wave,
+                None => continue,
+            };
+            let is_final = is_weighted_final_leader(
+                ingress.blocklace(),
+                &block.identity,
+                3,
+                ingress.bonds(),
+                |w| validators.get((w as usize) % validators.len()).cloned(),
+            );
+
+            println!(
+                "  block_number={} hash={} creator={} round={} wave={} weighted_final={}",
+                payload.state.block_number, hash, creator, round, wave, is_final
+            );
+        }
+    }
+}
+
+fn mirrored_blocks_in_height_range(
+    ingress: &LiveIngress<PassthroughAdapter>,
+    min_height: u64,
+    max_height: u64,
+) -> Vec<Block> {
+    let mut blocks = Vec::new();
+    for id in ingress.blocklace().dom() {
+        let Some(content) = ingress.blocklace().content(id) else {
+            continue;
+        };
+        let Ok(payload) = CordialBlockPayload::from_bytes(&content.payload) else {
+            continue;
+        };
+        if (min_height..=max_height).contains(&payload.state.block_number) {
+            if let Some(block) = ingress.blocklace().get(id) {
+                blocks.push(block);
+            }
+        }
+    }
+    blocks.sort_by_key(|block| {
+        ingress
+            .blocklace()
+            .content(&block.identity)
+            .and_then(|content| CordialBlockPayload::from_bytes(&content.payload).ok())
+            .map(|payload| payload.state.block_number)
+            .unwrap_or(u64::MAX)
+    });
+    blocks
+}
+
+async fn bootstrap_by_heights(
+    grpc: &mut LiveGrpcBlockClient,
+    ingress: &mut LiveIngress<PassthroughAdapter>,
+    target_max_height: i64,
+    batch_size: i64,
+    parents_only_bootstrap: bool,
+    decoded_messages: &mut usize,
+) -> Result<usize> {
+    let mut start = 0i64;
+    let mut bootstrapped = 0usize;
+
+    println!(
+        "[height-bootstrap] target_max_height={}, batch_size={}",
+        target_max_height, batch_size
+    );
+
+    while start <= target_max_height {
+        let end = (start + batch_size - 1).min(target_max_height);
+        let blocks = grpc
+            .light_blocks_by_heights(start, end)
+            .await
+            .with_context(|| format!("failed to fetch blocks in height range {}..={}", start, end))?;
+
+        println!(
+            "[height-bootstrap] range {}..={} returned {} blocks",
+            start,
+            end,
+            blocks.len()
+        );
+
+        for info in &blocks {
+            let _ = light_block_info_to_block_message(info)
+                .with_context(|| format!("failed to decode live block {}", info.block_hash))?;
+            *decoded_messages += 1;
+
+            let block = trusted_block_from_light_block_info_with_options(
+                info,
+                !parents_only_bootstrap,
+            )
+            .with_context(|| format!("failed to reconstruct trusted block {}", info.block_hash))?;
+            ingress
+                .ingest_trusted_block(block)
+                .with_context(|| format!("failed to mirror live block {}", info.block_hash))?;
+            bootstrapped += 1;
+        }
+
+        println!(
+            "[height-bootstrap] after range {}..={}: mirrored={}, pending={}",
+            start,
+            end,
+            ingress.blocklace().dom().len(),
+            ingress.pending_blocks().len()
+        );
+
+        start = end + 1;
+    }
+
+    Ok(bootstrapped)
+}
+
+async fn backfill_missing_predecessors(
+    grpc: &mut LiveGrpcBlockClient,
+    ingress: &mut LiveIngress<PassthroughAdapter>,
+    max_rounds: usize,
+    max_blocks: usize,
+    parents_only_bootstrap: bool,
+) -> Result<usize> {
+    let mut attempted = HashSet::new();
+    let mut backfilled = 0usize;
+    let mut round = 0usize;
+
+    loop {
+        if round >= max_rounds {
+            println!(
+                "[backfill] stopping after {} rounds with {} blocks fetched",
+                round, backfilled
+            );
+            break;
+        }
+
+        let missing = unresolved_predecessor_hashes(ingress);
+        let frontier: Vec<String> = missing
+            .into_iter()
+            .filter(|hash| attempted.insert(hash.clone()))
+            .collect();
+
+        round += 1;
+        println!(
+            "[backfill] round {}: mirrored={}, pending={}, unresolved={}",
+            round,
+            ingress.blocklace().dom().len(),
+            ingress.pending_blocks().len(),
+            frontier.len()
+        );
+        if let Some(first) = frontier.first() {
+            println!("[backfill] current unresolved head={}", first);
+        }
+
+        if frontier.is_empty() {
+            println!("[backfill] no unresolved predecessor hashes remain");
+            break;
+        }
+
+        let mut fetched_this_round = 0usize;
+        for hash in frontier {
+            if backfilled >= max_blocks {
+                println!(
+                    "[backfill] stopping after reaching max_backfill_blocks={}",
+                    max_blocks
+                );
+                return Ok(backfilled);
+            }
+
+            let info = grpc
+                .light_block_by_hash(hash.clone())
+                .await
+                .with_context(|| format!("failed to backfill missing predecessor {hash}"))?;
+
+            let block = trusted_block_from_light_block_info_with_options(
+                &info,
+                !parents_only_bootstrap,
+            )
+                .with_context(|| format!("failed to reconstruct backfilled block {}", info.block_hash))?;
+            ingress
+                .ingest_trusted_block(block)
+                .with_context(|| format!("failed to ingest backfilled block {}", info.block_hash))?;
+            backfilled += 1;
+            fetched_this_round += 1;
+
+            if fetched_this_round <= 5 || fetched_this_round % 25 == 0 {
+                println!(
+                    "[backfill] fetched {} this round ({} total), latest={}, block_number={}, parents={}, justifications={}",
+                    fetched_this_round,
+                    backfilled,
+                    hash,
+                    info.block_number,
+                    info.parents_hash_list.len(),
+                    info.justifications.len()
+                );
+            }
+        }
+
+        if fetched_this_round == 0 {
+            println!("[backfill] round {} made no progress", round);
+            break;
+        }
+
+        println!(
+            "[backfill] round {} complete: mirrored={}, pending={}",
+            round,
+            ingress.blocklace().dom().len(),
+            ingress.pending_blocks().len()
+        );
+    }
+
+    Ok(backfilled)
+}
+
+fn unresolved_predecessor_hashes(ingress: &LiveIngress<PassthroughAdapter>) -> BTreeSet<String> {
+    let applied: HashSet<String> = ingress
+        .blocklace()
+        .dom()
+        .iter()
+        .map(|id| PrettyPrinter::build_string_no_limit(&id.content_hash))
+        .collect();
+    let pending: HashSet<String> = ingress
+        .pending_blocks()
+        .keys()
+        .map(|id| PrettyPrinter::build_string_no_limit(&id.content_hash))
+        .collect();
+
+    let mut missing = BTreeSet::new();
+    for block in ingress.pending_blocks().values() {
+        for pred in &block.content.predecessors {
+            let hash = PrettyPrinter::build_string_no_limit(&pred.content_hash);
+            if !applied.contains(&hash) && !pending.contains(&hash) {
+                missing.insert(hash);
+            }
+        }
+    }
+
+    missing
+}

--- a/crates/cordial-f1r3node-adapter/src/bin/live_mirror_check.rs
+++ b/crates/cordial-f1r3node-adapter/src/bin/live_mirror_check.rs
@@ -22,7 +22,9 @@ use models::rust::string_ops::StringOps;
 
 #[derive(Parser, Debug)]
 #[command(name = "live-mirror-check")]
-#[command(about = "Mirror live f1r3node blocks into Cordial state and compare against HTTP-visible node state")]
+#[command(
+    about = "Mirror live f1r3node blocks into Cordial state and compare against HTTP-visible node state"
+)]
 struct Args {
     #[arg(long, default_value = "http://127.0.0.1:40401")]
     grpc_url: String,
@@ -179,14 +181,13 @@ async fn main() -> Result<()> {
         None => None,
     };
 
-    let initial_grpc_lfb_meta = match initial_grpc_last_finalized.as_ref() {
-        Some(hash) => Some(
-            grpc.light_block_by_hash(hash.clone())
-                .await
-                .with_context(|| format!("failed to fetch initial gRPC LFB metadata for {hash}"))?,
-        ),
-        None => None,
-    };
+    let initial_grpc_lfb_meta =
+        match initial_grpc_last_finalized.as_ref() {
+            Some(hash) => Some(grpc.light_block_by_hash(hash.clone()).await.with_context(
+                || format!("failed to fetch initial gRPC LFB metadata for {hash}"),
+            )?),
+            None => None,
+        };
 
     let ordered_count = if args.skip_ordering {
         println!("[phase] skipping ordered finalized blocks");
@@ -210,7 +211,10 @@ async fn main() -> Result<()> {
                 .compare_live_ingress(&ingress)
                 .await
                 .with_context(|| {
-                    format!("failed to compare mirror against HTTP endpoint {}", args.http_url)
+                    format!(
+                        "failed to compare mirror against HTTP endpoint {}",
+                        args.http_url
+                    )
                 })?,
         )
     };
@@ -285,14 +289,20 @@ async fn main() -> Result<()> {
         }
     );
 
-    if let Some(comparison) = comparison.as_ref().filter(|c| !c.missing_from_mirror.is_empty()) {
+    if let Some(comparison) = comparison
+        .as_ref()
+        .filter(|c| !c.missing_from_mirror.is_empty())
+    {
         println!("Missing from mirror:");
         for hash in &comparison.missing_from_mirror {
             println!("  - {}", hash);
         }
     }
 
-    if let Some(comparison) = comparison.as_ref().filter(|c| !c.missing_from_http.is_empty()) {
+    if let Some(comparison) = comparison
+        .as_ref()
+        .filter(|c| !c.missing_from_http.is_empty())
+    {
         println!("Missing from HTTP:");
         for hash in &comparison.missing_from_http {
             println!("  - {}", hash);
@@ -342,9 +352,9 @@ fn describe_mirror_block(
         .iter()
         .find(|id| id.content_hash.as_slice() == hash.as_slice())?
         .to_owned();
-    let round = depth(ingress.blocklace(), &id)?;
+    let round = depth(ingress.blocklace(), id)?;
     let wave = wave_of_round(round, 3)?;
-    let content = ingress.blocklace().content(&id)?;
+    let content = ingress.blocklace().content(id)?;
     let payload = CordialBlockPayload::from_bytes(&content.payload).ok()?;
 
     Some(MirrorBlockMeta {
@@ -389,11 +399,12 @@ fn print_finality_neighborhood(
         })
         .map(|id| hex_string(id.content_hash.to_vec()))
         .unwrap_or_else(|| "<none>".to_string());
-        let final_block = weighted_final_leader_for_wave(ingress.blocklace(), wave, 3, ingress.bonds(), |w| {
-            validators.get((w as usize) % validators.len()).cloned()
-        })
-        .map(|id| hex_string(id.content_hash.to_vec()))
-        .unwrap_or_else(|| "<none>".to_string());
+        let final_block =
+            weighted_final_leader_for_wave(ingress.blocklace(), wave, 3, ingress.bonds(), |w| {
+                validators.get((w as usize) % validators.len()).cloned()
+            })
+            .map(|id| hex_string(id.content_hash.to_vec()))
+            .unwrap_or_else(|| "<none>".to_string());
 
         println!(
             "  wave {}: selected_leader={} leader_block={} weighted_final={}",
@@ -464,10 +475,10 @@ fn mirrored_blocks_in_height_range(
         let Ok(payload) = CordialBlockPayload::from_bytes(&content.payload) else {
             continue;
         };
-        if (min_height..=max_height).contains(&payload.state.block_number) {
-            if let Some(block) = ingress.blocklace().get(id) {
-                blocks.push(block);
-            }
+        if (min_height..=max_height).contains(&payload.state.block_number)
+            && let Some(block) = ingress.blocklace().get(id)
+        {
+            blocks.push(block);
         }
     }
     blocks.sort_by_key(|block| {
@@ -502,7 +513,9 @@ async fn bootstrap_by_heights(
         let blocks = grpc
             .light_blocks_by_heights(start, end)
             .await
-            .with_context(|| format!("failed to fetch blocks in height range {}..={}", start, end))?;
+            .with_context(|| {
+                format!("failed to fetch blocks in height range {}..={}", start, end)
+            })?;
 
         println!(
             "[height-bootstrap] range {}..={} returned {} blocks",
@@ -516,11 +529,11 @@ async fn bootstrap_by_heights(
                 .with_context(|| format!("failed to decode live block {}", info.block_hash))?;
             *decoded_messages += 1;
 
-            let block = trusted_block_from_light_block_info_with_options(
-                info,
-                !parents_only_bootstrap,
-            )
-            .with_context(|| format!("failed to reconstruct trusted block {}", info.block_hash))?;
+            let block =
+                trusted_block_from_light_block_info_with_options(info, !parents_only_bootstrap)
+                    .with_context(|| {
+                        format!("failed to reconstruct trusted block {}", info.block_hash)
+                    })?;
             ingress
                 .ingest_trusted_block(block)
                 .with_context(|| format!("failed to mirror live block {}", info.block_hash))?;
@@ -599,18 +612,18 @@ async fn backfill_missing_predecessors(
                 .await
                 .with_context(|| format!("failed to backfill missing predecessor {hash}"))?;
 
-            let block = trusted_block_from_light_block_info_with_options(
-                &info,
-                !parents_only_bootstrap,
-            )
-                .with_context(|| format!("failed to reconstruct backfilled block {}", info.block_hash))?;
-            ingress
-                .ingest_trusted_block(block)
-                .with_context(|| format!("failed to ingest backfilled block {}", info.block_hash))?;
+            let block =
+                trusted_block_from_light_block_info_with_options(&info, !parents_only_bootstrap)
+                    .with_context(|| {
+                        format!("failed to reconstruct backfilled block {}", info.block_hash)
+                    })?;
+            ingress.ingest_trusted_block(block).with_context(|| {
+                format!("failed to ingest backfilled block {}", info.block_hash)
+            })?;
             backfilled += 1;
             fetched_this_round += 1;
 
-            if fetched_this_round <= 5 || fetched_this_round % 25 == 0 {
+            if fetched_this_round <= 5 || fetched_this_round.is_multiple_of(25) {
                 println!(
                     "[backfill] fetched {} this round ({} total), latest={}, block_number={}, parents={}, justifications={}",
                     fetched_this_round,

--- a/crates/cordial-f1r3node-adapter/src/http_observer.rs
+++ b/crates/cordial-f1r3node-adapter/src/http_observer.rs
@@ -17,62 +17,10 @@ pub enum HttpObserverError {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-pub struct HttpBondInfo {
-    pub validator: String,
-    pub stake: i64,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-pub struct HttpJustificationInfo {
-    pub validator: String,
-    #[serde(rename = "latestBlockHash")]
-    pub latest_block_hash: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-pub struct HttpRejectedDeployInfo {
-    pub sig: String,
-}
-
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub struct HttpLightBlockInfo {
     #[serde(rename = "blockHash")]
     pub block_hash: String,
-    pub sender: String,
-    #[serde(rename = "seqNum")]
-    pub seq_num: i64,
-    pub sig: String,
-    #[serde(rename = "sigAlgorithm")]
-    pub sig_algorithm: String,
-    #[serde(rename = "shardId")]
-    pub shard_id: String,
-    #[serde(rename = "extraBytes")]
-    pub extra_bytes: Vec<u8>,
-    pub version: i64,
-    pub timestamp: i64,
-    #[serde(rename = "headerExtraBytes")]
-    pub header_extra_bytes: Vec<u8>,
-    #[serde(rename = "parentsHashList")]
-    pub parents_hash_list: Vec<String>,
-    #[serde(rename = "blockNumber")]
-    pub block_number: i64,
-    #[serde(rename = "preStateHash")]
-    pub pre_state_hash: String,
-    #[serde(rename = "postStateHash")]
-    pub post_state_hash: String,
-    #[serde(rename = "bodyExtraBytes")]
-    pub body_extra_bytes: Vec<u8>,
-    pub bonds: Vec<HttpBondInfo>,
-    #[serde(rename = "blockSize")]
-    pub block_size: String,
-    #[serde(rename = "deployCount")]
-    pub deploy_count: i32,
-    #[serde(rename = "faultTolerance")]
-    pub fault_tolerance: f32,
-    pub justifications: Vec<HttpJustificationInfo>,
-    #[serde(rename = "rejectedDeploys")]
-    pub rejected_deploys: Vec<HttpRejectedDeployInfo>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]

--- a/crates/cordial-f1r3node-adapter/src/live_grpc.rs
+++ b/crates/cordial-f1r3node-adapter/src/live_grpc.rs
@@ -116,14 +116,15 @@ impl LiveGrpcBlockClient {
                 Some(block_info_response::Message::BlockInfo(light)) => blocks.push(light),
                 Some(block_info_response::Message::Error(status)) => {
                     return Err(LiveGrpcError::MissingPayload(Box::leak(
-                        format!(
-                            "get_blocks_by_heights returned service error: {:?}",
-                            status
-                        )
-                        .into_boxed_str(),
+                        format!("get_blocks_by_heights returned service error: {:?}", status)
+                            .into_boxed_str(),
                     )));
                 }
-                None => return Err(LiveGrpcError::MissingPayload("get_blocks_by_heights.message")),
+                None => {
+                    return Err(LiveGrpcError::MissingPayload(
+                        "get_blocks_by_heights.message",
+                    ));
+                }
             }
         }
 

--- a/crates/cordial-f1r3node-adapter/src/live_grpc.rs
+++ b/crates/cordial-f1r3node-adapter/src/live_grpc.rs
@@ -4,9 +4,12 @@ use cordial_miners_core::block::Block;
 use cordial_miners_core::execution::{BlockState, Bond, CordialBlockPayload};
 use cordial_miners_core::types::{BlockContent, BlockIdentity, NodeId};
 use models::casper::v1::{
-    block_info_response, deploy_service_client::DeployServiceClient, last_finalized_block_response,
+    block_info_response, block_response, deploy_service_client::DeployServiceClient,
+    last_finalized_block_response,
 };
-use models::casper::{BlocksQuery, LastFinalizedBlockQuery, LightBlockInfo};
+use models::casper::{
+    BlockQuery, BlocksQuery, BlocksQueryByHeight, LastFinalizedBlockQuery, LightBlockInfo,
+};
 use models::rust::string_ops::StringOps;
 use tonic::transport::{Channel, Endpoint};
 
@@ -92,6 +95,70 @@ impl LiveGrpcBlockClient {
         Ok(blocks)
     }
 
+    pub async fn light_blocks_by_heights(
+        &mut self,
+        start_block_number: i64,
+        end_block_number: i64,
+    ) -> Result<Vec<LightBlockInfo>, LiveGrpcError> {
+        let mut stream = self
+            .client
+            .get_blocks_by_heights(BlocksQueryByHeight {
+                start_block_number,
+                end_block_number,
+            })
+            .await
+            .map_err(LiveGrpcError::Status)?
+            .into_inner();
+
+        let mut blocks = Vec::new();
+        while let Some(item) = stream.message().await.map_err(LiveGrpcError::Status)? {
+            match item.message {
+                Some(block_info_response::Message::BlockInfo(light)) => blocks.push(light),
+                Some(block_info_response::Message::Error(status)) => {
+                    return Err(LiveGrpcError::MissingPayload(Box::leak(
+                        format!(
+                            "get_blocks_by_heights returned service error: {:?}",
+                            status
+                        )
+                        .into_boxed_str(),
+                    )));
+                }
+                None => return Err(LiveGrpcError::MissingPayload("get_blocks_by_heights.message")),
+            }
+        }
+
+        blocks.sort_by(|a, b| {
+            a.block_number
+                .cmp(&b.block_number)
+                .then_with(|| a.block_hash.cmp(&b.block_hash))
+        });
+        Ok(blocks)
+    }
+
+    pub async fn light_block_by_hash(
+        &mut self,
+        hash: impl Into<String>,
+    ) -> Result<LightBlockInfo, LiveGrpcError> {
+        let response = self
+            .client
+            .get_block(BlockQuery { hash: hash.into() })
+            .await
+            .map_err(LiveGrpcError::Status)?
+            .into_inner();
+
+        match response.message {
+            Some(block_response::Message::BlockInfo(block_info)) => block_info
+                .block_info
+                .ok_or(LiveGrpcError::MissingPayload("get_block.block_info")),
+            Some(block_response::Message::Error(status)) => {
+                Err(LiveGrpcError::MissingPayload(Box::leak(
+                    format!("get_block returned service error: {:?}", status).into_boxed_str(),
+                )))
+            }
+            None => Err(LiveGrpcError::MissingPayload("get_block.message")),
+        }
+    }
+
     pub async fn last_finalized_block_hash(&mut self) -> Result<Option<Vec<u8>>, LiveGrpcError> {
         let response = self
             .client
@@ -142,6 +209,13 @@ impl LiveGrpcBlockClient {
 }
 
 pub fn trusted_block_from_light_block_info(info: &LightBlockInfo) -> Result<Block, LiveGrpcError> {
+    trusted_block_from_light_block_info_with_options(info, true)
+}
+
+pub fn trusted_block_from_light_block_info_with_options(
+    info: &LightBlockInfo,
+    include_justifications: bool,
+) -> Result<Block, LiveGrpcError> {
     let mut justification_creators: HashMap<Vec<u8>, Vec<u8>> = HashMap::new();
     for justification in &info.justifications {
         let hash = decode_hex("latest_block_hash", &justification.latest_block_hash)?;
@@ -163,12 +237,14 @@ pub fn trusted_block_from_light_block_info(info: &LightBlockInfo) -> Result<Bloc
         });
     }
 
-    for justification in &info.justifications {
-        predecessors.insert(BlockIdentity {
-            content_hash: decode_hex_32("latest_block_hash", &justification.latest_block_hash)?,
-            creator: NodeId(decode_hex("validator", &justification.validator)?),
-            signature: vec![],
-        });
+    if include_justifications {
+        for justification in &info.justifications {
+            predecessors.insert(BlockIdentity {
+                content_hash: decode_hex_32("latest_block_hash", &justification.latest_block_hash)?,
+                creator: NodeId(decode_hex("validator", &justification.validator)?),
+                signature: vec![],
+            });
+        }
     }
 
     let payload = CordialBlockPayload {

--- a/crates/cordial-f1r3node-adapter/src/live_ingress.rs
+++ b/crates/cordial-f1r3node-adapter/src/live_ingress.rs
@@ -38,7 +38,10 @@ use cordial_miners_core::types::{BlockContent, NodeId};
 use crate::block_translation::BlockMessage;
 use crate::grpc_ingest::{BlocklaceAdapter, GrpcBlockMapper};
 use crate::shard_conf::CasperShardConf;
-use crate::snapshot::{CasperSnapshot, SnapshotError, build_snapshot};
+use crate::snapshot::{
+    CasperSnapshot, SnapshotError, build_snapshot, latest_finalized_block_id,
+    ordered_finalized_block_hashes,
+};
 
 /// High-level runtime phase for the live ingress adapter.
 ///
@@ -374,17 +377,13 @@ impl<A> LiveIngress<A> {
 
     /// Return the latest finalized block hash if the mirrored state has one.
     pub fn last_finalized_block_hash(&self) -> Result<Option<Vec<u8>>, SnapshotError> {
-        let snapshot = self.snapshot()?;
-        if snapshot.last_finalized_block.is_empty() {
-            Ok(None)
-        } else {
-            Ok(Some(snapshot.last_finalized_block))
-        }
+        Ok(latest_finalized_block_id(self.blocklace(), &self.bonds)
+            .map(|id| id.content_hash.to_vec()))
     }
 
     /// Return the current weighted tau output as block hashes.
     pub fn ordered_finalized_blocks(&self) -> Result<Vec<Vec<u8>>, SnapshotError> {
-        Ok(self.snapshot()?.ordered_finalized_blocks)
+        Ok(ordered_finalized_block_hashes(self.blocklace(), &self.bonds))
     }
 
     /// Ingest a trusted block that was reconstructed from a live node-facing

--- a/crates/cordial-f1r3node-adapter/src/live_ingress.rs
+++ b/crates/cordial-f1r3node-adapter/src/live_ingress.rs
@@ -383,7 +383,10 @@ impl<A> LiveIngress<A> {
 
     /// Return the current weighted tau output as block hashes.
     pub fn ordered_finalized_blocks(&self) -> Result<Vec<Vec<u8>>, SnapshotError> {
-        Ok(ordered_finalized_block_hashes(self.blocklace(), &self.bonds))
+        Ok(ordered_finalized_block_hashes(
+            self.blocklace(),
+            &self.bonds,
+        ))
     }
 
     /// Ingest a trusted block that was reconstructed from a live node-facing

--- a/crates/cordial-f1r3node-adapter/tests/test_http_observer.rs
+++ b/crates/cordial-f1r3node-adapter/tests/test_http_observer.rs
@@ -5,7 +5,7 @@ use cordial_f1r3node_adapter::block_translation::{
 };
 use cordial_f1r3node_adapter::grpc_ingest::BlocklaceAdapter;
 use cordial_f1r3node_adapter::http_observer::{
-    HttpBlockInfo, HttpJustificationInfo, HttpLightBlockInfo, compare_mirror_against_http,
+    HttpBlockInfo, HttpLightBlockInfo, compare_mirror_against_http,
 };
 use cordial_f1r3node_adapter::live_ingress::LiveIngress;
 use cordial_f1r3node_adapter::shard_conf::CasperShardConf;
@@ -30,38 +30,6 @@ fn compare_mirror_against_http_reports_matching_view() {
         .iter()
         .map(|block| HttpLightBlockInfo {
             block_hash: hex(&block.block_hash),
-            sender: hex(&block.sender),
-            seq_num: i64::from(block.seq_num),
-            sig: hex(&block.sig),
-            sig_algorithm: block.sig_algorithm.clone(),
-            shard_id: block.shard_id.clone(),
-            extra_bytes: block.extra_bytes.clone(),
-            version: block.header.version,
-            timestamp: block.header.timestamp,
-            header_extra_bytes: block.header.extra_bytes.clone(),
-            parents_hash_list: block
-                .header
-                .parents_hash_list
-                .iter()
-                .map(|h| hex(h))
-                .collect(),
-            block_number: block.body.state.block_number,
-            pre_state_hash: hex(&block.body.state.pre_state_hash),
-            post_state_hash: hex(&block.body.state.post_state_hash),
-            body_extra_bytes: block.body.extra_bytes.clone(),
-            bonds: vec![],
-            block_size: "0".to_string(),
-            deploy_count: 0,
-            fault_tolerance: 0.0,
-            justifications: block
-                .justifications
-                .iter()
-                .map(|j| HttpJustificationInfo {
-                    validator: hex(&j.validator),
-                    latest_block_hash: hex(&j.latest_block_hash),
-                })
-                .collect(),
-            rejected_deploys: vec![],
         })
         .collect();
 

--- a/crates/cordial-f1r3node-adapter/tests/test_http_observer.rs
+++ b/crates/cordial-f1r3node-adapter/tests/test_http_observer.rs
@@ -68,12 +68,10 @@ fn compare_mirror_against_http_reports_missing_blocks_and_lfb_mismatch() {
 
     let http_blocks = vec![HttpLightBlockInfo {
         block_hash: hex(&leader.block_hash),
-        ..HttpLightBlockInfo::default()
     }];
     let http_lfb = HttpBlockInfo {
         block_info: HttpLightBlockInfo {
             block_hash: "deadbeef".to_string(),
-            ..HttpLightBlockInfo::default()
         },
         deploys: vec![],
     };

--- a/docs/cordial-miners/integration/00-index.md
+++ b/docs/cordial-miners/integration/00-index.md
@@ -30,6 +30,9 @@ and easy to extend as new implementation notes are added.
 7. [07-deploy-ingress-trace.md](./07-deploy-ingress-trace.md)
    - Traces deploy flow from external API ingress into proposal scheduling
    - Identifies the first safe pre-proposal Cordial interception seam
+8. [08-live-mirror-check-harness.md](./08-live-mirror-check-harness.md)
+   - Documents the live mirror diagnostic binary and its runtime modes
+   - Explains parameters, output phases, and baseline-vs-drift interpretation
 
 ## Scope Of This Track
 

--- a/docs/cordial-miners/integration/00-index.md
+++ b/docs/cordial-miners/integration/00-index.md
@@ -27,6 +27,9 @@ and easy to extend as new implementation notes are added.
 6. [06-http-observer-comparison.md](./06-http-observer-comparison.md)
    - Adds an HTTP observer over `/api/blocks` and `/api/last-finalized-block`
    - Documents mirror-vs-node comparison and mismatch reporting
+7. [07-deploy-ingress-trace.md](./07-deploy-ingress-trace.md)
+   - Traces deploy flow from external API ingress into proposal scheduling
+   - Identifies the first safe pre-proposal Cordial interception seam
 
 ## Scope Of This Track
 
@@ -41,4 +44,4 @@ The integration notes in this folder focus on:
 
 Future notes in this folder are expected to cover:
 
-- deploy ingress tracing and later interception candidates
+- actual deploy-side interception work at the documented pre-proposal seam

--- a/docs/cordial-miners/integration/07-deploy-ingress-trace.md
+++ b/docs/cordial-miners/integration/07-deploy-ingress-trace.md
@@ -1,0 +1,123 @@
+# Deploy Ingress Trace And Interception Seam
+
+This note records the deploy-side tracing step for the
+`cordial-f1r3node-adapter` integration track.
+
+The goal of this step is not to intercept deploys yet. The goal is to trace
+how a deploy enters `f1r3node`, how it reaches proposal, and where the first
+safe Cordial interception seam exists before block production.
+
+## Reference Files
+
+In `f1r3node`:
+
+- `node/src/rust/api/deploy_grpc_service_v1.rs`
+- `node/src/rust/api/web_api.rs`
+- `casper/src/rust/api/block_api.rs`
+- `node/src/rust/instances/proposer_instance.rs`
+
+In this repository:
+
+- `docs/cordial-miners/integration/07-deploy-ingress-trace.md`
+
+## Traced Call Path
+
+There are two external deploy ingress paths today:
+
+1. gRPC deploy ingress
+   - `DeployGrpcServiceV1Impl::do_deploy`
+   - decodes `DeployDataProto`
+   - converts it into `Signed<DeployData>`
+   - calls `BlockAPI::deploy(...)`
+
+2. HTTP deploy ingress
+   - `WebApiImpl::deploy`
+   - converts `DeployRequest` with `to_signed_deploy(...)`
+   - calls `BlockAPI::deploy(...)`
+
+Both ingress paths converge on the same shared deploy entry point:
+
+- `casper::rust::api::block_api::BlockAPI::deploy`
+
+## What Happens Inside `BlockAPI::deploy`
+
+`BlockAPI::deploy(...)` is the real handoff from API ingress into Casper.
+
+At this point the node:
+
+- checks node read-only mode
+- checks shard id compatibility
+- checks forbidden signer keys
+- checks minimum phlo price
+- checks deploy expiration
+- obtains the live Casper instance from `EngineCell`
+- calls `casper.deploy(deploy_data)`
+
+If deploy admission succeeds, `BlockAPI::deploy(...)` then triggers proposal
+asynchronously through the configured `trigger_propose` function.
+
+That trigger does not create the block inline. Instead it schedules proposal
+work and returns deploy success to the caller without waiting for block
+inclusion or finalization.
+
+## How Proposal Is Reached
+
+After `BlockAPI::deploy(...)` accepts the deploy:
+
+- the node calls `trigger_propose(casper, true)`
+- that eventually reaches the proposer runtime
+- `node/src/rust/instances/proposer_instance.rs` processes queued propose
+  requests
+- the proposer produces a `BlockMessage` later, if proposal succeeds
+
+So the flow is:
+
+`API ingress -> Signed<DeployData> -> BlockAPI::deploy -> casper.deploy -> async trigger_propose -> proposer queue -> block creation`
+
+## First Safe Cordial Interception Seam
+
+The first safe pre-proposal seam is:
+
+- after request decoding into `Signed<DeployData>`
+- before calling `BlockAPI::deploy(...)`
+
+This seam is the safest starting point because:
+
+- both HTTP and gRPC deploy ingress already pass through it
+- the deploy has already been parsed into a typed internal form
+- proposal has not started yet
+- we can observe, mirror, tag, or stage deploys without modifying proposer
+  internals first
+- we avoid coupling the first Cordial deploy integration to the deeper Casper
+  queue and retry machinery
+
+## Why Not Intercept Deeper First
+
+A deeper seam inside the proposer path would be more invasive.
+
+By the time execution reaches `trigger_propose` and `ProposerInstance`, the
+deploy has already been admitted into Casper, and the control flow is mixed
+with scheduling, retries, and queue management. That is a good later
+integration point for proposal-aware behavior, but it is not the best first
+deploy-side seam.
+
+## Suggested Next Implementation Issue
+
+The next issue can be framed as:
+
+`Add a pre-proposal deploy observer seam in the adapter before BlockAPI::deploy admission`
+
+That issue should focus on:
+
+- defining a deploy-facing adapter input type
+- capturing deploy metadata at both HTTP and gRPC ingress
+- routing the typed deploy view into adapter-side observation code
+- keeping Casper admission behavior unchanged for the first increment
+
+## Acceptance Outcome
+
+This tracing step satisfies the current acceptance goals:
+
+- the ingress-to-proposal call path is now documented
+- one candidate pre-proposal Cordial interception seam is identified
+- the result is concrete enough to open the next implementation issue

--- a/docs/cordial-miners/integration/08-live-mirror-check-harness.md
+++ b/docs/cordial-miners/integration/08-live-mirror-check-harness.md
@@ -1,0 +1,216 @@
+# Live Mirror Check Harness
+
+This note documents the live mirror verification harness for the
+`cordial-f1r3node-adapter`.
+
+The harness lives at:
+
+- `crates/cordial-f1r3node-adapter/src/bin/live_mirror_check.rs`
+
+Its purpose is to connect to a running `f1r3node`, reconstruct a local
+Cordial blocklace mirror from live node-visible block APIs, and compare the
+result against node-visible finality state.
+
+## What The Harness Does
+
+The harness performs four logical steps:
+
+1. query the node's current gRPC block view
+2. bootstrap a local Cordial mirror from the live block stream
+3. compute Cordial finality and, optionally, Cordial ordering
+4. compare the mirror result against node-visible HTTP or gRPC state
+
+This makes it the main executable diagnostic tool for live integration.
+
+## Current Bootstrap Strategy
+
+The harness supports two bootstrap styles:
+
+1. height-based bootstrap
+   - fetches blocks from low heights upward using `get_blocks_by_heights`
+   - this is the preferred mode
+   - it reconstructs the DAG in the same direction the mirror expects
+
+2. predecessor backfill
+   - starts from a recent window and recursively fetches missing predecessors
+   - useful as a fallback diagnostic path
+   - slower and less natural for long single-parent histories
+
+In practice, height-based bootstrap is what made the live mirror converge
+reliably.
+
+## How To Run
+
+Typical run:
+
+```bash
+cargo run -p cordial-f1r3node-adapter --bin live_mirror_check -- \
+  --grpc-url http://127.0.0.1:40401 \
+  --http-url http://127.0.0.1:40403 \
+  --depth 64 \
+  --height-bootstrap \
+  --height-batch-size 64
+```
+
+Useful diagnostic run that skips expensive post-bootstrap phases:
+
+```bash
+cargo run -p cordial-f1r3node-adapter --bin live_mirror_check -- \
+  --grpc-url http://127.0.0.1:40401 \
+  --http-url http://127.0.0.1:40403 \
+  --depth 64 \
+  --height-bootstrap \
+  --height-batch-size 64 \
+  --skip-ordering \
+  --skip-http-compare
+```
+
+## Parameters
+
+### Connection parameters
+
+- `--grpc-url`
+  - gRPC endpoint for live block access
+  - default: `http://127.0.0.1:40401`
+
+- `--http-url`
+  - HTTP endpoint for observer comparison
+  - default: `http://127.0.0.1:40403`
+
+### Recent-view parameters
+
+- `--depth`
+  - recent block depth used to discover the live tip / max height
+  - also used when height bootstrap is disabled
+  - default: `64`
+
+### Bootstrap parameters
+
+- `--height-bootstrap`
+  - enables forward height-based bootstrap
+  - default: `true`
+
+- `--height-batch-size`
+  - number of heights fetched per bootstrap batch
+  - default: `64`
+
+- `--parents-only-bootstrap`
+  - reconstructs trusted blocks using parent edges only, excluding
+    justification edges from hard predecessor requirements
+  - useful for debugging bootstrap assumptions
+  - default: `false`
+
+### Backfill parameters
+
+- `--max-backfill-rounds`
+  - maximum recursive predecessor-recovery rounds
+  - default: `8`
+
+- `--max-backfill-blocks`
+  - maximum total predecessor blocks fetched during backfill
+  - default: `256`
+
+These are mainly relevant when height bootstrap is disabled or when the
+mirror still has unresolved predecessors after bootstrap.
+
+### Post-bootstrap diagnostics
+
+- `--skip-ordering`
+  - skips weighted `tau` ordering computation
+  - useful for isolating finality vs ordering cost
+
+- `--skip-http-compare`
+  - skips HTTP observer comparison
+  - useful for isolating mirror/finality behavior from HTTP fetch cost
+
+## Output Phases
+
+The harness prints explicit phase markers:
+
+- `[phase] querying initial gRPC last finalized block`
+- `[height-bootstrap] ...`
+- `[phase] bootstrap complete`
+- `[phase] computing mirror last finalized block`
+- `[phase] querying gRPC last finalized block`
+- `[phase] computing ordered finalized blocks`
+- `[phase] querying HTTP observer and comparing mirror`
+
+These messages are intentional. They help isolate which phase is expensive or
+misaligned during live debugging.
+
+## Output Meaning
+
+Important fields in the final report:
+
+- `Mirrored blocks`
+  - number of blocks accepted into the local mirror
+
+- `Pending blocks`
+  - blocks still waiting on missing predecessors
+
+- `Unresolved preds`
+  - unresolved predecessor hashes after bootstrap/backfill
+
+- `Initial gRPC LFB`
+  - node last-finalized block at the beginning of the run
+
+- `Mirror LFB`
+  - Cordial finality result over the mirrored blocklace
+
+- `gRPC LFB`
+  - node last-finalized block queried again after bootstrap
+
+- `Mirror LFB Meta`
+  - creator, block number, round, and wave for the mirror's final leader
+
+- `gRPC LFB Meta`
+  - creator and block number for the node's later finalized block
+
+## Interpreting Drift
+
+During live runs, the node may continue producing blocks while the harness is
+bootstrapping.
+
+So there are two different comparisons:
+
+1. baseline comparison
+   - `Mirror LFB` vs `Initial gRPC LFB`
+   - this is the correct frozen-in-time comparison
+
+2. moving-head comparison
+   - `Mirror LFB` vs later `gRPC LFB`
+   - this may differ simply because the node advanced during the run
+
+Recent runs showed that:
+
+- the mirror can match the initial node LFB exactly
+- later mismatch can be explained by node advancement during bootstrap
+
+That means a post-bootstrap mismatch is not automatically a correctness bug.
+
+## Intended Use
+
+This harness is intended for:
+
+- validating live mirror reconstruction
+- checking that the mirror reaches predecessor closure
+- confirming Cordial finality over mirrored live blocks
+- comparing mirror state to node-visible APIs at a known point in time
+- debugging performance boundaries between bootstrap, finality, ordering, and
+  HTTP comparison
+
+It is not intended to be the final production runtime path. It is a diagnostic
+and validation executable for the integration track.
+
+## Current Conclusion
+
+At this stage, the harness demonstrates that:
+
+- live gRPC block access works
+- height-based bootstrap reconstructs a closed local mirror
+- Cordial finality can be computed over that mirrored state
+- frozen-baseline finality can match the node snapshot taken at the start of
+  the run
+
+This makes the harness a successful validation tool for the live block
+mirroring milestone.


### PR DESCRIPTION
## Summary

This PR completes the live mirror verification milestone for the
`cordial-f1r3node-adapter`.

It adds a runnable live diagnostic harness that connects to a running
`f1r3node`, reconstructs a local Cordial blocklace mirror from live gRPC block
APIs, computes Cordial finality over that mirrored state, and compares the
result against node-visible finality surfaces.

The work also adds the supporting HTTP observer, targeted gRPC block lookup,
height-based bootstrap, richer diagnostics, and integration documentation
needed to make the live path understandable and usable in practice.

## What Changed

- added a live HTTP observer for:
  - `/api/blocks`
  - `/api/last-finalized-block`
- added mirror-vs-node comparison reporting for:
  - missing blocks in the mirror
  - missing blocks in the HTTP-visible node view
  - finalized block mismatch
- added live gRPC support for:
  - recent block streaming
  - targeted block lookup by hash
  - height-range block fetching
- added a runnable harness:
  - `crates/cordial-f1r3node-adapter/src/bin/live_mirror_check.rs`
- added bootstrap strategies for the live mirror:
  - recent-window ingestion
  - predecessor backfill
  - forward height-based bootstrap
- added diagnostics for:
  - bootstrap progress
  - unresolved predecessor tracking
  - mirror finality vs node finality
  - baseline vs moving-head drift
  - wave/leader/finality neighborhood inspection
- optimized live ingress finality lookup so `last_finalized_block_hash()` no
  longer builds the full snapshot or computes weighted `tau`
- documented the live mirror harness and runtime parameters in the integration
  docs
- fixed clippy issues introduced during the harness work

## Why

Before this PR, we had the building blocks for live ingress and node-facing
comparison, but not an end-to-end executable path that could prove the mirror
actually works against a running node.

This PR closes that gap.

It gives us a concrete runtime tool for validating that:

- live blocks can be mirrored into a local Cordial blocklace
- predecessor closure can be reconstructed from node APIs
- Cordial finality can be computed on the mirrored state
- mismatch against node state can be analyzed with enough context to tell
  bootstrap problems from live node drift

## Key Result

The harness now demonstrates that:

- live gRPC access works
- height-based bootstrap reconstructs a closed local mirror
- the mirror can reach zero pending blocks
- Cordial finality can be computed over the mirrored state
- the mirror finalized block can match the node's initial finalized block
- later mismatch can be explained by node advancement during bootstrap

In other words, the live mirror/finality path is now working end to end.

## Files

### Implementation
- `crates/cordial-f1r3node-adapter/src/http_observer.rs`
- `crates/cordial-f1r3node-adapter/src/live_grpc.rs`
- `crates/cordial-f1r3node-adapter/src/live_ingress.rs`
- `crates/cordial-f1r3node-adapter/src/bin/live_mirror_check.rs`

### Tests
- `crates/cordial-f1r3node-adapter/tests/test_http_observer.rs`
- `crates/cordial-f1r3node-adapter/tests/test_live_grpc.rs`
- `crates/cordial-f1r3node-adapter/tests/test_live_ingress.rs`

### Docs
- `docs/cordial-miners/integration/00-index.md`
- `docs/cordial-miners/integration/08-live-mirror-check-harness.md`

## Verification

```bash
cargo test -p cordial-f1r3node-adapter --test test_http_observer --test test_live_grpc --test test_live_ingress
cargo clippy -p cordial-miners-core -p cordial-f1r3node-adapter -p cordial-f1r3space-adapter --all-targets --all-features --no-deps -- -D warnings
```
## For live Run
```
cargo run -p cordial-f1r3node-adapter --bin live_mirror_check -- \
  --grpc-url http://127.0.0.1:40401 \
  --http-url http://127.0.0.1:40403 \
  --depth 64 \
  --height-bootstrap \
  --height-batch-size 64 \
  --skip-ordering \
  --skip-http-compare```