### PR TITLE
Optimize live mirror finality resolution for large f1r3node DAGs

### DIFF
--- a/crates/cordial-f1r3node-adapter/src/bin/live_mirror_check.rs
+++ b/crates/cordial-f1r3node-adapter/src/bin/live_mirror_check.rs
@@ -279,7 +279,11 @@ async fn main() -> Result<()> {
         );
     }
 
-    print_finality_neighborhood(&ingress, mirror_lfb_meta.as_ref(), grpc_lfb_meta.as_ref());
+    if args.skip_ordering && args.skip_http_compare {
+        println!("Finality neighborhood: skipped");
+    } else {
+        print_finality_neighborhood(&ingress, mirror_lfb_meta.as_ref(), grpc_lfb_meta.as_ref());
+    }
     println!(
         "Comparison:        {}",
         match comparison.as_ref() {

--- a/crates/cordial-f1r3node-adapter/src/snapshot.rs
+++ b/crates/cordial-f1r3node-adapter/src/snapshot.rs
@@ -370,12 +370,11 @@ pub(crate) fn latest_finalized_block_id(
         return None;
     }
 
-    if leaders.len() == 1 {
-        if let Some(id) =
+    if leaders.len() == 1
+        && let Some(id) =
             latest_single_validator_finalized_block_id(blocklace, &leaders[0], ES_WAVELENGTH)
-        {
-            return Some(id);
-        }
+    {
+        return Some(id);
     }
 
     latest_weighted_final_leader(blocklace, ES_WAVELENGTH, bonds, |wave| {

--- a/crates/cordial-f1r3node-adapter/src/snapshot.rs
+++ b/crates/cordial-f1r3node-adapter/src/snapshot.rs
@@ -61,7 +61,8 @@ use std::collections::{HashMap, HashSet};
 
 use cordial_miners_core::blocklace::Blocklace;
 use cordial_miners_core::consensus::{
-    collect_validator_tips, fork_choice, latest_weighted_final_leader, weighted_tau,
+    collect_validator_tips, compute_all_depths, fork_choice, last_round_of_wave,
+    latest_weighted_final_leader, wave_of_round, weighted_tau,
 };
 use cordial_miners_core::execution::{CordialBlockPayload, compute_deploys_in_scope};
 use cordial_miners_core::types::{BlockIdentity, NodeId};
@@ -369,6 +370,14 @@ pub(crate) fn latest_finalized_block_id(
         return None;
     }
 
+    if leaders.len() == 1 {
+        if let Some(id) =
+            latest_single_validator_finalized_block_id(blocklace, &leaders[0], ES_WAVELENGTH)
+        {
+            return Some(id);
+        }
+    }
+
     latest_weighted_final_leader(blocklace, ES_WAVELENGTH, bonds, |wave| {
         let idx = usize::try_from(wave).ok()? % leaders.len();
         Some(leaders[idx].clone())
@@ -402,4 +411,56 @@ fn ordered_validators(bonds: &HashMap<NodeId, u64>) -> Vec<NodeId> {
     let mut validators: Vec<NodeId> = bonds.keys().cloned().collect();
     validators.sort();
     validators
+}
+
+fn latest_single_validator_finalized_block_id(
+    blocklace: &Blocklace,
+    validator: &NodeId,
+    wavelength: u64,
+) -> Option<BlockIdentity> {
+    if wavelength == 0 {
+        return None;
+    }
+
+    let depths = compute_all_depths(blocklace);
+    let max_round = depths.values().copied().max()?;
+    let latest_wave = wave_of_round(max_round, wavelength)?;
+
+    for wave in (0..=latest_wave).rev() {
+        let last_round = last_round_of_wave(wave, wavelength)?;
+        if last_round > max_round {
+            continue;
+        }
+
+        let first_round = wave.checked_mul(wavelength)?;
+        let mut leader: Option<BlockIdentity> = None;
+        let mut complete_wave = true;
+
+        for round in first_round..=last_round {
+            let mut round_blocks = depths
+                .iter()
+                .filter(|(id, depth)| **depth == round && id.creator == *validator)
+                .map(|(id, _)| id.clone());
+
+            let Some(round_block) = round_blocks.next() else {
+                complete_wave = false;
+                break;
+            };
+
+            if round_blocks.next().is_some() {
+                complete_wave = false;
+                break;
+            }
+
+            if round == first_round {
+                leader = Some(round_block);
+            }
+        }
+
+        if complete_wave {
+            return leader;
+        }
+    }
+
+    None
 }

--- a/crates/cordial-miners-core/src/consensus/approval.rs
+++ b/crates/cordial-miners-core/src/consensus/approval.rs
@@ -6,11 +6,18 @@
 //! See Definition 18 of "Cordial Miners: Voluntary Participation in Blockchains"
 //! (arXiv:2205.09174) for the formal specification.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 
 use crate::block::Block;
 use crate::blocklace::Blocklace;
 use crate::types::{BlockIdentity, NodeId};
+
+#[derive(Default)]
+pub(crate) struct ApprovalMemo {
+    observe_cache: HashMap<BlockIdentity, BTreeSet<BlockIdentity>>,
+    approves_cache: HashMap<(BlockIdentity, BlockIdentity), bool>,
+    creator_blocks_cache: HashMap<NodeId, Vec<Block>>,
+}
 
 /// A block `approver` approves a `target` block if:
 /// 1. The approver observes the target (i.e., target is in the approver's predecessor closure)
@@ -20,13 +27,42 @@ use crate::types::{BlockIdentity, NodeId};
 /// A block approves a target it observes only when no equivocating sibling of that target
 /// is also in the observed set.
 pub fn approves(blocklace: &Blocklace, approver: &BlockIdentity, target: &BlockIdentity) -> bool {
+    let mut memo = ApprovalMemo::default();
+    approves_with_memo(blocklace, approver, target, &mut memo)
+}
+
+pub(crate) fn approves_with_memo(
+    blocklace: &Blocklace,
+    approver: &BlockIdentity,
+    target: &BlockIdentity,
+    memo: &mut ApprovalMemo,
+) -> bool {
+    let cache_key = (approver.clone(), target.clone());
+    if let Some(result) = memo.approves_cache.get(&cache_key) {
+        return *result;
+    }
+
+    let result = approves_uncached(blocklace, approver, target, memo);
+    memo.approves_cache.insert(cache_key, result);
+    result
+}
+
+fn approves_uncached(
+    blocklace: &Blocklace,
+    approver: &BlockIdentity,
+    target: &BlockIdentity,
+    memo: &mut ApprovalMemo,
+) -> bool {
     if blocklace.get(approver).is_none() {
         return false;
     }
 
     // Observation in the blocklace is inclusive: a block observes itself and
     // everything in its predecessor closure.
-    let observed = blocklace.observe(approver);
+    let observed = memo
+        .observe_cache
+        .entry(approver.clone())
+        .or_insert_with(|| blocklace.observe(approver));
 
     // Check if target is in the observed set
     if !observed.contains(target) {
@@ -43,7 +79,12 @@ pub fn approves(blocklace: &Blocklace, approver: &BlockIdentity, target: &BlockI
     // incomparable with the target. This follows the paper's "does not observe
     // any equivocating block of the target" relation more closely than a
     // same-round-only filter.
-    for other_block in blocklace.blocks_by(&target_block.identity.creator) {
+    let creator_blocks = memo
+        .creator_blocks_cache
+        .entry(target_block.identity.creator.clone())
+        .or_insert_with(|| blocklace.blocks_by(&target_block.identity.creator));
+
+    for other_block in creator_blocks.iter() {
         if other_block.identity == *target {
             continue;
         }
@@ -89,9 +130,20 @@ pub fn weighted_approving_creators(
     target: &BlockIdentity,
     bonds: &HashMap<NodeId, u64>,
 ) -> HashSet<NodeId> {
+    let mut memo = ApprovalMemo::default();
+    weighted_approving_creators_with_memo(blocklace, blocks, target, bonds, &mut memo)
+}
+
+pub(crate) fn weighted_approving_creators_with_memo(
+    blocklace: &Blocklace,
+    blocks: &HashSet<Block>,
+    target: &BlockIdentity,
+    bonds: &HashMap<NodeId, u64>,
+    memo: &mut ApprovalMemo,
+) -> HashSet<NodeId> {
     blocks
         .iter()
-        .filter(|block| approves(blocklace, &block.identity, target))
+        .filter(|block| approves_with_memo(blocklace, &block.identity, target, memo))
         .filter_map(|block| {
             let creator = &block.identity.creator;
             match bonds.get(creator).copied() {

--- a/crates/cordial-miners-core/src/consensus/cordiality.rs
+++ b/crates/cordial-miners-core/src/consensus/cordiality.rs
@@ -17,7 +17,7 @@ use std::collections::{HashMap, HashSet};
 
 use crate::block::Block;
 use crate::blocklace::Blocklace;
-use crate::consensus::approval::{approves, weighted_approving_creators};
+use crate::consensus::approval::{ApprovalMemo, approves, weighted_approving_creators_with_memo};
 use crate::consensus::round::{blocks_at_depth, depth};
 use crate::types::{BlockIdentity, NodeId};
 
@@ -39,6 +39,7 @@ pub struct HiddenEquivocation {
 
 #[derive(Default)]
 struct WeightedRatificationMemo {
+    approval_memo: ApprovalMemo,
     weighted_ratifies_cache: HashMap<(BlockIdentity, BlockIdentity), bool>,
 }
 
@@ -286,8 +287,13 @@ fn weighted_ratifies_with_memo(
             .filter_map(|id| blocklace.get(id))
             .collect();
 
-        let approving_creators =
-            weighted_approving_creators(blocklace, &observed_blocks, &target.identity, bonds);
+        let approving_creators = weighted_approving_creators_with_memo(
+            blocklace,
+            &observed_blocks,
+            &target.identity,
+            bonds,
+            &mut memo.approval_memo,
+        );
 
         is_weighted_supermajority(&approving_creators, bonds)
     };

--- a/crates/cordial-miners-core/src/consensus/finality.rs
+++ b/crates/cordial-miners-core/src/consensus/finality.rs
@@ -4,9 +4,11 @@ use std::collections::HashSet;
 use crate::block::Block;
 use crate::blocklace::Blocklace;
 use crate::consensus::cordiality::{super_ratifies, weighted_super_ratifies};
-use crate::consensus::round::{blocks_at_depth, depth};
+use crate::consensus::round::{blocks_at_depth, compute_all_depths, depth};
 use crate::consensus::wave::{last_round_of_wave, leader_blocks_of_wave, wave_of_round};
 use crate::types::{BlockIdentity, NodeId};
+
+type RoundIndex = HashMap<u64, Vec<Block>>;
 
 /// Return the unique leader block for a wave when exactly one exists.
 ///
@@ -141,18 +143,28 @@ where
         return None;
     }
 
-    let max_round = blocklace
-        .dom()
-        .iter()
-        .filter_map(|id| depth(blocklace, id))
-        .max()?;
+    let depths = compute_all_depths(blocklace);
+    let max_round = depths.values().copied().max()?;
+    let rounds = build_round_index(blocklace, &depths);
     let latest_wave = wave_of_round(max_round, wavelength)?;
 
     for wave in (0..=latest_wave).rev() {
-        if let Some(leader) =
-            final_leader_for_wave(blocklace, wave, wavelength, n, f, leader_selection)
-        {
-            return Some(leader);
+        let Some(leader) =
+            unique_leader_block_from_index(&rounds, wave, wavelength, &leader_selection)
+        else {
+            continue;
+        };
+
+        let Some(candidate_round) = depths.get(&leader.identity).copied() else {
+            continue;
+        };
+        let Some(last_round) = last_round_of_wave(wave, wavelength) else {
+            continue;
+        };
+
+        let witness_blocks = witness_blocks_from_index(&rounds, candidate_round, last_round);
+        if super_ratifies(blocklace, &witness_blocks, &leader, n, f) {
+            return Some(leader.identity);
         }
     }
 
@@ -264,21 +276,83 @@ where
         return None;
     }
 
-    let max_round = blocklace
-        .dom()
-        .iter()
-        .filter_map(|id| depth(blocklace, id))
-        .max()?;
-
+    let depths = compute_all_depths(blocklace);
+    let max_round = depths.values().copied().max()?;
+    let rounds = build_round_index(blocklace, &depths);
     let latest_wave = wave_of_round(max_round, wavelength)?;
 
     for wave in (0..=latest_wave).rev() {
-        if let Some(leader) =
-            weighted_final_leader_for_wave(blocklace, wave, wavelength, bonds, leader_selection)
-        {
-            return Some(leader);
+        let Some(leader) =
+            unique_leader_block_from_index(&rounds, wave, wavelength, &leader_selection)
+        else {
+            continue;
+        };
+
+        let Some(candidate_round) = depths.get(&leader.identity).copied() else {
+            continue;
+        };
+        let Some(last_round) = last_round_of_wave(wave, wavelength) else {
+            continue;
+        };
+
+        let witness_blocks = witness_blocks_from_index(&rounds, candidate_round, last_round);
+        if weighted_super_ratifies(blocklace, &witness_blocks, &leader, bonds) {
+            return Some(leader.identity);
         }
     }
 
     None
+}
+
+fn build_round_index(blocklace: &Blocklace, depths: &HashMap<BlockIdentity, u64>) -> RoundIndex {
+    let mut rounds = HashMap::new();
+
+    for (id, round) in depths {
+        if let Some(block) = blocklace.get(id) {
+            rounds.entry(*round).or_insert_with(Vec::new).push(block);
+        }
+    }
+
+    rounds
+}
+
+fn unique_leader_block_from_index<F>(
+    rounds: &RoundIndex,
+    wave: u64,
+    wavelength: u64,
+    leader_selection: F,
+) -> Option<Block>
+where
+    F: Fn(u64) -> Option<NodeId>,
+{
+    let leader = leader_selection(wave)?;
+    let leader_round = wave.checked_mul(wavelength)?;
+    let mut leaders = rounds
+        .get(&leader_round)?
+        .iter()
+        .filter(|block| block.identity.creator == leader)
+        .cloned();
+
+    let first = leaders.next()?;
+    if leaders.next().is_some() {
+        return None;
+    }
+
+    Some(first)
+}
+
+fn witness_blocks_from_index(
+    rounds: &RoundIndex,
+    start_round: u64,
+    end_round: u64,
+) -> HashSet<Block> {
+    let mut witness_blocks = HashSet::new();
+
+    for round in start_round..=end_round {
+        if let Some(blocks) = rounds.get(&round) {
+            witness_blocks.extend(blocks.iter().cloned());
+        }
+    }
+
+    witness_blocks
 }

--- a/crates/cordial-miners-core/src/consensus/finality.rs
+++ b/crates/cordial-miners-core/src/consensus/finality.rs
@@ -150,7 +150,7 @@ where
 
     for wave in (0..=latest_wave).rev() {
         let Some(leader) =
-            unique_leader_block_from_index(&rounds, wave, wavelength, &leader_selection)
+            unique_leader_block_from_index(&rounds, wave, wavelength, leader_selection)
         else {
             continue;
         };
@@ -283,7 +283,7 @@ where
 
     for wave in (0..=latest_wave).rev() {
         let Some(leader) =
-            unique_leader_block_from_index(&rounds, wave, wavelength, &leader_selection)
+            unique_leader_block_from_index(&rounds, wave, wavelength, leader_selection)
         else {
             continue;
         };


### PR DESCRIPTION
## Summary
This PR improves the performance of the Cordial live mirror when attached to a running `f1r3node`.

The main issue was that `live_mirror_check` became very slow once the mirrored DAG grew large, especially at the step where the adapter computes the mirror's latest finalized block. The implementation was repeatedly rebuilding round/depth views and recomputing approval/finality checks across a large blocklace.

This PR reduces that cost and makes the live mirror check complete much faster on a growing standalone node.

## What Changed
- optimized latest final leader lookup to reuse a precomputed depth/round index during backward wave scans
- added memoization for approval and observation checks used during weighted ratification
- reused approval memo state inside weighted super-ratification
- added a single-validator fast path for finalized leader lookup in the adapter snapshot path
- skipped expensive finality neighborhood diagnostics when the harness is run in summary-only mode

## Why
The live integration path is now far enough along that performance matters on real node state, not only in small tests.

Before this change, the harness could stall for a long time at:

`[phase] computing mirror last finalized block`

especially after height-bootstrapping a large standalone `f1r3node` DAG.

This PR improves that path so the mirror can:
- ingest a large live DAG,
- compute its latest finalized block,
- and finish the verification run in a practical amount of time.

## Result
With these changes, the live mirror check now gets past the previous finality bottleneck and completes successfully on a large standalone node mirror.

## Verification
- ran the live mirror harness against a running standalone `f1r3node`
- confirmed the command now completes after height bootstrap and finalized-block resolution
- verified the previous stall point is removed for the summary-only harness path

## Notes
A full workspace-wide test sweep was limited locally by disk-space pressure during linking, but the patched live harness compiled and ran successfully against the live node.